### PR TITLE
Feat/multi trace overlay

### DIFF
--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -57,6 +57,7 @@ ENTRIES = [
     CE('feature_map_color_unknown', QColor, QColor(0xa, 0xa, 0xa)),
     CE('feature_map_color_delimiter', QColor, QColor(0, 0, 0)),
     CE('feature_map_color_data', QColor, QColor(0xc0, 0xc0, 0xc0)),
+    CE('trace_func_font', QFont, None)
 ]
 
 
@@ -94,6 +95,8 @@ class ConfigurationManager:
         self.code_font_height = self.code_font_metrics.height()
         self.code_font_width = self.code_font_metrics.width('A')
         self.code_font_ascent = self.code_font_metrics.ascent()
+
+        self.trace_func_font = QFont("Source Code Pro", 7)
 
     def __getattr__(self, item):
 

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -10,6 +10,7 @@ from .sync_ctrl import SyncControl
 from ..logic import GlobalInfo
 from ..logic.threads import gui_thread_schedule_async
 
+from .trace_statistics import TraceStatistics
 
 class Instance:
     def __init__(self, project=None):
@@ -37,6 +38,8 @@ class Instance:
         self._start_worker()
 
         self._disassembly = {}
+
+        self.trace = None
 
         self.database_path = None
 
@@ -102,6 +105,9 @@ class Instance:
 
     def set_image(self, image):
         self.img_name = image
+
+    def set_trace(self, trace):
+        self.trace = TraceStatistics(self.workspace, trace)
 
     def initialize(self, cfg_args=None):
         if cfg_args is None:

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -11,6 +11,7 @@ from ..logic import GlobalInfo
 from ..logic.threads import gui_thread_schedule_async
 
 from .trace_statistics import TraceStatistics
+from .multi_trace import MultiTrace
 
 class Instance:
     def __init__(self, project=None):
@@ -40,6 +41,7 @@ class Instance:
         self._disassembly = {}
 
         self.trace = None
+        self.multi_trace = None
 
         self.database_path = None
 
@@ -108,6 +110,9 @@ class Instance:
 
     def set_trace(self, trace):
         self.trace = TraceStatistics(self.workspace, trace)
+
+    def set_multi_trace(self, trace):
+        self.multi_trace = MultiTrace(self.workspace, trace)
 
     def initialize(self, cfg_args=None):
         if cfg_args is None:

--- a/angrmanagement/data/multi_trace.py
+++ b/angrmanagement/data/multi_trace.py
@@ -1,0 +1,55 @@
+import math
+
+from PySide2.QtGui import QColor
+
+
+class MultiTrace:
+
+    HIT_COLOR = QColor(0xee, 0xee, 0xee)
+    MISS_COLOR = QColor(0x99, 0x00, 0x00, 0x30)
+    FUNCTION_NOT_VISITED_COLOR = QColor(0x99, 0x00, 0x00, 0x20)
+    BUCKET_COLORS = [QColor(0xef, 0x65, 0x48, 0x20), QColor(0xfc, 0x8d, 0x59, 0x60),
+                     QColor(0xfd, 0xbb, 0x84, 0x60), QColor(0xfd, 0xd4, 0x9e, 0x60)]
+
+    def __init__(self, workspace, multi_trace):
+        self.workspace = workspace
+        self._multi_trace = multi_trace
+        self.function_info = {}
+
+    def get_hit_miss_color(self, addr):
+
+        hexstr_addr = hex(addr)
+        if hexstr_addr not in self._multi_trace:
+            return MultiTrace.MISS_COLOR
+        else:
+            return MultiTrace.HIT_COLOR
+
+    def get_percent_color(self, func):
+        if func.addr not in self.function_info:
+            self._calc_function_info(func)
+
+        return self.function_info[func.addr]["color"]
+
+    def get_coverage(self, func):
+        if func.addr not in self.function_info:
+            self._calc_function_info(func)
+        return self.function_info[func.addr]["coverage"]
+
+    def _calc_function_info(self, func):
+        blocks = list(func.block_addrs)
+        hit_count = 0
+
+        for block in blocks:
+            hexstr_addr = hex(block)
+            if hexstr_addr in self._multi_trace:
+                hit_count += 1
+
+        if hit_count == 0:
+            self.function_info[func.addr] = {"color": MultiTrace.FUNCTION_NOT_VISITED_COLOR, "coverage": 0}
+        elif hit_count == len(blocks):
+            self.function_info[func.addr] = {"color": MultiTrace.HIT_COLOR, "coverage": 0}
+        else:
+            hit_percent = (hit_count / len(blocks)) * 100
+            bucket_size = 100 / len(MultiTrace.BUCKET_COLORS)
+            bucket_pos = math.floor(hit_percent / bucket_size)
+            self.function_info[func.addr] = {"color": MultiTrace.BUCKET_COLORS[bucket_pos], "coverage": hit_percent}

