### PR TITLE
Add Function/Instruction Selection Events

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -16,10 +16,12 @@ class EventSentinel(object):
         self.am_subscribers = []
 
     def am_subscribe(self, listener):
-        self.am_subscribers.append(listener)
+        if listener is not None:
+            self.am_subscribers.append(listener)
 
     def am_unsubscribe(self, listener):
-        self.am_subscribers.remove(listener)
+        if listener is not None:
+            self.am_subscribers.remove(listener)
 
     def am_event(self, **kwargs):
         for listener in self.am_subscribers:

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -2,7 +2,7 @@
 from PySide2.QtWidgets import QVBoxLayout, QMenu, QApplication
 from PySide2.QtCore import Qt, QSize
 
-from angrmanagement.data.instance import ObjectContainer
+from ...data.instance import ObjectContainer
 from ...utils import locate_function
 from ...data.function_graph import FunctionGraph
 from ...logic.disassembly import JumpHistory, InfoDock

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -1,6 +1,6 @@
 
 from PySide2.QtWidgets import QVBoxLayout, QMenu, QApplication
-from PySide2.QtCore import Qt, QSize
+from PySide2.QtCore import Qt, QSize, Signal
 
 from ...utils import locate_function
 from ...data.function_graph import FunctionGraph
@@ -15,6 +15,8 @@ from .view import BaseView
 
 
 class DisassemblyView(BaseView):
+    sig_insn_selected = Signal(int)
+
     def __init__(self, workspace, *args, **kwargs):
         super(DisassemblyView, self).__init__('disassembly', workspace, *args, **kwargs)
 
@@ -240,6 +242,7 @@ class DisassemblyView(BaseView):
         else:
             self.current_graph.select_instruction(insn_addr, unique=QApplication.keyboardModifiers() & Qt.CTRL == 0)
             self.current_graph.show_instruction(insn_addr)
+            self.sig_insn_selected.emit(insn_addr)
 
     def toggle_operand_selection(self, insn_addr, operand_idx):
         """

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -154,7 +154,7 @@ class DisassemblyView(BaseView):
     # Public methods
     #
 
-    def set_cb_on_insn_select(self, callback):
+    def subscribe_insn_select(self, callback):
         self._linear_viewer.selected_insns.am_subscribe(callback)
         self._flow_graph.selected_insns.am_subscribe(callback)
 

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -155,6 +155,14 @@ class DisassemblyView(BaseView):
     #
 
     def subscribe_insn_select(self, callback):
+        """
+        Appends the provided function to the list of callbacks to be called when an instruction is selected in the
+        disassembly. The callback's parameters are:
+            'graph': the `QBaseGraph` object
+            'addr': integer address of the selected instruction
+            'block': the `QBlock` containing the instruction
+        :param callback: The callback function to call, which must accept **kwargs
+        """
         self._linear_viewer.selected_insns.am_subscribe(callback)
         self._flow_graph.selected_insns.am_subscribe(callback)
 

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -1,6 +1,6 @@
 
 from PySide2.QtWidgets import QVBoxLayout, QMenu, QApplication
-from PySide2.QtCore import Qt, QSize, Signal
+from PySide2.QtCore import Qt, QSize
 
 from ...utils import locate_function
 from ...data.function_graph import FunctionGraph
@@ -15,8 +15,6 @@ from .view import BaseView
 
 
 class DisassemblyView(BaseView):
-    sig_insn_selected = Signal(int)
-
     def __init__(self, workspace, *args, **kwargs):
         super(DisassemblyView, self).__init__('disassembly', workspace, *args, **kwargs)
 
@@ -155,6 +153,10 @@ class DisassemblyView(BaseView):
     # Public methods
     #
 
+    def set_cb_on_insn_select(self, callback):
+        self._linear_viewer.selected_insns.am_subscribe(callback)
+        self._flow_graph.selected_insns.am_subscribe(callback)
+
     def display_disasm_graph(self):
 
         self._linear_viewer.hide()
@@ -242,7 +244,6 @@ class DisassemblyView(BaseView):
         else:
             self.current_graph.select_instruction(insn_addr, unique=QApplication.keyboardModifiers() & Qt.CTRL == 0)
             self.current_graph.show_instruction(insn_addr)
-            self.sig_insn_selected.emit(insn_addr)
 
     def toggle_operand_selection(self, insn_addr, operand_idx):
         """

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -2,6 +2,7 @@
 from PySide2.QtWidgets import QVBoxLayout, QMenu, QApplication
 from PySide2.QtCore import Qt, QSize
 
