### PR TITLE
Unpin PySide2/shiboken version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pygments
 angr
 ipython
 pyzmq
-shiboken2<=5.12.0
-PySide2<=5.12.0
+shiboken2
+PySide2
 qtconsole


### PR DESCRIPTION
This has been fixed with (at least) `5.12.3`, which is on PyPi.