--- a/angrmanagement/data/trace_statistics.py
+++ b/angrmanagement/data/trace_statistics.py
@@ -18,16 +18,16 @@ class TraceFunc:
 
 class TraceStatistics:
 
-    BBL_FILL_COLOR = QColor(00, 0xf0, 0xf0, 15)
-    BBL_BORDER_COLOR = QColor(00, 0xf0, 0xf0)
+    BBL_FILL_COLOR = QColor(0, 0xf0, 0xf0, 0xf)
+    BBL_BORDER_COLOR = QColor(0, 0xf0, 0xf0)
 
     def __init__(self, workspace, trace):
         self.workspace = workspace
         self.trace = trace
-        self.trace_func = list()
-        self._func_color = dict()
+        self.trace_func = []
+        self._func_color = {}
         self.count = None
-        self._mark_color = dict()
+        self._mark_color = {}
         self._positions = defaultdict(list)
 
         self._statistics(trace)
@@ -60,7 +60,7 @@ class TraceStatistics:
 
     def _statistics(self, trace):
         """
-        trace: bbl address list
+        :param trace: basic block address list
         """
         bbls = filter(self._get_bbl, trace)
 

--- a/angrmanagement/data/trace_statistics.py
+++ b/angrmanagement/data/trace_statistics.py
@@ -1,0 +1,98 @@
+from PySide2.QtGui import QColor
+
+import logging
+import random
+from collections import defaultdict
+
+from angr.errors import SimEngineError
+
+l = logging.getLogger(name=__name__)
+l.setLevel('DEBUG')
+
+
+class TraceFunc:
+    def __init__(self, bbl_addr=None, func_name=None):
+        self.bbl_addr = bbl_addr
+        self.func_name = func_name
+
+
+class TraceStatistics:
+
+    BBL_FILL_COLOR = QColor(00, 0xf0, 0xf0, 15)
+    BBL_BORDER_COLOR = QColor(00, 0xf0, 0xf0)
+
+    def __init__(self, workspace, trace):
+        self.workspace = workspace
+        self.trace = trace
+        self.trace_func = list()
+        self._func_color = dict()
+        self.count = None
+        self._mark_color = dict()
+        self._positions = defaultdict(list)
+
+        self._statistics(trace)
+
+    def get_func_color(self, func_name):
+        if func_name in self._func_color:
+            return self._func_color[func_name]
+        else:
+            color = self._random_color()
+            self._func_color[func_name] = color
+        return color
+
+    def set_mark_color(self, p, color):
+        self._mark_color[p] = color
+
+    def get_mark_color(self, addr, i):
+        return self._mark_color[self._get_position(addr, i)]
+
+    def get_positions(self, addr):
+        return self._positions[addr]
+
+    def get_count(self, ins):
+        return len(self._positions[ins])
+
+    def get_bbl_from_position(self, position):
+        return self.trace_func[position].bbl_addr
+
+    def get_func_name_from_position(self, position):
+        return self.trace_func[position].func_name
+
+    def _statistics(self, trace):
+        """
+        trace: bbl address list
+        """
+        bbls = filter(self._get_bbl, trace)
+
+        for p, bbl_addr in enumerate(bbls):
+            block = self.workspace.instance.project.factory.block(bbl_addr)
+            for addr in block.instruction_addrs:
+                self._positions[addr].append(p)
+
+            func_addr = self.workspace.instance.cfg.get_any_node(bbl_addr).function_address
+            func_name = self.workspace.instance.project.kb.functions[func_addr].name
+            self.trace_func.append(TraceFunc(bbl_addr, func_name))
+
+        self.count = len(self.trace_func)
+
+    def _get_bbl(self, addr):
+        try:
+            return self.workspace.instance.project.factory.block(addr)
+        except SimEngineError:
+            return None
+
+    def _func_addr(self, a):
+        return self.workspace.instance.cfg.get_any_node(a).function_address
+
+    def _func_name(self, a):
+        return self.workspace.instance.project.kb.functions[self._func_addr(a)].name
+
+    def _random_color(self):
+        r = random.randint(0, 255)
+        g = random.randint(0, 255)
+        b = random.randint(0, 255)
+        return QColor(r, g, b)
+
+    def _get_position(self, addr, i):
+        return self._positions[addr][i]
+

