### PR TITLE
Fix issues in visualizing AFL bitmaps.

### DIFF
--- a/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
+++ b/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
@@ -77,7 +77,7 @@ class QTraceViewer(QWidget):
     def _on_set_trace(self, **kwargs):
         self._reset()
 
-        if self.trace != None:
+        if self.trace.am_obj is not None:
             l.debug('minheight: %d, count: %d', self.TRACE_FUNC_MINHEIGHT,
                     self.trace.count)
             if self.trace.count <= 0:

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -199,7 +199,7 @@ class DisassemblyView(BaseView):
 
         super().keyReleaseEvent(event)
 
-    def _redraw_current_graph(self, **kwargs):
+    def redraw_current_graph(self, **kwargs):
         """
         Redraw the graph currently in display.
 
@@ -494,12 +494,12 @@ class DisassemblyView(BaseView):
 
     def _register_events(self):
         # redraw the current graph if instruction/operand selection changes
-        self.infodock.selected_insns.am_subscribe(self._redraw_current_graph)
-        self.infodock.selected_operands.am_subscribe(self._redraw_current_graph)
-        self.infodock.selected_blocks.am_subscribe(self._redraw_current_graph)
-        self.infodock.hovered_block.am_subscribe(self._redraw_current_graph)
-        self.infodock.hovered_edge.am_subscribe(self._redraw_current_graph)
-        self.infodock.selected_labels.am_subscribe(self._redraw_current_graph)
+        self.infodock.selected_insns.am_subscribe(self.redraw_current_graph)
+        self.infodock.selected_operands.am_subscribe(self.redraw_current_graph)
+        self.infodock.selected_blocks.am_subscribe(self.redraw_current_graph)
+        self.infodock.hovered_block.am_subscribe(self.redraw_current_graph)
+        self.infodock.hovered_edge.am_subscribe(self.redraw_current_graph)
+        self.infodock.selected_labels.am_subscribe(self.redraw_current_graph)
 
         self._feature_map.addr.am_subscribe(lambda: self._jump_to(self._feature_map.addr.am_obj))
 

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -28,6 +28,9 @@ class FunctionsView(BaseView):
     # Public methods
     #
 
+    def refresh(self):
+        self._function_table.refresh()
+
     def set_function_count(self, count):
         self._function_count = count
         self._refresh_status_label()

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -229,6 +229,9 @@ class QFunctionTableView(QTableView):
         self.horizontalHeader().sortIndicatorChanged.connect(self.sortByColumn)
         self.doubleClicked.connect(self._on_function_selected)
 
+    def refresh(self):
+        self.viewport().update()
+
     @property
     def function_manager(self):
         return self._functions
@@ -325,6 +328,9 @@ class QFunctionTable(QWidget):
     #
     # Public methods
     #
+
+    def refresh(self):
+        self._table_view.refresh()
 
     def show_filter_box(self, prefix=""):
         if prefix:


### PR DESCRIPTION
- AFL bitmaps are not always bit-inverted.
- Properly handle fake return edges (fallthrough edges).
- Properly handle nodes that are split during the graph normalization
process.
- Do not follow a node's successors if the node is never hit. Reduce
false positives on small binaries.
- Automatically refreshes function table and disassembly view after
loading new traces and bitmaps.
- Support resetting loaded traces and bitmaps.