### PR TITLE
Added missing dependency nclib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyzmq
 shiboken2<=5.12.0
 PySide2<=5.12.0
 qtconsole
+nclib

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         'pyzmq',
         'shiboken2<=5.12.0',
         'PySide2<=5.12.0',
+        'nclib'
     ]
 )


### PR DESCRIPTION
Hello, it appears that a required dependency `nclib` is not included in `requirements.txt` and `setup.py`. Attempting to run without will result in an error:
```
...
 File "...\angr-management\angrmanagement\ui\views\interaction_view.py", line 15, in <module>
    import nclib
ModuleNotFoundError: No module named 'nclib'
```
After manually installing `nclib` I was able to run it without issues. Thanks!