--- a/angrmanagement/logic/disassembly/info_dock.py
+++ b/angrmanagement/logic/disassembly/info_dock.py
@@ -59,6 +59,7 @@ class InfoDock:
             else:
                 self.selected_insns.add(insn_addr)
             self.disasm_view.current_graph.show_instruction(insn_addr, insn_pos=insn_pos)
+            self.disasm_view.set_trace_mark(insn_addr)
             self.selected_insns.am_event()
 
     def unselect_instruction(self, insn_addr):

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 import os
 
@@ -132,6 +133,12 @@ class MainWindow(QMainWindow):
     def _open_mainfile_dialog(self):
         file_path, _ = QFileDialog.getOpenFileName(self, "Open a binary", ".",
                                                    "All executables (*);;Windows PE files (*.exe);;Core Dumps (*.core);;angr database (*.adb)",
+                                                   )
+        return file_path
+
+    def _open_trace_dialog(self):
+        file_path, _ = QFileDialog.getOpenFileName(self, "Open a trace", ".",
+                                                   "json (*.json)",
                                                    )
         return file_path
 
@@ -331,12 +338,27 @@ class MainWindow(QMainWindow):
         self.workspace.instance.add_job(LoadTargetJob(target))
         self.workspace.instance.set_image(img_name)
 
+    def open_trace(self):
+        trace_path = self._open_trace_dialog()
+        self.load_trace(trace_path)
+
     def load_file(self, file_path):
         if os.path.isfile(file_path):
             if file_path.endswith(".adb"):
                 self.load_database(file_path)
             else:
                 self.workspace.instance.add_job(LoadBinaryJob(file_path))
+            self._file_menu.action_by_key('load_trace').enable()
+
+    def load_trace(self, trace_path):
+        if os.path.isfile(trace_path):
+            with open(trace_path, 'r') as f:
+                trace = json.load(f)
+                self._set_trace(trace)
+
+    def _set_trace(self, trace):
+        self.workspace.instance.set_trace(trace)
+        self.workspace.view_manager.first_view_in_category('disassembly').show_trace_view()
 
     def save_database(self):
         if self.workspace.instance.database_path is None:

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -349,6 +349,7 @@ class MainWindow(QMainWindow):
             else:
                 self.workspace.instance.add_job(LoadBinaryJob(file_path))
             self._file_menu.action_by_key('load_trace').enable()
+            self._file_menu.action_by_key('load_multi_trace').enable()
 
     def load_trace(self, trace_path):
         if os.path.isfile(trace_path):
@@ -359,6 +360,21 @@ class MainWindow(QMainWindow):
     def _set_trace(self, trace):
         self.workspace.instance.set_trace(trace)
         self.workspace.view_manager.first_view_in_category('disassembly').show_trace_view()
+
+    def open_multi_trace(self):
+        multi_trace_path = self._open_trace_dialog()
+        self.load_multi_trace(multi_trace_path)
+
+    def load_multi_trace(self, trace_path):
+        if os.path.isfile(trace_path):
+            with open(trace_path, 'r') as f:
+                trace = json.load(f)
+                self._set_multi_trace(trace)
+
+    def _set_multi_trace(self, trace):
+        self.workspace.instance.set_multi_trace(trace)
+
+
 
     def save_database(self):
         if self.workspace.instance.database_path is None:

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -13,6 +13,8 @@ class FileMenu(Menu):
             MenuEntry('L&oad a new binary...', main_window.open_file_button, shortcut=QKeySequence(Qt.CTRL + Qt.Key_O)),
             MenuEntry('Loa&d a new docker target...', main_window.open_docker_button, shortcut=QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_O)),
             MenuEntry('Load a &trace...', main_window.open_trace, enabled=False, shortcut=QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_T), key='load_trace'),
