### PR TITLE
LinearViewer: Update children's sizes when _update_size() is called.

### DIFF
--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -105,6 +105,9 @@ class QBlock(QCachedGraphicsItem):
         """
         Create the block background and border.
         """
+        if self._block_item is not None and self.scene is not None:
+            self.scene.removeItem(self._block_item)
+            self._block_item = None
 
         self._block_item = QPainterPath()
         self._block_item.addRect(0, 0, self.width, self.height)

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -19,6 +19,7 @@ class QCachedGraphicsItem(QGraphicsItem):
         return self.boundingRect().height()
 
     def recalculate_size(self):
+        self.prepareGeometryChange()
         self._cached_bounding_rect = self._boundingRect()
 
     def boundingRect(self):

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -273,6 +273,12 @@ class QLinearDisassembly(QAbstractScrollArea, QDisassemblyBaseControl):
         self.setLayout(layout)
 
     def _update_size(self):
+
+        # ask all objects to update their sizes
+        for obj in self.objects:
+            obj.refresh()
+
+        # update vertical scrollbar
         self.verticalScrollBar().setRange(0, self.max_offset * self._line_height - self.height() // 2)
         offset = 0 if self.offset is None else self.offset
         self.verticalScrollBar().setValue(offset * self._line_height)


### PR DESCRIPTION
Also, call prepareGeometryChange() in
QCachedGraphicsItem.recalculate_size() to avoid crashing inside Qt.