### PR TITLE
Adds instructions for fixing MIPS_GRP_CALL issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ python start.py
 
 ### 'module' object has noattribute 'MIPS_GRP_CALL'
 
-Your capstone install is too old.
-You may install the version from [our fork](https://github.com/angr/capstone).
+Your capstone install does not support functionality that angr-management uses.
+
+To install a version that does:
+```
+git clone https://github.com/angr/capstone
+cd capstone
+git checkout next
+./make.sh
+sudo ./make.sh install
+cd bindings/python
+sudo pip uninstall capstone  # if already installed
+sudo python setup.py install
+```
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,16 @@ python start.py
 
 Your capstone install does not support functionality that angr-management uses.
 
-To install a version that does:
+To install a version that does (in your angr virtualenv):
 ```
+workon angr
 git clone https://github.com/angr/capstone
 cd capstone
 git checkout next
 ./make.sh
-sudo ./make.sh install
+cp libcapstone.so.4 $(python -c "from distutils.sysconfig import get_python_lib; import os; print(os.path.join(get_python_lib(), 'capstone/libcapstone.so'))")
 cd bindings/python
-sudo pip uninstall capstone  # if already installed
-sudo python setup.py install
+pip uninstall capstone  # if already installed
+python setup.py install
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ git clone https://github.com/angr/capstone
 cd capstone
 git checkout next
 ./make.sh
-cp libcapstone.so.4 $(python -c "from distutils.sysconfig import get_python_lib; import os; print(os.path.join(get_python_lib(), 'capstone/libcapstone.so'))")
+PACKAGES_PATH=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+mkdir -p $PACKAGES_PATH/capstone
+cp libcapstone.so.4 $PACKAGES_PATH/capstone/libcapstone.so
 cd bindings/python
 pip uninstall capstone  # if already installed
 python setup.py install


### PR DESCRIPTION
The instructions on fixing the MIPS_GRP_CALL issue are not clear. The angr fork of capstone does not have the correct commit included in master and neither does the latest mainline capstone. In order to install it you must change branches to 'next' which does have it included.