+            MenuEntry('Load a &Multi-Trace...', main_window.open_multi_trace, enabled=False,
+                      shortcut=QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_M), key='load_multi_trace'),
             MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL + Qt.Key_S)),
             MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
             MenuSeparator(),

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -12,6 +12,7 @@ class FileMenu(Menu):
         self.entries.extend([
             MenuEntry('L&oad a new binary...', main_window.open_file_button, shortcut=QKeySequence(Qt.CTRL + Qt.Key_O)),
             MenuEntry('Loa&d a new docker target...', main_window.open_docker_button, shortcut=QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_O)),
+            MenuEntry('Load a &trace...', main_window.open_trace, enabled=False, shortcut=QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_T), key='load_trace'),
             MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL + Qt.Key_S)),
             MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
             MenuSeparator(),

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -33,7 +33,7 @@ class DisassemblyView(BaseView):
 
         self._linear_viewer = None
         self._flow_graph = None  # type: QDisassemblyGraph
-        self._trace_viewer = None # type: QTraceViewer
+        self._trace_viewer = None  # type: QTraceViewer
         self._statusbar = None
         self._jump_history = JumpHistory()
         self.infodock = InfoDock(self)
@@ -362,8 +362,8 @@ class DisassemblyView(BaseView):
     def set_trace_mark(self, insn_addr):
         """
         Show the appearance of the instruction in trace viewer, if trace viewer is being shown.
-        :param addr: instruction address
-        :return:
+        :param insn_addr: instruction address
+        :return:              None
         """
 
         if self._trace_viewer is not None:

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -1,5 +1,6 @@
 from PySide2.QtWidgets import QVBoxLayout, QLabel
 from PySide2.QtCore import QSize
+from PySide2.QtGui import QColor
 
 from .view import BaseView
 from ..widgets.qfunction_table import QFunctionTable
@@ -15,8 +16,6 @@ class FunctionsView(BaseView):
 
         self.workspace.instance.cfg_container.am_subscribe(self.reload)
 
-        self.backcolor_callback = None
-
         self._init_widgets()
 
         self.width_hint = 100
@@ -31,13 +30,19 @@ class FunctionsView(BaseView):
         if self.workspace.instance.trace is not None:
             for itr_func in self.workspace.instance.trace.trace_func:
                 if itr_func.bbl_addr == func.addr:
-                    return 0xf0, 0xe7, 0xda
-            return 0xee, 0xee, 0xee
+                    return QColor(0xf0, 0xe7, 0xda)
+            return QColor(0xee, 0xee, 0xee)
 
-        if self.backcolor_callback:
-            return self.backcolor_callback(func)
+        if self.workspace.instance.multi_trace is not None:
+            return self.workspace.instance.multi_trace.get_percent_color(func)
+
+        return QColor(255, 255, 255)
+
+    def get_function_coverage(self, func):
+        if self.workspace.instance.multi_trace is not None:
+            return self.workspace.instance.multi_trace.get_coverage(func)
         else:
-            return 255, 255, 255
+            return -1
 
     def set_function_count(self, count):
         if self._status_label is not None:

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -28,6 +28,12 @@ class FunctionsView(BaseView):
     #
 
     def get_function_backcolor(self, func):
+        if self.workspace.instance.trace is not None:
+            for itr_func in self.workspace.instance.trace.trace_func:
+                if itr_func.bbl_addr == func.addr:
+                    return 0xf0, 0xe7, 0xda
+            return 0xee, 0xee, 0xee
+
         if self.backcolor_callback:
             return self.backcolor_callback(func)
         else:

--- a/angrmanagement/ui/widgets/__init__.py
+++ b/angrmanagement/ui/widgets/__init__.py
@@ -11,3 +11,4 @@ from .qlinear_viewer import QLinearDisassembly
 
 # other widgets
 from .qfeature_map import QFeatureMap
+from .qtrace_viewer import QTraceViewer

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -155,11 +155,16 @@ class QGraphBlock(QBlock):
         should_omit_text = lod < QGraphBlock.MINIMUM_DETAIL_LEVEL
 
         # background of the node
-        if should_omit_text:
-            painter.setBrush(QColor(0xda, 0xda, 0xda))
+
+        if self.workspace.instance.multi_trace is not None:
+            color = self.workspace.instance.multi_trace.get_hit_miss_color(self.addr)
+            painter.setBrush(color)
         else:
-            painter.setBrush(self._config.disasm_view_node_background_color)
-        painter.setPen(QPen(self._config.disasm_view_node_border_color, 1.5))
+            if should_omit_text:
+                painter.setBrush(QColor(0xda, 0xda, 0xda))
+            else:
+                painter.setBrush(self._config.disasm_view_node_background_color)
+
         painter.drawPath(self._block_item)
 
         # content

