### PR TITLE
Fixing tab decompilation-to-assembly correspondance

### DIFF
--- a/angrmanagement/ui/documents/qcodedocument.py
+++ b/angrmanagement/ui/documents/qcodedocument.py
@@ -3,7 +3,7 @@ from PySide2.QtGui import QTextDocument
 from PySide2.QtWidgets import QPlainTextDocumentLayout
 
 from angr.analyses.decompiler.structured_codegen import CConstant, CVariable, CFunctionCall, StructuredCodeGenerator, \
-    CStructField
+    CStructField, CStatement
 
 from ...config import Conf
 
@@ -41,7 +41,6 @@ class QCodeDocument(QTextDocument):
         return self._codegen.nodemap
 
     def get_node_at_position(self, pos):
-
         if self._codegen is not None and self._codegen.posmap is not None:
             n = self._codegen.posmap.get_node(pos)
             if n is None:
@@ -49,6 +48,18 @@ class QCodeDocument(QTextDocument):
             return n
 
         return None
+
+    def get_stmt_node_at_position(self, pos):
+        if self._codegen is not None and self._codegen.stmt_posmap is not None:
+            n = self._codegen.stmt_posmap.get_node(pos)
+
+            # catch function calls
+            if isinstance(n, CFunctionCall):
+                return n
+
+            if n is None or n is not isinstance(n, CStatement):
+                n = self._codegen.stmt_posmap.get_node(pos - 1)
+            return n
 
     def find_related_text_chunks(self, node):
 

--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -9,7 +9,7 @@ from pyqodeng.core import modes
 from pyqodeng.core import panels
 
 import pyvex
-from angr.analyses.decompiler.structured_codegen import CBinaryOp, CFunctionCall
+from angr.analyses.decompiler.structured_codegen import CBinaryOp, CFunctionCall, CVariable
 
 from ..widgets.qccode_highlighter import QCCodeHighlighter
 
@@ -117,11 +117,46 @@ class QCCodeEdit(api.CodeEdit):
 
         return super().event(event)
 
+    def get_src_to_inst(self) -> int:
+        """
+        Uses the current cursor position, which is in a code view, and gets the
+        corresponding instruction address that is associated to the code.
+        Returns the start of the function if unable to calculate.
+
+        :return: int (address of inst)
+        """
+
+        # get the Qt document
+        doc: 'QCodeDocument' = self.document()
+
+        # get the current position of the cursor
+        cursor = self.textCursor()
+        pos = cursor.position()
+
+        # get the node at the associated cursor position
+        current_node = doc.get_node_at_position(pos)
+
+        if current_node is not None:
+            # associated asm pos to the current node of code
+            if isinstance(current_node, CFunctionCall):
+                asm_ins_addr = current_node.tags['ins_addr']
+            elif isinstance(current_node, CVariable):
+                asm_ins_addr = self._code_view.function.addr
+
+        else:
+            # the top of the function decompiled
+            asm_ins_addr = self._code_view.function.addr
+
+        return asm_ins_addr
+
     def keyReleaseEvent(self, key_event):
         key = key_event.key()
         if key == Qt.Key_Tab:
+            # Compute the location to switch back to
+            asm_inst_addr = self.get_src_to_inst()
+
             # Switch back to disassembly view
-            self.workspace.jump_to(self._code_view.function.addr)
+            self.workspace.jump_to(asm_inst_addr)
             return True
 
         super().keyPressEvent(key_event)

--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -9,7 +9,7 @@ from pyqodeng.core import modes
 from pyqodeng.core import panels
 
 import pyvex
-from angr.analyses.decompiler.structured_codegen import CBinaryOp, CFunctionCall, CVariable
+from angr.analyses.decompiler.structured_codegen import CBinaryOp, CStatement, CVariable
 
 from ..widgets.qccode_highlighter import QCCodeHighlighter
 
@@ -134,14 +134,10 @@ class QCCodeEdit(api.CodeEdit):
         pos = cursor.position()
 
         # get the node at the associated cursor position
-        current_node = doc.get_node_at_position(pos)
+        current_node = doc.get_stmt_node_at_position(pos)
 
-        if current_node is not None:
-            # associated asm pos to the current node of code
-            if isinstance(current_node, CFunctionCall):
-                asm_ins_addr = current_node.tags['ins_addr']
-            elif isinstance(current_node, CVariable):
-                asm_ins_addr = self._code_view.function.addr
+        if current_node is not None and isinstance(current_node, CStatement):
+            asm_ins_addr = current_node.tags['ins_addr']
 
         else:
             # the top of the function decompiled


### PR DESCRIPTION
* Add a new way to track statement positions
* Add a new way to resolve positions with statements before variables
* Add tags over to Cxxx classes for resolving
* Add feature to make the cursor go to the corresponding disassembly