### PR TITLE
Add comment support

### DIFF
--- a/angrmanagement/ui/dialogs/set_comment.py
+++ b/angrmanagement/ui/dialogs/set_comment.py
@@ -1,0 +1,81 @@
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QPlainTextEdit
+from PySide2.QtCore import Qt
+
+
+class CommentTextBox(QPlainTextEdit):
+    def __init__(self, textchanged_callback=None, parent=None):
+        super(CommentTextBox, self).__init__(parent)
+        if textchanged_callback is not None:
+            self.textChanged.connect(textchanged_callback)
+
+    @property
+    def text(self):
+        text = self.toPlainText()
+        if text is not None:
+            return text.strip()
+        return None
+
+
+class SetComment(QDialog):
+    def __init__(self, disasm_view, comment_addr, parent=None):
+        super(SetComment, self).__init__(parent)
+
+        # initialization
+        self._disasm_view = disasm_view
+        self._comment_addr = comment_addr
+
+        self._comment_textbox = None
+
+        self.setWindowTitle('Set Comment')
+        self.main_layout = QVBoxLayout()
+        self._init_widgets()
+        self.setLayout(self.main_layout)
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+
+        # name label
+        comment_lbl = QLabel(self)
+        comment_lbl.setText('Comment text')
+
+        # comment textbox
+        comment_txtbox = CommentTextBox(parent=self)
+        if self._comment_addr in self._disasm_view.disasm.kb.comments:
+            comment_txtbox.setPlainText(self._disasm_view.disasm.kb.comments[self._comment_addr])
+            comment_txtbox.selectAll()
+        self._comment_textbox = comment_txtbox
+
+        comment_layout = QVBoxLayout()
+        comment_layout.addWidget(comment_lbl)
+        comment_layout.addWidget(comment_txtbox)
+        self.main_layout.addLayout(comment_layout)
+
+        # buttons
+        ok_button = QPushButton(self)
+        ok_button.setText('OK')
+        ok_button.clicked.connect(self._on_ok_clicked)
+
+        cancel_button = QPushButton(self)
+        cancel_button.setText('Cancel')
+        cancel_button.clicked.connect(self._on_cancel_clicked)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(ok_button)
+        buttons_layout.addWidget(cancel_button)
+
+        self.main_layout.addLayout(buttons_layout)
+
+    #
+    # Event handlers
+    #
+
+    def _on_ok_clicked(self):
+        comment_txt = self._comment_textbox.text
+        self._disasm_view.set_comment(self._comment_addr, comment_txt)
+        self.close()
+
+    def _on_cancel_clicked(self):
+        self.close()

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -8,6 +8,7 @@ from ...logic.disassembly import JumpHistory, InfoDock
 from ..widgets import QDisasmGraph, QDisasmStatusBar, QLinearViewer
 from ..dialogs.jumpto import JumpTo
 from ..dialogs.rename_label import RenameLabel
+from ..dialogs.set_comment import SetComment
 from ..dialogs.new_state import NewState
 from ..dialogs.xref import XRef
 from ..menus.disasm_insn_context_menu import DisasmInsnContextMenu
@@ -128,6 +129,14 @@ class DisassemblyView(BaseView):
             return
 
         dialog = RenameLabel(self, label_addr, parent=self)
+        dialog.exec_()
+
+    def popup_comment_dialog(self):
+        comment_addr = self._address_in_selection()
+        if comment_addr is None:
+            return
+
+        dialog = SetComment(self, comment_addr, parent=self)
         dialog.exec_()
 
     def popup_newstate_dialog(self, asynch=True):
@@ -293,6 +302,22 @@ class DisassemblyView(BaseView):
 
             # redraw the current block
             self._flow_graph.update_label(addr, is_renaming=is_renaming)
+
+    def set_comment(self, addr, comment_text):
+        if self._flow_graph.disasm is not None:
+
+            is_updating = False
+
+            kb = self._flow_graph.disasm.kb
+            if comment_text is None and addr in kb.comments:
+                del kb.comments[addr]
+            else:
+                is_updating = addr in kb.comments
+
+            kb.comments[addr] = comment_text
+
+            # redraw the current block
+            self._flow_graph.update_comment(addr, comment_text)
 
     def avoid_addr_in_exec(self, addr):
 

--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -283,6 +283,11 @@ class QDisasmGraph(QBaseGraph):
             self.disassembly_view.decompile_current_function()
             return True
 
+        elif key == Qt.Key_Semicolon:
+            # add comment
+            self.disassembly_view.popup_comment_dialog()
+            return True
+
         return False
 
     def _on_keyreleased_event(self, key_event):

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -133,6 +133,18 @@ class QBaseGraph(QZoomingGraphicsView):
         else:
             self.reload()
 
+    def update_comment(self, comment_addr, comment_text):
+        if comment_addr in self._insn_addr_to_block:
+            block = self._insn_addr_to_block[comment_addr]
+            insn = block.addr_to_insns[comment_addr]
+            if insn:
+                insn.set_comment(comment_text)
+        else:
+            # umm not sure what's going wrong
+            _l.error('Label address %#x is not found in the current function.', comment_addr)
+
+        self.reload()
+
     def select_instruction(self, insn_addr, unique=True):
         block = self._insn_addr_to_block.get(insn_addr, None)
         if block is None:

--- a/angrmanagement/utils/__init__.py
+++ b/angrmanagement/utils/__init__.py
@@ -188,3 +188,9 @@ def get_string_for_display(cfg, insn_addr):
         else: return '"' + filter_string_for_display(str_content) + '"'
     else:
         return '<Unknown>'
+
+def get_comment_for_display(kb, insn_addr):
+    if insn_addr in kb.comments:
+        return filter_string_for_display(kb.comments[insn_addr])
+    else:
+        return None


### PR DESCRIPTION
This allows adding, editing, and displaying comments from the KB. Like IDA, comments take precedence over any strings in the display.

<img width="350" alt="comment" src="https://user-images.githubusercontent.com/4247887/54765988-7b8ea880-4bc8-11e9-8e74-77e1f1087c96.png">

Some things I'd like input on:
 - Should I keep the text blue (like IDA)?
 - Should I use a wider spacing following operands (currently uses `5`, like strings)
 - Should I prepend a semicolon in the display?

Also, there is a lot of duplication in `QInstruction`'s linear/graph painting functions. I followed along with that for now but I plan to refactor those out.
