### PR TITLE
angr URL scheme

### DIFF
--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -87,7 +87,6 @@ def start_management(filepath=None):
     time.sleep(0.05)
     app.processEvents()
 
-    import rpyc
     from .logic import GlobalInfo
     from .ui.css import CSS
     from .ui.main_window import MainWindow
@@ -112,7 +111,7 @@ def start_management(filepath=None):
         print("Connecting to an existing angr management daemon.")
         try:
             GlobalInfo.daemon_conn = daemon_conn(service=ClientService)
-        except rpyc.ConnectionRefusedError:
+        except ConnectionRefusedError:
             print("[-] Connection failed... try again.")
             time.sleep(0.4)
             continue

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -41,16 +41,12 @@ def set_app_user_model_id():
 
 def start_management(filepath=None):
 
-    #from .logic.url_scheme import AngrUrlScheme
-    #AngrUrlScheme().register_url_scheme()
-    #sys.exit(1)
-
     if not check_dependencies():
         sys.exit(1)
 
     set_app_user_model_id()
 
-    from PySide2.QtWidgets import QApplication, QSplashScreen
+    from PySide2.QtWidgets import QApplication, QSplashScreen, QMessageBox
     from PySide2.QtGui import QFontDatabase, QPixmap, QIcon
     from PySide2.QtCore import Qt
 
@@ -59,6 +55,25 @@ def start_management(filepath=None):
     app = QApplication(sys.argv)
     app.setApplicationDisplayName("angr management")
     app.setApplicationName("angr management")
+
+    # URL scheme
+    from .logic.url_scheme import AngrUrlScheme
+    scheme = AngrUrlScheme()
+    registered, _ = scheme.is_url_scheme_registered()
+    if not registered:
+        btn = QMessageBox.question(None, "Setting up angr URL scheme",
+                "angr URL scheme allows \"deep linking\" from browsers and other applications by registering the "
+                "angr:// protocol to the current user. Do you want to register it? You may unregister at any "
+                "time in Preferences.",
+                defaultButton=QMessageBox.Yes)
+        if btn == QMessageBox.Yes:
+            try:
+                AngrUrlScheme().register_url_scheme()
+            except (ValueError, FileNotFoundError) as ex:
+                QMessageBox.error(None, "Error in registering angr URL scheme",
+                        "Failed to register the angr URL scheme.\n"
+                        "The following exception occurred:\n"
+                        + str(ex))
 
     # Make + display splash screen
     splashscreen_location = os.path.join(IMG_LOCATION, 'angr-splash.png')

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -103,12 +103,13 @@ def start_management(filepath=None):
 
     # connect to daemon (if there is one)
     if not daemon_exists():
-        print("Starting a new daemon.")
+        print("[+] Starting a new daemon.")
         run_daemon_process()
         time.sleep(0.2)
+    else:
+        print("[+] Connecting to an existing angr management daemon.")
 
     while True:
-        print("Connecting to an existing angr management daemon.")
         try:
             GlobalInfo.daemon_conn = daemon_conn(service=ClientService)
         except ConnectionRefusedError:

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -70,7 +70,7 @@ def start_management(filepath=None):
             try:
                 AngrUrlScheme().register_url_scheme()
             except (ValueError, FileNotFoundError) as ex:
