### PR TITLE
Point development install to angr-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,7 @@ Please consider having a development install if you plan to use latest features/
 
 ### Development Install
 
-- Create a virtual environment using virtualenv. Make sure that virtualenv creates a Python 3 environment for you!
-
-```
-virtualenv angr-env
-cd angr-env
-source bin/activate
-```
-
-- Clone the Git repository
-
-```
-git clone git@github.com:angr/angr-management.git
-```
-
-- Install angr Management
-
-```
-cd angr-management
-pip install -e .
-```
+See [angr-dev](https://github.com/angr/angr-dev) for how to set up a development enviroment for the angr suite.
 
 ## Usage
 


### PR DESCRIPTION
Previous method suggested installing angr-management in a virtualenv by itself, pulling deps from pypi. This works at the moment since there haven't been any huge changes since the last release, but this will not work long-term. angr-dev is the simplest solution.