+from angrmanagement.data.instance import ObjectContainer
 from ...utils import locate_function
 from ...data.function_graph import FunctionGraph
 from ...logic.disassembly import JumpHistory, InfoDock
@@ -32,7 +33,7 @@ class DisassemblyView(BaseView):
         self.infodock = InfoDock()
         self._variable_recovery_flavor = 'fast'
         self.variable_manager = None  # type: VariableManager
-        self._current_function = None
+        self._current_function = ObjectContainer(None, 'The currently selected function')
 
         self._insn_menu = None
 

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -29,6 +29,9 @@ class FunctionsView(BaseView):
     def sizeHint(self):
         return QSize(200, 0)
 
+    def set_cb_on_func_select(self, callback):
+        self._function_table.set_cb_on_func_selected(callback)
+
     #
     # Private methods
     #

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -30,6 +30,11 @@ class FunctionsView(BaseView):
         return QSize(200, 0)
 
     def subscribe_func_select(self, callback):
+        """
+        Appends the provided function to the list of callbacks to be called when a function is selected in the
+        functions table. The callback's only parameter is the `angr.knowledge_plugins.functions.function.Function`
+        :param callback: The callback function to call, which must accept **kwargs
+        """
         self._function_table.subscribe_func_select(callback)
 
     #

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -1,11 +1,14 @@
 from PySide2.QtWidgets import QVBoxLayout, QLabel
-from PySide2.QtCore import QSize
+from PySide2.QtCore import QSize, Signal
 
 from .view import BaseView
 from ..widgets.qfunction_table import QFunctionTable
 
 
 class FunctionsView(BaseView):
+    from angr.knowledge_plugins import Function
+    sig_function_selected = Signal(Function)
+
     def __init__(self, workspace, default_docking_position, *args, **kwargs):
         super(FunctionsView, self).__init__('functions', workspace, default_docking_position, *args, **kwargs)
 