-                QMessageBox.error(None, "Error in registering angr URL scheme",
+                QMessageBox.warning(None, "Error in registering angr URL scheme",
                         "Failed to register the angr URL scheme.\n"
                         "The following exception occurred:\n"
                         + str(ex))

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -87,6 +87,7 @@ def start_management(filepath=None):
     time.sleep(0.05)
     app.processEvents()
 
+    import rpyc
     from .logic import GlobalInfo
     from .ui.css import CSS
     from .ui.main_window import MainWindow
@@ -106,8 +107,17 @@ def start_management(filepath=None):
         print("Starting a new daemon.")
         run_daemon_process()
         time.sleep(0.2)
-    print("Connecting to an existing angr management daemon.")
-    GlobalInfo.daemon_conn = daemon_conn(service=ClientService)
+
+    while True:
+        print("Connecting to an existing angr management daemon.")
+        try:
+            GlobalInfo.daemon_conn = daemon_conn(service=ClientService)
+        except rpyc.ConnectionRefusedError:
+            print("[-] Connection failed... try again.")
+            time.sleep(0.4)
+            continue
+        print("[+] Connected to daemon.")
+        break
 
     from rpyc import BgServingThread
     th = BgServingThread(GlobalInfo.daemon_conn)

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -92,7 +92,7 @@ def start_management(filepath=None):
         run_daemon_process()
         time.sleep(0.2)
     print("Connecting to an existing angr management daemon.")
-    GlobalInfo.daemon_conn = daemon_conn(service=ClientService, allow_callback=True)
+    GlobalInfo.daemon_conn = daemon_conn(service=ClientService)
 
     from rpyc import BgServingThread
     th = BgServingThread(GlobalInfo.daemon_conn)

--- a/angrmanagement/daemon/__init__.py
+++ b/angrmanagement/daemon/__init__.py
@@ -1,0 +1,133 @@
+
+import os
+import sys
+import subprocess
+import binascii
+
+import tendo.singleton
+import rpyc
+from rpyc.utils.server import ThreadedServer
+from rpyc.utils.helpers import BgServingThread
+
+
+DEFAULT_PORT = 64000
+
+CONNECTIONS = { }
+MD5toCONN = { }
+SHA256toCONN = { }
+
+
+class ManagementService(rpyc.Service):
+
+    def on_connect(self, conn):
+        self._conn = conn
+        CONNECTIONS[conn] = None
+
+    def on_disconnect(self, conn):
+        self._conn = None
+        CONNECTIONS[conn] = None
+
+    def exposed_open(self, bin_path):
+        flags = { }
+        if sys.platform.startswith("win"):
+            DETACHED_PROCESS = 0x00000008
+            flags['creationflags'] = DETACHED_PROCESS
+
+        python_path = os.path.normpath(sys.executable)
+        if sys.platform.startswith("win"):
+            python_path = python_path.replace("pythonw.exe", "python.exe")
+        proc = subprocess.Popen([python_path, "-m", "angrmanagement", bin_path], shell=True, stdin=None, stdout=None,
+                                stderr=None,
+                                close_fds=True, **flags)
+
+    def exposed_jumpto(self, addr, symbol, md5, sha256):
+
+        if md5 in MD5toCONN:
+            conn = MD5toCONN[md5]
+        elif sha256 in SHA256toCONN:
+            conn = SHA256toCONN[sha256]
+        else:
+            raise Exception("The specified binary %s/%s is not open in angr management. We have the following ones: %s." % (
+                md5,
+                sha256,
+                str(MD5toCONN)))
+
+        conn.root.jumpto(addr, symbol)
+
+    def exposed_register_binary(self, bin_path, md5, sha256):
+        del CONNECTIONS[self._conn]
+
+        md5 = binascii.hexlify(md5).decode("ascii")
+        sha256 = binascii.hexlify(sha256).decode("ascii")
+
+        MD5toCONN[md5] = self._conn
+        SHA256toCONN[sha256] = self._conn
+
+    def exposed_exit(self):
+        pass
+
+
+def start_daemon(port=DEFAULT_PORT):
+
+    try:
+        inst = tendo.singleton.SingleInstance()
+    except tendo.singleton.SingleInstanceException:
+        return
+
+    server = ThreadedServer(ManagementService, port=port)
+    server.start()
+
+
+def daemon_exists():
+    try:
+        inst = tendo.singleton.SingleInstance()
+    except tendo.singleton.SingleInstanceException:
+        return True
+    del inst
+    return False
+
+
+def run_daemon_process():
+    """
+    Start a new Python process to run daemon.
+
+    :return:
+    """
+
+    flags = { }
+    if sys.platform.startswith("win"):
+        DETACHED_PROCESS = 0x00000008
+        flags['creationflags'] = DETACHED_PROCESS
+
+    python_path = os.path.normpath(sys.executable)
+    if sys.platform.startswith("win"):
+        python_path = python_path.replace("python.exe", "pythonw.exe")
+    proc = subprocess.Popen([python_path, "-m", "angrmanagement", "-d"], stdin=None, stdout=None, stderr=None,
+                            close_fds=True, **flags)
+
+
+def daemon_conn(port=DEFAULT_PORT, service=None, allow_callback=False):
+    kwargs = { }
+    if service is not None:
+        kwargs['service'] = service
+    conn = rpyc.connect("localhost", port, **kwargs)
+    #if allow_callback:
+    #    BgServingThread(conn)
+    return conn
+
+
+def monkeypatch_rpyc():
+    from rpyc.core.async_ import AsyncResult, AsyncResultTimeout
+
+    def patched_wait(self):
+        while not self._is_ready and not self._ttl.expired():
+            self._conn.serve(0.01)
+        if not self._is_ready:
+            raise AsyncResultTimeout("result expired")
+
+    AsyncResult.wait = patched_wait
+
+
+monkeypatch_rpyc()
+
+from .url_handler import handle_url

--- a/angrmanagement/daemon/__init__.py
+++ b/angrmanagement/daemon/__init__.py
@@ -1,122 +1,8 @@
 
-import os
-import sys
-import subprocess
-import binascii
-
-import tendo.singleton
-import rpyc
-from rpyc.utils.server import ThreadedServer
-from rpyc.utils.helpers import BgServingThread
-
-
-DEFAULT_PORT = 64000
-
-CONNECTIONS = { }
-MD5toCONN = { }
-SHA256toCONN = { }
-
-
-class ManagementService(rpyc.Service):
-
-    def on_connect(self, conn):
-        self._conn = conn
-        CONNECTIONS[conn] = None
-
-    def on_disconnect(self, conn):
-        self._conn = None
-        CONNECTIONS[conn] = None
-
-    def exposed_open(self, bin_path):
-        flags = { }
-        if sys.platform.startswith("win"):
-            DETACHED_PROCESS = 0x00000008
-            flags['creationflags'] = DETACHED_PROCESS
-
-        python_path = os.path.normpath(sys.executable)
-        if sys.platform.startswith("win"):
-            python_path = python_path.replace("pythonw.exe", "python.exe")
-        proc = subprocess.Popen([python_path, "-m", "angrmanagement", bin_path], shell=True, stdin=None, stdout=None,
-                                stderr=None,
-                                close_fds=True, **flags)
-
-    def exposed_jumpto(self, addr, symbol, md5, sha256):
-
-        if md5 in MD5toCONN:
-            conn = MD5toCONN[md5]
-        elif sha256 in SHA256toCONN:
-            conn = SHA256toCONN[sha256]
-        else:
-            raise Exception("The specified binary %s/%s is not open in angr management. We have the following ones: %s." % (
-                md5,
-                sha256,
-                str(MD5toCONN)))
-
-        conn.root.jumpto(addr, symbol)
-
-    def exposed_register_binary(self, bin_path, md5, sha256):
-        del CONNECTIONS[self._conn]
-
-        md5 = binascii.hexlify(md5).decode("ascii")
-        sha256 = binascii.hexlify(sha256).decode("ascii")
-
-        MD5toCONN[md5] = self._conn
-        SHA256toCONN[sha256] = self._conn
-
-    def exposed_exit(self):
-        pass
-
-
-def start_daemon(port=DEFAULT_PORT):
-
-    try:
-        inst = tendo.singleton.SingleInstance()
-    except tendo.singleton.SingleInstanceException:
-        return
-
-    server = ThreadedServer(ManagementService, port=port)
-    server.start()
-
-
-def daemon_exists():
-    try:
-        inst = tendo.singleton.SingleInstance()
-    except tendo.singleton.SingleInstanceException:
-        return True
-    del inst
-    return False
-
-
-def run_daemon_process():
-    """
-    Start a new Python process to run daemon.
-
-    :return:
-    """
-
-    flags = { }
-    if sys.platform.startswith("win"):
-        DETACHED_PROCESS = 0x00000008
-        flags['creationflags'] = DETACHED_PROCESS
-
-    python_path = os.path.normpath(sys.executable)
-    if sys.platform.startswith("win"):
-        python_path = python_path.replace("python.exe", "pythonw.exe")
-    proc = subprocess.Popen([python_path, "-m", "angrmanagement", "-d"], stdin=None, stdout=None, stderr=None,
-                            close_fds=True, **flags)
-
-
-def daemon_conn(port=DEFAULT_PORT, service=None, allow_callback=False):
-    kwargs = { }
-    if service is not None:
-        kwargs['service'] = service
-    conn = rpyc.connect("localhost", port, **kwargs)
-    #if allow_callback:
-    #    BgServingThread(conn)
-    return conn
-
-
 def monkeypatch_rpyc():
+
+    # The AsyncResult in rpyc has a bug that causes a race condition when clients are cascaded. this monkeypatch fixes
+    # the bug.
     from rpyc.core.async_ import AsyncResult, AsyncResultTimeout
 
     def patched_wait(self):
@@ -130,4 +16,6 @@ def monkeypatch_rpyc():
 
 monkeypatch_rpyc()
 
+
+from .server import daemon_conn, daemon_exists, start_daemon, run_daemon_process
 from .url_handler import handle_url

--- a/angrmanagement/daemon/client.py
+++ b/angrmanagement/daemon/client.py
@@ -29,6 +29,7 @@ class ClientService(rpyc.Service):
     def exposed_jumpto(self, addr, symbol):
 
         if self.workspace is not None:
+            gui_thread_schedule_async(GlobalInfo.main_window.bring_to_front)
             if addr is not None:
                 gui_thread_schedule_async(self.workspace.jump_to, args=(addr,))
             elif symbol is not None:

--- a/angrmanagement/daemon/client.py
+++ b/angrmanagement/daemon/client.py
@@ -1,0 +1,57 @@
+
+import functools
+
+import rpyc
+
+from ..logic.threads import gui_thread_schedule_async
+from ..logic import GlobalInfo
+
+
+def requires_daemon_conn(f):
+    @functools.wraps(f)
+    def with_daemon_conn(self, *args, **kwargs):
+        if self.conn is None:
+            return
+        return f(self, *args, **kwargs)
+    return with_daemon_conn
+
+
+class ClientService(rpyc.Service):
+
+    @property
+    def instance(self):
+        return GlobalInfo.main_window.workspace.instance
+
+    @property
+    def workspace(self):
+        return GlobalInfo.main_window.workspace
+
+    def exposed_jumpto(self, addr, symbol):
+
+        if self.workspace is not None:
+            if addr is not None:
+                gui_thread_schedule_async(self.workspace.jump_to, args=(addr,))
+            elif symbol is not None:
+                # TODO: Support it
+                gui_thread_schedule_async(self.workspace.jump_to, args=(symbol,))
+
+
+class DaemonClientCls:
+    """
+    Implements logic that the client needs to talk to the daemon service.
+    """
+
+    @property
+    def conn(self):
+        return GlobalInfo.daemon_conn
+
+    @requires_daemon_conn
+    def register_binary(self, binary_name, md5, sha256):
+        self.conn.root.register_binary(binary_name, md5, sha256)
+
+    @requires_daemon_conn
+    def exit(self):
+        self.conn.exit()
+
+
+DaemonClient = DaemonClientCls()

--- a/angrmanagement/daemon/client.py
+++ b/angrmanagement/daemon/client.py
@@ -35,6 +35,12 @@ class ClientService(rpyc.Service):
                 # TODO: Support it
                 gui_thread_schedule_async(self.workspace.jump_to, args=(symbol,))
 
+    def exposed_commentat(self, addr, comment):
+
+        if self.workspace is not None:
+            if addr is not None:
+                gui_thread_schedule_async(self.workspace.set_comment(addr, comment))
+
 
 class DaemonClientCls:
     """

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -1,0 +1,130 @@
+
+import os
+import sys
+import subprocess
+import binascii
+
+import tendo.singleton
+import rpyc
+from rpyc.utils.server import ThreadedServer
+
+
+DEFAULT_PORT = 64000
+
+CONNECTIONS = { }
+MD5toCONN = { }
+SHA256toCONN = { }
+
+
+class ManagementService(rpyc.Service):
+
+    def _get_conn(self, md5, sha256):
+
+        if md5 in MD5toCONN:
+            conn = MD5toCONN[md5]
+        elif sha256 in SHA256toCONN:
+            conn = SHA256toCONN[sha256]
+        else:
+            raise Exception("The specified binary %s/%s is not open in angr management. We have the following ones: %s." % (
+                md5,
+                sha256,
+                str(MD5toCONN)))
+        return conn
+
+    def on_connect(self, conn):
+        self._conn = conn
+        CONNECTIONS[conn] = None
+
+    def on_disconnect(self, conn):
+        self._conn = None
+        CONNECTIONS[conn] = None
+
+    def exposed_open(self, bin_path):
+        flags = { }
+        if sys.platform.startswith("win"):
+            DETACHED_PROCESS = 0x00000008
+            flags['creationflags'] = DETACHED_PROCESS
+
+        python_path = os.path.normpath(sys.executable)
+        if sys.platform.startswith("win"):
+            python_path = python_path.replace("pythonw.exe", "python.exe")
+        proc = subprocess.Popen([python_path, "-m", "angrmanagement", bin_path], shell=True, stdin=None, stdout=None,
+                                stderr=None,
+                                close_fds=True, **flags)
+
+    def exposed_jumpto(self, addr, symbol, md5, sha256):
+
+        conn = self._get_conn(md5, sha256)
+        conn.root.jumpto(addr, symbol)
+
+    def exposed_register_binary(self, bin_path, md5, sha256):
+        del CONNECTIONS[self._conn]
+
+        md5 = binascii.hexlify(md5).decode("ascii")
+        sha256 = binascii.hexlify(sha256).decode("ascii")
+
+        MD5toCONN[md5] = self._conn
+        SHA256toCONN[sha256] = self._conn
+
+    def exposed_commentat(self, addr, comment, md5, sha256):
+        """
+
+        :param addr:
+        :param str comment:
+        :param md5:
+        :param sha256:
+        :return:
+        """
+
+        conn = self._get_conn(md5, sha256)
+        conn.root.commentat(addr, comment)
+
+    def exposed_exit(self):
+        pass
+
+
+def start_daemon(port=DEFAULT_PORT):
+
+    try:
+        inst = tendo.singleton.SingleInstance()
+    except tendo.singleton.SingleInstanceException:
+        return
+
+    server = ThreadedServer(ManagementService, port=port)
+    server.start()
+
+
+def daemon_exists():
+    try:
+        inst = tendo.singleton.SingleInstance()
+    except tendo.singleton.SingleInstanceException:
+        return True
+    del inst
+    return False
+
+
+def run_daemon_process():
+    """
+    Start a new Python process to run daemon.
+
+    :return:
+    """
+
+    flags = { }
+    if sys.platform.startswith("win"):
+        DETACHED_PROCESS = 0x00000008
+        flags['creationflags'] = DETACHED_PROCESS
+
+    python_path = os.path.normpath(sys.executable)
+    if sys.platform.startswith("win"):
+        python_path = python_path.replace("python.exe", "pythonw.exe")
+    proc = subprocess.Popen([python_path, "-m", "angrmanagement", "-d"], stdin=None, stdout=None, stderr=None,
+                            close_fds=True, **flags)
+
+
+def daemon_conn(port=DEFAULT_PORT, service=None):
+    kwargs = { }
+    if service is not None:
+        kwargs['service'] = service
+    conn = rpyc.connect("localhost", port, **kwargs)
+    return conn

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -8,6 +8,8 @@ import tendo.singleton
 import rpyc
 from rpyc.utils.server import ThreadedServer
 
+from ..utils.env import app_path
+
 
 DEFAULT_PORT = 64000
 
@@ -115,10 +117,8 @@ def run_daemon_process():
         DETACHED_PROCESS = 0x00000008
         flags['creationflags'] = DETACHED_PROCESS
 
-    python_path = os.path.normpath(sys.executable)
-    if sys.platform.startswith("win"):
-        python_path = python_path.replace("python.exe", "pythonw.exe")
-    proc = subprocess.Popen([python_path, "-m", "angrmanagement", "-d"], stdin=None, stdout=None, stderr=None,
+    apppath = app_path(pythonw=True, as_list=True)
+    proc = subprocess.Popen(apppath + ["-d"], stdin=None, stdout=None, stderr=None,
                             close_fds=True, **flags)
 
 

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -4,10 +4,10 @@ import sys
 import subprocess
 import binascii
 
-import tendo.singleton
 import rpyc
 from rpyc.utils.server import ThreadedServer
 
+from ..logic.singleton import SingleInstance, SingleInstanceException
 from ..utils.env import app_path
 
 
@@ -87,8 +87,9 @@ class ManagementService(rpyc.Service):
 def start_daemon(port=DEFAULT_PORT):
 
     try:
-        inst = tendo.singleton.SingleInstance()
-    except tendo.singleton.SingleInstanceException:
+        from ..logic import GlobalInfo
+        GlobalInfo.daemon_inst = SingleInstance()
+    except SingleInstanceException:
         return
 
     server = ThreadedServer(ManagementService, port=port)
@@ -97,8 +98,8 @@ def start_daemon(port=DEFAULT_PORT):
 
 def daemon_exists():
     try:
-        inst = tendo.singleton.SingleInstance()
-    except tendo.singleton.SingleInstanceException:
+        inst = SingleInstance()
+    except SingleInstanceException:
         return True
     del inst
     return False

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -47,10 +47,8 @@ class ManagementService(rpyc.Service):
             DETACHED_PROCESS = 0x00000008
             flags['creationflags'] = DETACHED_PROCESS
 
-        python_path = os.path.normpath(sys.executable)
-        if sys.platform.startswith("win"):
-            python_path = python_path.replace("pythonw.exe", "python.exe")
-        proc = subprocess.Popen([python_path, "-m", "angrmanagement", bin_path], shell=True, stdin=None, stdout=None,
+        apppath = app_path(pythonw=False, as_list=True)
+        proc = subprocess.Popen(apppath + [bin_path], shell=False, stdin=None, stdout=None,
                                 stderr=None,
                                 close_fds=True, **flags)
 

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -48,7 +48,8 @@ class ManagementService(rpyc.Service):
             flags['creationflags'] = DETACHED_PROCESS
 
         apppath = app_path(pythonw=False, as_list=True)
-        proc = subprocess.Popen(apppath + [bin_path], shell=False, stdin=None, stdout=None,
+        shell = True if sys.platform.startswith("win") else False
+        proc = subprocess.Popen(apppath + [bin_path], shell=shell, stdin=None, stdout=None,
                                 stderr=None,
                                 close_fds=True, **flags)
 

--- a/angrmanagement/daemon/url_handler.py
+++ b/angrmanagement/daemon/url_handler.py
@@ -1,0 +1,98 @@
+
+import urllib.parse
+
+
+class UrlActionBase:
+
+    def act(self, daemon_conn=None):
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_params(params):
+        action = params.get('action', None)
+
+        if action is None:
+            raise ValueError("'action' is not specified.")
+        if not isinstance(action, list):
+            raise TypeError("Unexpected type of 'action'. Expecting a list.")
+        if len(action) != 1:
+            raise ValueError("We do not support multiple actions within the same URL.")
+        action = action[0]
+
+        if action not in _ACT2CLS:
+            raise KeyError("Unsupported action %s." % action)
+        return _ACT2CLS[action]._from_params(params)
+
+    @staticmethod
+    def _one_param(param, key):
+        v = param.get(key, None)
+        if v is None:
+            return None
+        return v[0]
+
+
+class UrlActionOpen(UrlActionBase):
+
+    def __init__(self, bin_path, md5_checksum=None, sha256_checksum=None, headless=False):
+        self.bin_path = bin_path
+        self.md5_checksum = md5_checksum
+        self.sha256_checksum = sha256_checksum
+        self.headless = headless
+
+    def act(self, daemon_conn=None):
+        daemon_conn.root.open(self.bin_path)
+
+    @classmethod
+    def _from_params(cls, params):
+        return cls(
+            cls._one_param(params, 'path'),
+            md5_checksum=cls._one_param(params, 'md5_checksum'),
+            sha256_checksum=cls._one_param(params, 'sha256_checksum'),
+            headless=cls._one_param(params, 'headless'),
+        )
+
+
+class UrlActionJumpTo(UrlActionBase):
+
+    def __init__(self, addr=None, symbol=None, md5_checksum=None, sha256_checksum=None):
+        self.addr = addr
+        self.symbol = symbol
+        self.md5_checksum = md5_checksum
+        self.sha256_checksum = sha256_checksum
+
+    def act(self, daemon_conn=None):
+        daemon_conn.root.jumpto(self.addr, self.symbol, self.md5_checksum, self.sha256_checksum)
+
+    @classmethod
+    def _from_params(cls, params):
+
+        addr = None
+        if 'addr' in params:
+            addr_str = params['addr'][0]
+            try:
+                addr = int(addr_str)
+            except ValueError:
+                addr = int(addr_str, 16)
+
+        return cls(
+            addr=addr,
+            symbol=cls._one_param(params, 'symbol'),
+            md5_checksum=cls._one_param(params, 'md5'),
+            sha256_checksum=cls._one_param(params, 'sha256'),
+        )
+
+
+_ACT2CLS = {
+    'open': UrlActionOpen,
+    'jumpto': UrlActionJumpTo,
+}
+
+
+def handle_url(url, act=True):
+    o = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(o.query)
+
+    action = UrlActionBase.from_params(params)
+    if act:
+        action.act()
+    return action

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -9,6 +9,8 @@ from .object_container import ObjectContainer
 from .sync_ctrl import SyncControl
 from ..logic import GlobalInfo
 from ..logic.threads import gui_thread_schedule_async
+from ..daemon.client import DaemonClient
+
 
 class Instance:
     def __init__(self, project=None):
@@ -118,6 +120,14 @@ class Instance:
         # should not trigger a signal
 
     def set_project(self, project, cfg_args=None):
+
+        try:
+            DaemonClient.register_binary(project.loader.main_object.binary,
+                                         project.loader.main_object.md5,
+                                         project.loader.main_object.sha256)
+        except Exception as ex:
+            print(ex)
+
         self._project_container.am_obj = project
         self._project_container.am_event(cfg_args=cfg_args)
 

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -1,7 +1,8 @@
 import time
 from threading import Thread
 from queue import Queue
-from typing import List, Optional, Type
+from typing import List, Optional, Type, Union, Callable
+
 import angr
 
 from .jobs import CFGGenerationJob
@@ -35,6 +36,11 @@ class Instance:
         self.register_container('interactions', lambda: [], List[SavedInteraction], 'Saved program interactions')
         # TODO: the current setup will erase all loaded protocols on a new project load! do we want that?
         self.register_container('interaction_protocols', lambda: [PlainTextProtocol], List[Type[ProtocolInteractor]], 'Available interaction protocols')
+
+        # Callbacks
+        self._insn_backcolor_callback = None  # type: Union[None, Callable[[int, bool], None]]   #  (addr, is_selected)
+        self._label_rename_callback = None  # type: Union[None, Callable[[int, str], None]]      #  (addr, new_name)
+        self._set_comment_callback = None  # type: Union[None, Callable[[int, str], None]]       #  (addr, comment_text)
 
         self.sync = SyncControl(self)
         self.cfg_args = None
@@ -94,6 +100,30 @@ class Instance:
 
     def __dir__(self):
         return list(super().__dir__()) + list(self.extra_containers)
+
+    @property
+    def insn_backcolor_callback(self):
+        return self._insn_backcolor_callback
+
+    @insn_backcolor_callback.setter
+    def insn_backcolor_callback(self, v):
+        self._insn_backcolor_callback = v
+
+    @property
+    def label_rename_callback(self):
+        return self._label_rename_callback
+
+    @label_rename_callback.setter
+    def label_rename_callback(self, v):
+        self._label_rename_callback = v
+
+    @property
+    def set_comment_callback(self):
+        return self._set_comment_callback
+
+    @set_comment_callback.setter
+    def set_comment_callback(self, v):
+        self._set_comment_callback = v
 
     #
     # Public methods

--- a/angrmanagement/data/jobs/loading.py
+++ b/angrmanagement/data/jobs/loading.py
@@ -43,7 +43,12 @@ class LoadBinaryJob(Job):
 
     def run(self, inst):
         self._progress_callback(5)
-        partial_ld = cle.Loader(self.fname, perform_relocations=False, load_debug_info=False)
+        try:
+            partial_ld = cle.Loader(self.fname, perform_relocations=False, load_debug_info=False)
+        except cle.CLECompatibilityError:
+            # we don't support this binary format (at least for now)
+            gui_thread_schedule(LoadBinary.binary_loading_failed, (self.fname,))
+            return
         self._progress_callback(50)
         load_options, cfg_args = gui_thread_schedule(LoadBinary.run, (partial_ld, ))
         partial_ld.close()

--- a/angrmanagement/logic/__init__.py
+++ b/angrmanagement/logic/__init__.py
@@ -1,3 +1,5 @@
-class GlobalInfo(object):
+
+class GlobalInfo:
     gui_thread = None
     main_window = None
+    daemon_conn = None

--- a/angrmanagement/logic/__init__.py
+++ b/angrmanagement/logic/__init__.py
@@ -2,4 +2,5 @@
 class GlobalInfo:
     gui_thread = None
     main_window = None
+    daemon_inst = None
     daemon_conn = None

--- a/angrmanagement/logic/singleton.py
+++ b/angrmanagement/logic/singleton.py
@@ -1,0 +1,149 @@
+# Copied and adapted from tendo
+
+import logging
+from multiprocessing import Process
+import os
+import sys
+import tempfile
+import unittest
+
+logger = logging.getLogger(name=__name__)
+
+
+if sys.platform != "win32":
+    import fcntl
+
+
+class SingleInstanceException(BaseException):
+    pass
+
+
+class SingleInstance:
+
+    """Class that can be instantiated only once per machine.
+
+    If you want to prevent your script from running in parallel just instantiate SingleInstance() class. If is there
+    another instance already running it will throw a `SingleInstanceException`.
+
+    >>> me = SingleInstance()
+
+    This option is very useful if you have scripts executed by crontab at small amounts of time.
+
+    Remember that this works by creating a lock file with a filename based on the full path to the script file.
+
+    Providing a flavor_id will augment the filename with the provided flavor_id, allowing you to create multiple
+    singleton instances from the same file. This is particularly useful if you want specific functions to have their
+    own singleton instances.
+    """
+
+    def __init__(self, flavor_id="", lockfile=""):
+        self.initialized = False
+        if lockfile:
+            self.lockfile = lockfile
+        else:
+            basename = os.path.splitext(os.path.abspath(__file__))[0].replace(
+                "/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
+            self.lockfile = os.path.normpath(
+                tempfile.gettempdir() + '/' + basename)
+
+        logger.debug("SingleInstance lockfile: " + self.lockfile)
+        if sys.platform == 'win32':
+            try:
+                # file already exists, we try to remove (in case previous
+                # execution was interrupted)
+                if os.path.exists(self.lockfile):
+                    os.unlink(self.lockfile)
+                self.fd = os.open(
+                    self.lockfile, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            except OSError:
+                type, e, tb = sys.exc_info()
+                if e.errno == 13:
+                    logger.debug(
+                        "Another instance is already running, quitting.")
+                    raise SingleInstanceException()
+                print(e.errno)
+                raise
+        else:  # non Windows
+            self.fp = open(self.lockfile, 'w')
+            self.fp.flush()
+            try:
+                fcntl.lockf(self.fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except IOError:
+                logger.debug(
+                    "Another instance is already running, quitting.")
+                raise SingleInstanceException()
+        self.initialized = True
+
+    def __del__(self):
+        if not self.initialized:
+            return
+        try:
+            if sys.platform == 'win32':
+                if hasattr(self, 'fd'):
+                    os.close(self.fd)
+                    os.unlink(self.lockfile)
+            else:
+                fcntl.lockf(self.fp, fcntl.LOCK_UN)
+                # os.close(self.fp)
+                if os.path.isfile(self.lockfile):
+                    os.unlink(self.lockfile)
+        except Exception as e:
+            if logger:
+                logger.debug(e)
+            else:
+                print("Unloggable error: %s" % e)
+            sys.exit(-1)
+
+
+def f(name):
+    tmp = logger.level
+    logger.setLevel(logging.CRITICAL)  # we do not want to see the warning
+    try:
+        me2 = SingleInstance(flavor_id=name)  # noqa
+    except SingleInstanceException:
+        sys.exit(-1)
+    logger.setLevel(tmp)
+    pass
+
+
+class testSingleton(unittest.TestCase):
+
+    def test_1(self):
+        me = SingleInstance(flavor_id="test-1")
+        del me  # now the lock should be removed
+        assert True
+
+    def test_2(self):
+        p = Process(target=f, args=("test-2",))
+        p.start()
+        p.join()
+        # the called function should succeed
+        assert p.exitcode == 0, "%s != 0" % p.exitcode
+
+    def test_3(self):
+        me = SingleInstance(flavor_id="test-3")  # noqa -- me should still kept
+        p = Process(target=f, args=("test-3",))
+        p.start()
+        p.join()
+        # the called function should fail because we already have another
+        # instance running
+        assert p.exitcode != 0, "%s != 0 (2nd execution)" % p.exitcode
+        # note, we return -1 but this translates to 255 meanwhile we'll
+        # consider that anything different from 0 is good
+        p = Process(target=f, args=("test-3",))
+        p.start()
+        p.join()
+        # the called function should fail because we already have another
+        # instance running
+        assert p.exitcode != 0, "%s != 0 (3rd execution)" % p.exitcode
+
+    def test_4(self):
+        lockfile = '/tmp/foo.lock'
+        me = SingleInstance(lockfile=lockfile)
+        assert me.lockfile == lockfile
+
+
+if __name__ == "__main__":
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
+    unittest.main()

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -102,7 +102,6 @@ class AngrUrlScheme:
     def _register_url_scheme_linux(self):
 
         cmd_0 = ["xdg-mime", "default", "angr.desktop", "x-scheme-handler/{url_scheme}".format(url_scheme=self.URL_SCHEME)]
-        cmd_1 = ["update-desktop-database"]
 
         # test if xdg-mime is available
         retcode = subprocess.call(["xdg-mime"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -134,9 +133,6 @@ Type=Application
         retcode = subprocess.call(cmd_0)
         if retcode != 0:
             raise ValueError("Failed to setup the URL scheme. Command \"%s\" failed." % " ".join(cmd_0))
-        retcode = subprocess.call(cmd_1)
-        if retcode != 0:
-            raise ValueError("Failed to setup the URL scheme. Command \"%s\" failed." % " ".join(cmd_1))
 
     def _unregister_url_scheme_linux(self):
 

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -1,6 +1,7 @@
 
 import os
 import sys
+import subprocess
 
 from PySide2.QtCore import QSettings
 
@@ -8,22 +9,71 @@ from PySide2.QtCore import QSettings
 class AngrUrlScheme:
 
     URL_SCHEME = "angr"
+    WIN_REG_PATH = "HKEY_CURRENT_USER\\Software\\Classes\\{}"
 
     """
     Registers and handlers URL schemes to the operating system.
     """
 
     def register_url_scheme(self):
-        self._register_url_scheme_windows()
+        if sys.platform.startswith("win"):
+            self._register_url_scheme_windows()
+        elif sys.platform.startswith("linux"):
+            self._register_url_scheme_linux()
+        else:
+            raise NotImplementedError("We currently do not support registering angr URL scheme on %s." % sys.platform)
+
+    def unregister_url_scheme(self):
+        if sys.platform.startswith("win"):
+            self._unregister_url_scheme_windows()
+        elif sys.platform.startswith("linux"):
+            self._unregister_url_scheme_linux()
+        else:
+            raise NotImplementedError("We currently do not support unregistering angr URL scheme on %s." % sys.platform)
+
+    def is_url_scheme_registered(self):
+        if sys.platform.startswith("win"):
+            return self._is_url_scheme_registered_windows()
+        elif sys.platform.startswith("linux"):
+            return self._is_url_scheme_registered_linux()
+        else:
+            raise NotImplementedError("We currently do not support registering angr URL scheme on %s." % sys.platform)
+
+    #
+    # Utils
+    #
+
+    def _app_path(self, pythonw=False):
+        """
+        Return the path of the application.
+
+        - In standalone mode (a PyInstaller module), we return the absolute path to the executable.
+        - In development mode, we return the absolute path to the python executable and "-m angr management"
+
+        :return:    A string that represents the path to the application that can be used to run angr management.
+        :rtype:     str
+        """
+
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            # running as a PyInstaller bundle
+            return sys.executable
+        else:
+            # running as a Python package
+            python_path = os.path.normpath(sys.executable)
+            if sys.platform.startswith("win") and pythonw:
+                python_path = python_path.replace("python.exe", "pythonw.exe")
+            app_path = python_path + " -m angrmanagement"
+            return app_path
+
+    #
+    # Windows
+    #
 
     def _register_url_scheme_windows(self):
 
-        python_path = os.path.normpath(sys.executable)
-        if sys.platform.startswith("win"):
-            python_path = python_path.replace("python.exe", "pythonw.exe")
-        app_path = python_path + " -m angrmanagement"
+        app_path = self._app_path(pythonw=True)
 
-        reg_path = "HKEY_CURRENT_USER\\Software\\Classes\\{}".format(self.URL_SCHEME)
+        reg_path = self.WIN_REG_PATH.format(self.URL_SCHEME)
         reg = QSettings(reg_path, QSettings.NativeFormat)
 
         reg.setValue("Default", "angr management")
@@ -40,3 +90,62 @@ class AngrUrlScheme:
         reg.endGroup()
         reg.endGroup()
         reg.endGroup()
+
+    def _unregister_url_scheme_windows(self):
+
+        reg_path = self.WIN_REG_PATH.format(self.URL_SCHEME)
+        reg = QSettings(reg_path, QSettings.NativeFormat)
+
+        reg.remove()
+
+    def _is_url_scheme_registered_windows(self):
+
+        reg_path = self.WIN_REG_PATH.format(self.URL_SCHEME)
+        reg = QSettings(reg_path, QSettings.NativeFormat)
+
+        if reg.contains("Default"):
+            if reg.contains("shell\\open\\command\\Default"):
+                return True, reg.value("shell\\open\\command\\Default")
+        return False, None
+
+    #
+    # Linux
+    #
+
+    def _register_url_scheme_linux(self):
+
+        cmd_0 = "gconftool-2 -t string -s /desktop/gnome/url-handlers/{url_scheme}/command '{app_path} \"%s\"'".format(
+            url_scheme=self.URL_SCHEME,
+            app_path=self._app_path(),
+        )
+        cmd_1 = "gconftool-2 -s /desktop/gnome/url-handlers/{url_scheme}/needs_terminal false -t bool".format(
+            url_scheme=self.URL_SCHEME,
+        )
+        cmd_2 = "gconftool-2 -s /desktop/gnome/url-handlers/{url_scheme}/enabled true -t bool".format(
+            url_scheme=self.URL_SCHEME,
+        )
+
+        # test if gconftool-2 is available
+        retcode = subprocess.call(["gconftool-2"])
+        if retcode != 1:
+            raise FileNotFoundError("gconftool-2 is not installed.")
+        retcode = subprocess.call(["gconftool-2", "-h"])
+        if retcode != 0:
+            raise FileNotFoundError("gconftool-2 is not installed.")
+
+        # register the scheme
+        retcode = subprocess.call(cmd_0)
+        if retcode != 0:
+            raise ValueError("Failed to setup the URL scheme. Command \"%s\" failed." % cmd_0)
+        retcode = subprocess.call(cmd_1)
+        if retcode != 0:
+            raise ValueError("Failed to setup the URL scheme. Command \"%s\" failed." % cmd_1)
+        retcode = subprocess.call(cmd_2)
+        if retcode != 0:
+            raise ValueError("Failed to setup the URL scheme. Command \"%s\" failed." % cmd_2)
+
+    def _unregister_url_scheme_linux(self):
+        raise NotImplementedError()
+
+    def _is_url_scheme_registered_linux(self):
+        raise NotImplementedError()

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -73,7 +73,7 @@ class AngrUrlScheme:
         reg.beginGroup("shell")
         reg.beginGroup("open")
         reg.beginGroup("command")
-        reg.setValue("Default", app_path_ + ' "%1"')
+        reg.setValue("Default", app_path_ + ' -u "%1"')
         reg.endGroup()
         reg.endGroup()
         reg.endGroup()

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -83,7 +83,7 @@ class AngrUrlScheme:
         reg_path = self.WIN_REG_PATH.format(self.URL_SCHEME)
         reg = QSettings(reg_path, QSettings.NativeFormat)
 
-        reg.remove()
+        reg.remove("")
 
     def _is_url_scheme_registered_windows(self):
 
@@ -91,8 +91,11 @@ class AngrUrlScheme:
         reg = QSettings(reg_path, QSettings.NativeFormat)
 
         if reg.contains("Default"):
-            if reg.contains("shell\\open\\command\\Default"):
-                return True, reg.value("shell\\open\\command\\Default")
+            reg.beginGroup("shell")
+            reg.beginGroup("open")
+            reg.beginGroup("command")
+            if reg.contains("Default"):
+                return True, reg.value("Default")
         return False, None
 
     #

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -115,7 +115,7 @@ class AngrUrlScheme:
         # extract angr.desktop
         angr_desktop = """[Desktop Entry]
 Comment=angr management
-Exec={app_path} -u "%U"
+Exec={app_path} -u %U
 Hidden=true
 Name=angr management
 Terminal=false

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -114,7 +114,7 @@ class AngrUrlScheme:
         # extract angr.desktop
         angr_desktop = """[Desktop Entry]
 Comment=angr management
-Exec={app_path} -u "%f"
+Exec={app_path} -u "%U"
 Hidden=true
 Name=angr management
 Terminal=false

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+import pathlib
 
 from PySide2.QtCore import QSettings
 
@@ -121,7 +122,10 @@ Terminal=false
 MimeType=x-scheme-handler/{url_scheme};
 Type=Application
 """
-        with open(self._angr_desktop_path(), "w") as f:
+        angr_desktop_path = self._angr_desktop_path()
+        angr_desktop_base = os.path.dirname(angr_desktop_path)
+        pathlib.Path(angr_desktop_base).mkdir(parents=True, exist_ok=True)
+        with open(angr_desktop_path, "w") as f:
             f.write(
                 angr_desktop.format(app_path=app_path(), url_scheme=self.URL_SCHEME)
             )

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -1,0 +1,42 @@
+
+import os
+import sys
+
+from PySide2.QtCore import QSettings
+
+
+class AngrUrlScheme:
+
+    URL_SCHEME = "angr"
+
+    """
+    Registers and handlers URL schemes to the operating system.
+    """
+
+    def register_url_scheme(self):
+        self._register_url_scheme_windows()
+
+    def _register_url_scheme_windows(self):
+
+        python_path = os.path.normpath(sys.executable)
+        if sys.platform.startswith("win"):
+            python_path = python_path.replace("python.exe", "pythonw.exe")
+        app_path = python_path + " -m angrmanagement"
+
+        reg_path = "HKEY_CURRENT_USER\\Software\\Classes\\{}".format(self.URL_SCHEME)
+        reg = QSettings(reg_path, QSettings.NativeFormat)
+
+        reg.setValue("Default", "angr management")
+        reg.setValue("URL Protocol", "")
+
+        # reg.beginGroup("DefaultIcon")
+        # reg.setValue("Default", TODO)
+        # reg.endGroup()
+
+        reg.beginGroup("shell")
+        reg.beginGroup("open")
+        reg.beginGroup("command")
+        reg.setValue("Default", app_path + ' "%1"')
+        reg.endGroup()
+        reg.endGroup()
+        reg.endGroup()

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -114,7 +114,7 @@ class AngrUrlScheme:
         # extract angr.desktop
         angr_desktop = """[Desktop Entry]
 Comment=angr management
-Exec="{app_path}" -u "%f"
+Exec={app_path} -u "%f"
 Hidden=true
 Name=angr management
 Terminal=false

--- a/angrmanagement/ui/dialogs/__init__.py
+++ b/angrmanagement/ui/dialogs/__init__.py
@@ -1,3 +1,4 @@
 from .load_binary import LoadBinary
 from .load_plugins import LoadPlugins
 from .load_docker_prompt import LoadDockerPrompt
+from .preferences import Preferences

--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -6,8 +6,6 @@ from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWid
     QGroupBox, QListWidgetItem, QListWidget, QMessageBox, QLineEdit, QGridLayout
 from PySide2.QtCore import Qt
 
-import cle
-
 
 l = logging.getLogger('dialogs.load_binary')
 
@@ -237,3 +235,11 @@ class LoadBinary(QDialog):
         except LoadBinaryError:
             pass
         return None, None
+
+    @staticmethod
+    def binary_loading_failed(filename):
+        # TODO: Normalize the path for Windows
+        QMessageBox.critical(None,
+                             "Failed to load binary",
+                             "angr failed to load binary %s. The format is not supported "
+                             "(we don't support loading blobs yet)." % filename)

--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -1,8 +1,9 @@
 import os
+import binascii
 import logging
 
 from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWidget, QPushButton, QCheckBox, QFrame, \
-    QGroupBox, QListWidgetItem, QListWidget, QMessageBox
+    QGroupBox, QListWidgetItem, QListWidget, QMessageBox, QLineEdit, QGridLayout
 from PySide2.QtCore import Qt
 
 import cle
@@ -21,6 +22,8 @@ class LoadBinary(QDialog):
 
         # initialization
         self.file_path = partial_ld.main_object.binary
+        self.md5 = None
+        self.sha256 = None
         self.option_widgets = { }
 
         # return values
@@ -28,6 +31,12 @@ class LoadBinary(QDialog):
         self.load_options = None
 
         self.setWindowTitle('Load a new binary')
+
+        # checksums
+        if hasattr(partial_ld.main_object, 'md5'):
+            self.md5 = binascii.hexlify(partial_ld.main_object.md5).decode("ascii")
+        if hasattr(partial_ld.main_object, 'sha256'):
+            self.sha256 = binascii.hexlify(partial_ld.main_object.sha256).decode("ascii")
 
         self.main_layout = QVBoxLayout()
 
@@ -58,6 +67,8 @@ class LoadBinary(QDialog):
             deps.append(ident)
             processed_objects.add(obj)
 
+        # dependencies
+
         dep_list = self.option_widgets['dep_list']  # type: QListWidget
         for dep in deps:
             dep_item = QListWidgetItem(dep)
@@ -65,6 +76,9 @@ class LoadBinary(QDialog):
             dep_list.addItem(dep_item)
 
     def _init_widgets(self):
+
+        layout = QGridLayout()
+        self.main_layout.addLayout(layout)
 
         # filename
 
@@ -74,10 +88,32 @@ class LoadBinary(QDialog):
         filename = QLabel(self)
         filename.setText(self.filename)
 
-        filename_layout = QHBoxLayout()
-        filename_layout.addWidget(filename_caption)
-        filename_layout.addWidget(filename)
-        self.main_layout.addLayout(filename_layout)
+        layout.addWidget(filename_caption, 0, 0, Qt.AlignRight)
+        layout.addWidget(filename, 0, 1)
+
+        # md5
+
+        if self.md5 is not None:
+            md5_caption = QLabel(self)
+            md5_caption.setText('MD5:')
+            md5 = QLineEdit(self)
+            md5.setText(self.md5)
+            md5.setReadOnly(True)
+
+            layout.addWidget(md5_caption, 1, 0, Qt.AlignRight)
+            layout.addWidget(md5, 1, 1)
+
+        # sha256
+
+        if self.sha256 is not None:
+            sha256_caption = QLabel(self)
+            sha256_caption.setText('SHA256:')
+            sha256 = QLineEdit(self)
+            sha256.setText(self.sha256)
+            sha256.setReadOnly(True)
+
+            layout.addWidget(sha256_caption, 2, 0, Qt.AlignRight)
+            layout.addWidget(sha256, 2, 1)
 
         # central tab
 

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -1,0 +1,121 @@
+
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
+    QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit
+from PySide2.QtCore import QSize
+
+from ...logic.url_scheme import AngrUrlScheme
+
+
+class Integration(QWidget):
+    """
+    The integration page.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._url_scheme_chk = None  # type:QCheckBox
+        self._url_scheme_text = None  # type:QLineEdit
+
+        self._init_widgets()
+        self._load_config()
+
+    def _init_widgets(self):
+
+        # os integratio
+        os_integration = QGroupBox("OS integration")
+        self._url_scheme_chk = QCheckBox("Register angr URL scheme (angr://).")
+        self._url_scheme_text = QLineEdit()
+        self._url_scheme_text.setReadOnly(True)
+        url_scheme_lbl = QLabel("Currently registered to:")
+
+        os_layout = QVBoxLayout()
+        os_layout.addWidget(self._url_scheme_chk)
+        os_layout.addWidget(url_scheme_lbl)
+        os_layout.addWidget(self._url_scheme_text)
+
+        os_integration.setLayout(os_layout)
+
+        layout = QVBoxLayout()
+        layout.addWidget(os_integration)
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def _load_config(self):
+        scheme = AngrUrlScheme()
+        try:
+            registered, register_as = scheme.is_url_scheme_registered()
+            self._url_scheme_chk.setChecked(registered)
+            self._url_scheme_text.setText(register_as)
+        except NotImplementedError:
+            # the current OS is not supported
+            self._url_scheme_chk.setDisabled(True)
+
+    def save_config(self):
+        scheme = AngrUrlScheme()
+        try:
+            registered, register_as = scheme.is_url_scheme_registered()
+            if registered != self._url_scheme_chk.isChecked():
+                # we need to do something
+                if self._url_scheme_chk.isChecked():
+                    scheme.register_url_scheme()
+                else:
+                    scheme.unregister_url_scheme()
+        except NotImplementedError:
+            # the current OS is not supported
+            pass
+
+
+class Preferences(QDialog):
+    def __init__(self, workspace, parent=None):
+        super().__init__(parent)
+
+        self.workspace = workspace
+
+        self._pages = [ ]
+
+        self._init_widgets()
+
+    def _init_widgets(self):
+
+        # contents
+        contents = QListWidget()
+        contents.setViewMode(QListView.IconMode)
+        contents.setIconSize(QSize(96, 84))
+        contents.setMovement(QListView.Static)
+        contents.setMaximumWidth(128)
+        contents.setSpacing(12)
+
+        self._pages.append(Integration())
+
+        pages = QStackedWidget()
+        for page in self._pages:
+            pages.addWidget(page)
+
+        # buttons
+        ok_button = QPushButton("OK")
+        ok_button.clicked.connect(self._on_ok_clicked)
+        cancel_button = QPushButton("Cancel")
+        cancel_button.clicked.connect(self._on_cancel_clicked)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(ok_button)
+        button_layout.addWidget(cancel_button)
+
+        # layout
+        top_layout = QHBoxLayout()
+        top_layout.addWidget(contents)
+        top_layout.addWidget(pages)
+
+        main_layout = QVBoxLayout()
+        main_layout.addLayout(top_layout)
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+
+    def _on_ok_clicked(self):
+        for page in self._pages:
+            page.save_config()
+        self.close()
+
+    def _on_cancel_clicked(self):
+        self.close()

--- a/angrmanagement/ui/dialogs/set_comment.py
+++ b/angrmanagement/ui/dialogs/set_comment.py
@@ -25,11 +25,11 @@ class QCommentTextBox(QPlainTextEdit):
 
 
 class SetComment(QDialog):
-    def __init__(self, disasm_view, comment_addr, parent=None):
+    def __init__(self, workspace, comment_addr, parent=None):
         super(SetComment, self).__init__(parent)
 
         # initialization
-        self._disasm_view = disasm_view
+        self._workspace = workspace
         self._comment_addr = comment_addr
 
         self._comment_textbox = None  # type: QCommentTextBox
@@ -51,8 +51,8 @@ class SetComment(QDialog):
 
         # comment textbox
         comment_txtbox = QCommentTextBox(textconfirmed_callback=self._on_ok_clicked, parent=self)
-        if self._comment_addr in self._disasm_view.disasm.kb.comments:
-            comment_txtbox.setPlainText(self._disasm_view.disasm.kb.comments[self._comment_addr])
+        if self._comment_addr in self._workspace.instance.project.kb.comments:
+            comment_txtbox.setPlainText(self._workspace.instance.project.kb.comments[self._comment_addr])
             comment_txtbox.selectAll()
         self._comment_textbox = comment_txtbox
 
@@ -82,7 +82,7 @@ class SetComment(QDialog):
 
     def _on_ok_clicked(self):
         comment_txt = self._comment_textbox.text
-        self._disasm_view.set_comment(self._comment_addr, comment_txt)
+        self._workspace.set_comment(self._comment_addr, comment_txt)
         self.close()
 
     def _on_cancel_clicked(self):

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -31,10 +31,10 @@ from .dialogs.load_docker_prompt import LoadDockerPrompt, LoadDockerPromptError
 from .dialogs.new_state import NewState
 from .dialogs.sync_config import SyncConfig
 from .dialogs.about import LoadAboutDialog
+from .dialogs.preferences import Preferences
 from .toolbars import StatesToolbar, AnalysisToolbar, FileToolbar
 from ..utils import has_binsync
 from ..config import Conf
-from ..daemon.client import DaemonClient
 from .. import plugins
 
 
@@ -372,6 +372,12 @@ class MainWindow(QMainWindow):
             file_path = file_path + ".adb"
 
         self._save_database(file_path)
+
+    def preferences(self):
+
+        # Open Preferences dialog
+        pref = Preferences(self.workspace, parent=self)
+        pref.exec_()
 
     def quit(self):
         self.close()

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -34,6 +34,7 @@ from .dialogs.about import LoadAboutDialog
 from .toolbars import StatesToolbar, AnalysisToolbar, FileToolbar
 from ..utils import has_binsync
 from ..config import Conf
+from ..daemon.client import DaemonClient
 from .. import plugins
 
 

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -400,6 +400,11 @@ class MainWindow(QMainWindow):
         self._progress = None
         self._progressbar.hide()
 
+    def bring_to_front(self):
+        self.setWindowState((self.windowState() & ~Qt.WindowMinimized) | Qt.WindowActive)
+        self.raise_()
+        self.activateWindow()
+
     #
     # Private methods
     #

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -15,5 +15,7 @@ class FileMenu(Menu):
             MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL + Qt.Key_S)),
             MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
             MenuSeparator(),
