### PR TITLE
Add Support for MenuSeparator()

### DIFF
--- a/angrmanagement/plugins/base_plugin.py
+++ b/angrmanagement/plugins/base_plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple, Callable, Iterator, List, Any
+from typing import Optional, Tuple, Callable, Iterator, List, Any, Union
 from PySide2.QtGui import QColor, QPainter
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QGraphicsSceneMouseEvent
@@ -74,8 +74,14 @@ class BasePlugin:
         # should return a tuple of the sortable column data and the rendered string
         return 0, ''
 
-    def build_context_menu_insn(self, item) -> Iterator[Tuple[str, Callable]]:
+    def build_context_menu_insn(self, item) -> Iterator[Union[None, Tuple[str, Callable]]]:
+        """
+        Use None to insert a MenuSeparator(). The tuples are: (menu entry text, callback)
+        """
         return []
 
-    def build_context_menu_block(self, item) -> Iterator[Tuple[str, Callable]]:
+    def build_context_menu_block(self, item) -> Iterator[Union[None, Tuple[str, Callable]]]:
+        """
+        Use None to insert a MenuSeparator(). The tuples are: (menu entry text, callback)
+        """
         return []

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -62,7 +62,7 @@ class Menu:
         if extra_entries is None:
             extra_entries = []
         else:
-            extra_entries = [MenuEntry(*entry) for entry in extra_entries]
+            extra_entries = [MenuSeparator() if entry is None else MenuEntry(*entry) for entry in extra_entries]
 
         if not extra_entries and self._qmenu is not None:
             # in order to use the cached result, must not have extra entries


### PR DESCRIPTION
This just helps break up the noise when there's a bunch of extra entries. Use case:

```
def build_context_menu_insn(self, item):
    return [None,
            ('Mark Generic &POI', lambda ctxm: self.on_ctx_menu_tag_poi(ctxm.insn_addr)),
            ('&Annotate POI', lambda ctxm: self.on_ctx_menu_annotate_poi(ctxm.insn_addr)),
            ('Add &Task', lambda ctxm: self.on_ctx_menu_add_task(ctxm.insn_addr))]
```