--- a/angrmanagement/ui/widgets/qtrace_viewer.py
+++ b/angrmanagement/ui/widgets/qtrace_viewer.py
@@ -1,0 +1,196 @@
+from PySide2.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItemGroup
+from PySide2.QtGui import QPen, QBrush, QLinearGradient, QPixmap, QColor, QPainter, QFont
+from PySide2.QtCore import Qt, QRectF, QSize, QPoint
+
+from ...config import Conf
+
+import logging
+l = logging.getLogger(name=__name__)
+
+class QTraceViewer(QWidget):
+    TAG_SPACING = 50
+    LEGEND_X = -50
+    LEGEND_Y = 0
+    LEGEND_WIDTH = 10
+
+    TRACE_FUNC_X = 0
+    TRACE_FUNC_Y = 0
+    TRACE_FUNC_WIDTH = 50
+    TRACE_FUNC_MINHEIGHT = 1000
+
+    MARK_X = LEGEND_X
+    MARK_WIDTH = TRACE_FUNC_X - LEGEND_X + TRACE_FUNC_WIDTH
+    MARK_HEIGHT = 5
+
+    def __init__(self, workspace, disasm_view, parent=None):
+        super().__init__(parent=parent)
+        self.workspace = workspace
+        self.disasm_view = disasm_view
+
+        self.view = None
+        self.scene = None
+        self.mark = None
+
+        self._trace = None
+        self.selected_ins = None
+
+        self._init_widgets()
+
+    def _init_widgets(self):
+        self.view = QGraphicsView()
+        self.scene = QGraphicsScene()
+        self.view.setScene(self.scene)
+
+        self.trace_func = QGraphicsItemGroup()
+        self.scene.addItem(self.trace_func)
+
+        self.legend = None
+
+        layout = QHBoxLayout()
+        layout.addWidget(self.view)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.setLayout(layout)
+        self.setFixedWidth(500)
+
+    def set_trace(self, trace):
+        self._trace = trace
+        l.debug('minheight: %d, count: %d', self.TRACE_FUNC_MINHEIGHT,
+                self._trace.count)
+        if self.TRACE_FUNC_MINHEIGHT < self._trace.count * 15:
+            self.trace_func_unit_height = 15
+            show_func_tag = True
+        else:
+            self.trace_func_unit_height = self.TRACE_FUNC_MINHEIGHT / self._trace.count
+            show_func_tag = True
+        self.legend_height = self._trace.count * self.trace_func_unit_height
+
+        self._show_trace_func(show_func_tag)
+        self._show_legend()
+        self._set_mark_color()
+
+        # if self.selected_ins is not None:
+        #     self.set_trace_mark(self.selected_ins)
+
+    def set_trace_mark(self, addr):
+        self.selected_ins = addr
+        if self.mark is not None:
+            for i in self.mark.childItems():
+                self.mark.removeFromGroup(i)
+                self.scene.removeItem(i)
+        else:
+            self.mark = QGraphicsItemGroup()
+            self.scene.addItem(self.mark)
+        positions = self._trace.get_positions(addr)
+        for p in positions:
+            color = self._get_mark_color(p, self._trace.count)
+            y = self._get_mark_y(p, self._trace.count)
+            self.mark.addToGroup(self.scene.addRect(self.MARK_X, y, self.MARK_WIDTH,
+                                                    self.MARK_HEIGHT, QPen(color), QBrush(color)))
+
+        y = self._get_mark_y(positions[0], self._trace.count)
+        self.view.verticalScrollBar().setValue(y - 0.5 * self.view.size().height())
+
+    def mousePressEvent(self, event):
+        button = event.button()
+        pos = self._to_logical_pos(event.pos())
+        if button == Qt.LeftButton and self._at_legend(pos):
+            func = self._get_func_from_y(pos.y())
+            bbl_addr = self._get_bbl_from_y(pos.y())
+            self.workspace.on_function_selected(func)
+            self.disasm_view.infodock.toggle_instruction_selection(bbl_addr)
+
+    def _get_mark_color(self, i, total):
+        return self.legend_img.pixelColor(self.LEGEND_WIDTH // 2,
+                                          self.legend_height * i // total + 1)
+
+    def _get_mark_y(self, i, total):
+        return self.TRACE_FUNC_Y + self.trace_func_unit_height * i
+
+    def _graphicsitem_to_pixmap(self, graph):
+        if graph.scene() is not None:
+            r = graph.boundingRect()
+            pixmap = QPixmap(r.width(), r.height())
+            pixmap.fill(QColor(0, 0, 0, 0));
+            painter = QPainter(pixmap)
+            painter.drawRect(r)
+            graph.scene().render(painter, QRectF(), graph.sceneBoundingRect())
+            return pixmap
+        else:
+            return None
+
+    def _show_trace_func(self, show_func_tag):
+        x = self.TRACE_FUNC_X
+        y = self.TRACE_FUNC_Y
+        prev_name = None
+        for position in self._trace.trace_func:
+            bbl_addr = position.bbl_addr
+            func_name = position.func_name
+            l.debug('Draw function %x, %s', bbl_addr, func_name)
+            color = self._trace.get_func_color(func_name)
+            self.trace_func.addToGroup(self.scene.addRect(x, y,
+                                                          self.TRACE_FUNC_WIDTH, self.trace_func_unit_height,
+                                                          QPen(color), QBrush(color)))
+            if show_func_tag is True and func_name != prev_name:
+                tag = self.scene.addText(func_name,
+                                         Conf.trace_func_font)
+                tag.setPos(x + self.TRACE_FUNC_WIDTH +
+                           self.TAG_SPACING, y -
+                           tag.boundingRect().height() // 2)
+                self.trace_func.addToGroup(tag)
+                anchor = self.scene.addLine(
+                    self.TRACE_FUNC_X + self.TRACE_FUNC_WIDTH, y,
+                    x + self.TRACE_FUNC_WIDTH + self.TAG_SPACING, y)
+                self.trace_func.addToGroup(anchor)
+                prev_name = func_name
+            y += self.trace_func_unit_height
+
+    def _show_legend(self):
+        pen = QPen(Qt.transparent)
+
+        gradient = QLinearGradient(self.LEGEND_X, self.LEGEND_Y,
+                                   self.LEGEND_X, self.LEGEND_Y + self.legend_height)
+        gradient.setColorAt(0.0, Qt.red)
+        gradient.setColorAt(0.4, Qt.yellow)
+        gradient.setColorAt(0.6, Qt.green)
+        gradient.setColorAt(0.8, Qt.blue)
+        brush = QBrush(gradient)
+
+        self.legend = self.scene.addRect(self.LEGEND_X, self.LEGEND_Y,
+                                         self.LEGEND_WIDTH, self.legend_height, pen, brush)
+
+    def _set_mark_color(self):
+        pixmap = self._graphicsitem_to_pixmap(self.legend)
+        self.legend_img = pixmap.toImage()
+        for p in range(self._trace.count):
+            color = self._get_mark_color(p, self._trace.count)
+            self._trace.set_mark_color(p, color)
+
+    def _at_legend(self, pos):
+        x = pos.x()
+        y = pos.y()
+        if x > self.TRACE_FUNC_X and \
+                x < self.TRACE_FUNC_X + self.TRACE_FUNC_WIDTH and \
+                y > self.TRACE_FUNC_Y and \
+                y < self.TRACE_FUNC_Y + self.legend_height:
+            return True
+        else:
+            return False
+
+    def _to_logical_pos(self, pos):
+        x_offset = self.view.horizontalScrollBar().value()
+        y_offset = self.view.verticalScrollBar().value()
+        return QPoint(pos.x() + x_offset, pos.y() + y_offset)
+
+    def _get_position(self, y):
+        y_relative = y - self.legend_height
+        return y_relative // self.trace_func_unit_height
+
+    def _get_bbl_from_y(self, y):
+        position = self._get_position(y)
+        return self._trace.get_bbl_from_position(position)
+
+    def _get_func_from_y(self, y):
+        position = self._get_position(y)
+        func_name = self._trace.get_func_name_from_position(position)
+        return self.workspace.instance.cfg.kb.functions.function(name=func_name)


### PR DESCRIPTION
This feature adds the capability to overlay multiple traces onto the CFG in the disassembly view and the functions in the function list.  

While similar to the traceview feature, this capability is focused on giving the user visibility into multiple traces.  For example, the input json file might be generated by tracing all the inputs generated by AFL.  The resulting json file contains the combined addresses and hit counts after tracing the binary while using all the inputs.  

The idea is that this quickly shows branches missed during the fuzzing of the binary so that a user could then form inputs that follow the missed branch.
