### PR TITLE
Make symbolic execution view just work

### DIFF
--- a/angrmanagement/ui/widgets/qstate_block.py
+++ b/angrmanagement/ui/widgets/qstate_block.py
@@ -24,11 +24,14 @@ class QStateBlock(QGraphicsItem):
         self._config = Conf
 
         self.state = state
+        self.addr = None
         self.history = history
         if history is None and state is not None:
             self.history = state.history
+            self.addr = state.addr
         if history is not None and state is None:
             self.state = history.state
+            self.addr = history.state.addr
         self.selected = is_selected
 
         # widgets

--- a/angrmanagement/ui/widgets/qsymexec_graph.py
+++ b/angrmanagement/ui/widgets/qsymexec_graph.py
@@ -47,13 +47,9 @@ class QSymExecGraph(QZoomableDraggableGraphicsView):
 
         # remove all edges
         scene = self.scene()
-        for p in self._edge_paths:
-            scene.removeItem(p)
 
         # remove all nodes
         self.blocks.clear()
-        #self.remove_all_children()
-        self._edge_paths = []
 
         node_sizes = {}
         for node in self.graph.nodes():

--- a/angrmanagement/utils/graph_layouter.py
+++ b/angrmanagement/utils/graph_layouter.py
@@ -321,7 +321,7 @@ class GraphLayouter:
         # order the nodes
         ordered_nodes = CFGUtils.quasi_topological_sort_nodes(self.graph)
 
-        # conver the graph to an acylic graph
+        # convert the graph to an acylic graph
         acyclic_graph = self._to_acyclic_graph(self.graph, ordered_nodes=ordered_nodes)
 
         # assign row and column to each node


### PR DESCRIPTION
I don't understand what I did. But it looks like this `_edge_paths` breaks everything. I tried to search the keyword `_edge_paths` in the whole repo. It turns out these are the only two usages of them in `angr-management`. I guess they might be some legacy QT stuff? Is it safe to just remove them?

The new `GraphLayouter` requires an `addr` attribute for each node in the graph so it can do some sorting. So the second change is to add that to `QStateBlock`