### PR TITLE
Remove unused imports from help_menu.py

### DIFF
--- a/angrmanagement/ui/menus/help_menu.py
+++ b/angrmanagement/ui/menus/help_menu.py
@@ -1,8 +1,6 @@
 
-from PySide2.QtGui import QKeySequence, QDesktopServices
-from PySide2.QtCore import Qt, QUrl
-from pyside2uic.properties import QtCore
-from pyside2uic.uiparser import QtGui
+from PySide2.QtGui import QKeySequence
+from PySide2.QtCore import Qt
 
 from .menu import Menu, MenuEntry, MenuSeparator
 


### PR DESCRIPTION
There were a few imports not used, but most notably the uic imports. These modules aren't installed by default from setup.py, so they are causing angr-management to fail to run. Since they are unused, I have simply removed them.

Discovery credit goes to @dnivra 