+            MenuEntry('&Preferences...', main_window.preferences, shortcut=QKeySequence(Qt.CTRL + Qt.Key_P)),
+            MenuSeparator(),
             MenuEntry('E&xit', main_window.quit),
         ])

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -221,6 +221,22 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
+    def set_comment(self, addr, comment_text):
+
+        kb = self.instance.project.kb
+        if comment_text is None and addr in kb.comments:
+            del kb.comments[addr]
+        kb.comments[addr] = comment_text
+
+        # callback first
+        if self.instance.set_comment_callback:
+            self.instance.set_comment_callback(addr=addr, comment_text=comment_text)
+
+        disasm_view = self._get_or_create_disassembly_view()
+        if disasm_view._flow_graph.disasm is not None:
+            # redraw
+            disasm_view.current_graph.refresh()
+
     def decompile_current_function(self, view=None):
         if view is None or view.category != "disassembly":
             view = self._get_or_create_disassembly_view()

--- a/angrmanagement/utils/env.py
+++ b/angrmanagement/utils/env.py
@@ -3,7 +3,7 @@ import sys
 import os
 
 
-def app_path(pythonw=False, as_list=False):
+def app_path(pythonw=None, as_list=False):
     """
     Return the path of the application.
 
@@ -22,10 +22,16 @@ def app_path(pythonw=False, as_list=False):
     else:
         # running as a Python package
         python_path = os.path.normpath(sys.executable)
-        if sys.platform.startswith("win") and pythonw:
-            python_path = python_path.replace("python.exe", "pythonw.exe")
+        if sys.platform.startswith("win"):
+            # if pythonw is None, we don't do anything
+            if pythonw is True:
+                python_path = python_path.replace("python.exe", "pythonw.exe")
+            elif pythonw is False:
+                python_path = python_path.replace("pythonw.exe", "python.exe")
         if as_list:
             return [python_path, "-m", "angrmanagement"]
         else:
+            if " " in python_path:
+                python_path = '"%s"' % python_path
             app_path = python_path + " -m angrmanagement"
             return app_path

--- a/angrmanagement/utils/env.py
+++ b/angrmanagement/utils/env.py
@@ -11,7 +11,7 @@ def app_path(pythonw=None, as_list=False):
     - In development mode, we return the absolute path to the python executable and "-m angr management"
 
     :return:    A string that represents the path to the application that can be used to run angr management.
-    :rtype:     str
+    :rtype:     str|list
     """
 
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):

