### PR TITLE
Make paintEvent on graphs call the super method

### DIFF
--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -162,7 +162,7 @@ class QDisasmGraph(QBaseGraph):
 
         self._update_size()
 
-    def paintEvent(self, event):
+    def _paintEvent(self, event):
         """
         Paint the graph.
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -329,3 +329,11 @@ class QBaseGraph(QZoomingGraphicsView):
 
     def _add_insn_addr_block_mapping(self, insn_addr, block):
         self._insn_addr_to_block[insn_addr] = block
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+
+        self._paintEvent(event)
+
+    def _paintEvent(self, event):
+        raise NotImplementedError

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -153,7 +153,7 @@ class QLinearGraphicsView(QBaseGraph):
 
         self._update_size()
 
-    def paintEvent(self, event):
+    def _paintEvent(self, event):
         """
         Paint the linear view.
 

--- a/angrmanagement/ui/widgets/qsymexec_graph.py
+++ b/angrmanagement/ui/widgets/qsymexec_graph.py
@@ -168,7 +168,7 @@ class QSymExecGraph(QBaseGraph):
 
         return False
 
-    def paintEvent(self, event):
+    def _paintEvent(self, event):
         """
         Paint the graph.
 


### PR DESCRIPTION
Without calling the super method, functionality such as setting the background brush with setBackgroundBrush breaks.