@@ -51,5 +54,5 @@ class FunctionsView(BaseView):
         :param function:
         :return:
         """
+        self.sig_function_selected.emit(function)
 
-        self.workspace.on_function_selected(function)

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -29,8 +29,8 @@ class FunctionsView(BaseView):
     def sizeHint(self):
         return QSize(200, 0)
 
-    def set_cb_on_func_select(self, callback):
-        self._function_table.set_cb_on_func_selected(callback)
+    def subscribe_func_select(self, callback):
+        self._function_table.subscribe_func_select(callback)
 
     #
     # Private methods

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -1,14 +1,11 @@
 from PySide2.QtWidgets import QVBoxLayout, QLabel
-from PySide2.QtCore import QSize, Signal
+from PySide2.QtCore import QSize
 
 from .view import BaseView
 from ..widgets.qfunction_table import QFunctionTable
 
 
 class FunctionsView(BaseView):
-    from angr.knowledge_plugins import Function
-    sig_function_selected = Signal(Function)
-
     def __init__(self, workspace, default_docking_position, *args, **kwargs):
         super(FunctionsView, self).__init__('functions', workspace, default_docking_position, *args, **kwargs)
 
@@ -47,12 +44,12 @@ class FunctionsView(BaseView):
 
         self.setLayout(vlayout)
 
-    def _on_function_selected(self, function):
+    def _on_function_selected(self, func):
         """
         A new function is on selection right now. Update the disassembly view that is currently at front.
 
         :param function:
         :return:
         """
-        self.sig_function_selected.emit(function)
+        self.workspace.on_function_selected(func=func)
 

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -183,8 +183,7 @@ class QFunctionTableView(QTableView):
 
         self._function_table = parent  # type: QFunctionTable
         self._selected_func = ObjectContainer(None, 'Currently selected function')
-        if selection_callback is not None:
-            self._selected_func.am_subscribe(selection_callback)
+        self._selected_func.am_subscribe(selection_callback)
 
         self.horizontalHeader().setVisible(True)
         self.verticalHeader().setVisible(False)

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -8,6 +8,8 @@ from PySide2.QtWidgets import QWidget, QTableView, QAbstractItemView, QHeaderVie
 from PySide2.QtGui import QBrush, QColor
 from PySide2.QtCore import Qt, QSize, QAbstractTableModel, SIGNAL, QEvent
 
+from angrmanagement.data.instance import ObjectContainer
+
 
 class QFunctionTableModel(QAbstractTableModel):
 
@@ -181,6 +183,7 @@ class QFunctionTableView(QTableView):
 
         self._selection_callback = selection_callback
         self._function_table = parent  # type: QFunctionTable
+        self._selected_func = ObjectContainer(None, 'Currently selected function')
 
         self.horizontalHeader().setVisible(True)
         self.verticalHeader().setVisible(False)
@@ -221,6 +224,8 @@ class QFunctionTableView(QTableView):
         else:
             selected_func = None
 
+        self._selected_func.am_obj = selected_func
+        self._selected_func.am_event(func=selected_func)
         if self._selection_callback is not None:
             self._selection_callback(selected_func)
 

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -7,8 +7,7 @@ from PySide2.QtWidgets import QWidget, QTableView, QAbstractItemView, QHeaderVie
     QStyledItemDelegate
 from PySide2.QtGui import QBrush, QColor
 from PySide2.QtCore import Qt, QSize, QAbstractTableModel, SIGNAL, QEvent
-
-from angrmanagement.data.instance import ObjectContainer
+from ...data.instance import ObjectContainer
 
 
 class QFunctionTableModel(QAbstractTableModel):

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -220,13 +220,8 @@ class QFunctionTableView(QTableView):
 
     def _on_function_selected(self, model_index):
         row = model_index.row()
-        if 0 <= row < len(self._model):
-            selected_func = self._model.func_list[row]
-        else:
-            selected_func = None
-
-        self._selected_func.am_obj = selected_func
-        self._selected_func.am_event(func=selected_func)
+        self._selected_func.am_obj = self._model.func_list[row]
+        self._selected_func.am_event(func=self._selected_func.am_obj)
 
     def keyPressEvent(self, key_event):
 

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -181,9 +181,10 @@ class QFunctionTableView(QTableView):
     def __init__(self, parent, selection_callback=None):
         super(QFunctionTableView, self).__init__(parent)
 
-        self._selection_callback = selection_callback
         self._function_table = parent  # type: QFunctionTable
         self._selected_func = ObjectContainer(None, 'Currently selected function')
+        if selection_callback is not None:
+            self._selected_func.am_subscribe(selection_callback)
 
         self.horizontalHeader().setVisible(True)
         self.verticalHeader().setVisible(False)
@@ -226,8 +227,6 @@ class QFunctionTableView(QTableView):
 
         self._selected_func.am_obj = selected_func
         self._selected_func.am_event(func=selected_func)
-        if self._selection_callback is not None:
-            self._selection_callback(selected_func)
 
     def keyPressEvent(self, key_event):
 
@@ -267,13 +266,11 @@ class QFunctionTable(QWidget):
     def __init__(self, parent, selection_callback=None):
         super(QFunctionTable, self).__init__(parent)
 
-        self._selection_callback = selection_callback
         self._view = parent
-
         self._table_view = None  # type: QFunctionTableView
         self._filter_box = None  # type: QFunctionTableFilterBox
 
-        self._init_widgets()
+        self._init_widgets(selection_callback)
 
     @property
     def function_manager(self):
@@ -308,10 +305,10 @@ class QFunctionTable(QWidget):
     # Private methods
     #
 
-    def _init_widgets(self):
+    def _init_widgets(self, selection_callback=None):
 
         # function table view
-        self._table_view = QFunctionTableView(self, selection_callback=self._selection_callback)
+        self._table_view = QFunctionTableView(self, selection_callback)
 
         # filter text box
         self._filter_box = QFunctionTableFilterBox(self)

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -214,7 +214,7 @@ class QFunctionTableView(QTableView):
         self._functions = functions
         self._model.func_list = list(self._functions.values())
 
-    def set_cb_on_func_selected(self, callback):
+    def subscribe_func_select(self, callback):
         self._selected_func.am_subscribe(callback)
 
     def filter(self, keyword):
@@ -298,8 +298,8 @@ class QFunctionTable(QWidget):
         self._filter_box.hide()
         self._table_view.setFocus()
 
-    def set_cb_on_func_selected(self, callback):
-        self._table_view.set_cb_on_func_selected(callback)
+    def subscribe_func_select(self, callback):
+        self._table_view.subscribe_func_select(callback)
 
     #
     # Private methods

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -214,6 +214,9 @@ class QFunctionTableView(QTableView):
         self._functions = functions
         self._model.func_list = list(self._functions.values())
 
+    def set_cb_on_func_selected(self, callback):
+        self._selected_func.am_subscribe(callback)
+
     def filter(self, keyword):
         self._model.filter(keyword)
 
@@ -294,6 +297,9 @@ class QFunctionTable(QWidget):
     def hide_filter_box(self):
         self._filter_box.hide()
         self._table_view.setFocus()
+
+    def set_cb_on_func_selected(self, callback):
+        self._table_view.set_cb_on_func_selected(callback)
 
     #
     # Private methods

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -151,7 +151,8 @@ class QBaseGraph(QZoomingGraphicsView):
 
             block.addr_to_insns[insn_addr].select()
 
-        self.selected_insns.am_event(addr=insn_addr)
+        # Notify subscribers BEFORE we update the viewport so they can make any further changes
+        self.selected_insns.am_event(graph=self, addr=insn_addr, block=block)
         self.viewport().update()
 
     def unselect_instruction(self, insn_addr):

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -4,6 +4,8 @@ from PySide2.QtWidgets import QGraphicsScene, QGraphicsView
 from PySide2.QtGui import QPainter, QKeyEvent
 from PySide2.QtCore import Qt, QSize, Signal, QPoint, QEvent
 
+from angrmanagement.data.instance import ObjectContainer
+
 _l = logging.getLogger('ui.widgets.qgraph')
 
 
@@ -84,7 +86,7 @@ class QBaseGraph(QZoomingGraphicsView):
         self._edge_paths = []
         self.blocks = set()
 
-        self.selected_insns = set()
+        self.selected_insns = ObjectContainer(set(), 'The currently selected instructions')
         self.selected_operands = set()
         self._insn_addr_to_block = {}
         self._allow_dragging = allow_dragging
@@ -143,12 +145,13 @@ class QBaseGraph(QZoomingGraphicsView):
             if unique:
                 # unselect existing ones
                 self.unselect_all_instructions()
-                self.selected_insns = { insn_addr }
+                self.selected_insns.add(insn_addr)
             else:
                 self.selected_insns.add(insn_addr)
 
             block.addr_to_insns[insn_addr].select()
 
+        self.selected_insns.am_event(addr=insn_addr)
         self.viewport().update()
 
     def unselect_instruction(self, insn_addr):

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -4,7 +4,7 @@ from PySide2.QtWidgets import QGraphicsScene, QGraphicsView
 from PySide2.QtGui import QPainter, QKeyEvent
 from PySide2.QtCore import Qt, QSize, Signal, QPoint, QEvent
 
-from angrmanagement.data.instance import ObjectContainer
+from ...data.instance import ObjectContainer
 
 _l = logging.getLogger('ui.widgets.qgraph')
 

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -2,7 +2,7 @@
 import logging
 from collections import defaultdict
 
-from PySide2.QtCore import Qt, Slot
+from PySide2.QtCore import Qt
 
 from angr.knowledge_plugins import Function
 from angr import StateHierarchy
@@ -45,8 +45,6 @@ class Workspace:
         for tab in default_tabs:
             self.add_view(tab, tab.caption, tab.category)
 
-        self.views_by_category['functions'][0].sig_function_selected.connect(self.on_function_selected)
-
     #
     # Properties
     #
@@ -59,10 +57,9 @@ class Workspace:
     # Events
     #
 
-    @Slot(Function)
-    def on_function_selected(self, function):
+    def on_function_selected(self, func):
 
-        self.views_by_category['disassembly'][0].display_function(function)
+        self.views_by_category['disassembly'][0].display_function(func)
 
     def on_cfg_generated(self):
 

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -2,7 +2,7 @@
 import logging
 from collections import defaultdict
 
-from PySide2.QtCore import Qt
+from PySide2.QtCore import Qt, Slot
 
 from angr.knowledge_plugins import Function
 from angr import StateHierarchy
@@ -45,6 +45,8 @@ class Workspace:
         for tab in default_tabs:
             self.add_view(tab, tab.caption, tab.category)
 
+        self.views_by_category['functions'][0].sig_function_selected.connect(self.on_function_selected)
+
     #
     # Properties
     #
@@ -57,6 +59,7 @@ class Workspace:
     # Events
     #
 
+    @Slot(Function)
     def on_function_selected(self, function):
 
         self.views_by_category['disassembly'][0].display_function(function)


### PR DESCRIPTION
I'm adding various signals to the "view" objects. I've got a bunch of hacks doing this right now but I'd like to add standard signals as well as some callbacks for things like highlighting instructions or rows in the functions view.

Right now, this PR is for code review. I've got about a dozen signals/callbacks to add in to at least get through my current project.