--- a/angrmanagement/utils/env.py
+++ b/angrmanagement/utils/env.py
@@ -1,0 +1,31 @@
+
+import sys
+import os
+
+
+def app_path(pythonw=False, as_list=False):
+    """
+    Return the path of the application.
+
+    - In standalone mode (a PyInstaller module), we return the absolute path to the executable.
+    - In development mode, we return the absolute path to the python executable and "-m angr management"
+
+    :return:    A string that represents the path to the application that can be used to run angr management.
+    :rtype:     str
+    """
+
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # running as a PyInstaller bundle
+        if as_list:
+            return [sys.executable]
+        return sys.executable
+    else:
+        # running as a Python package
+        python_path = os.path.normpath(sys.executable)
+        if sys.platform.startswith("win") and pythonw:
+            python_path = python_path.replace("python.exe", "pythonw.exe")
+        if as_list:
+            return [python_path, "-m", "angrmanagement"]
+        else:
+            app_path = python_path + " -m angrmanagement"
+            return app_path

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(
         'toml',
         'pyxdg',
         'jupyter-client<6',
+        'tendo',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(
         'toml',
         'pyxdg',
         'jupyter-client<6',
+        'requests',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,5 @@ setup(
         'toml',
         'pyxdg',
         'jupyter-client<6',
-        'tendo',
     ]
 )

--- a/tests/test_urlscheme.py
+++ b/tests/test_urlscheme.py
@@ -1,0 +1,12 @@
+
+from angrmanagement.daemon import handle_url
+
+
+def test_open_binary():
+
+    # open
+    url = "angr://?action=open&path=/tmp/test&md5sum=00000000&headless=true"
+
+    # jumpto
+    url = "angr://?action=jumpto&addr=0x4006c6&md5=f6ad81a7f5028055d757f6eb39840708"
+

--- a/tests/test_urlscheme.py
+++ b/tests/test_urlscheme.py
@@ -10,3 +10,5 @@ def test_open_binary():
     # jumpto
     url = "angr://?action=jumpto&addr=0x4006c6&md5=f6ad81a7f5028055d757f6eb39840708"
 
+    # point of interests
+    url = "angr://?action=commentat&addr=0x4006c6&md5=f6ad81a7f5028055d757f6eb39840708&comment=dGVzdCBjb21tZW50"


### PR DESCRIPTION
Support `angr://`.

TODO:
- [x] Linux support.
- [ ] (Optional) MacOS support.
- [x] angr management executable support (i.e., in standalone mode where angr management is a single executable).
- [x] Add a configuration dialog to allow users to enable/disable the angr URL scheme.
- [x] Ask user if this URL scheme should be installed to the system upon first run.
- [x] Support more types of actions.
- [x] Support loading binaries from URLs.