### PR TITLE
Display source code when available

### DIFF
--- a/angrmanagement/data/jobs/decompile_function.py
+++ b/angrmanagement/data/jobs/decompile_function.py
@@ -5,14 +5,17 @@ class DecompileFunctionJob(Job):
     def __init__(self, function, on_finish=None, **kwargs):
         self.kwargs = kwargs
         self.function = function
-        self.result = None
         super().__init__(name="Decompiling", on_finish=on_finish)
 
     def run(self, inst):
-        d = inst.project.analyses.Decompiler(
+        inst.project.analyses.Decompiler(
             self.function,
+            flavor='pseudocode',
             **self.kwargs,
             progress_callback=self._progress_callback,
         )
-        self.result = d
-        return d
+        inst.project.analyses.ImportSourceCode(
+            self.function,
+            flavor='source',
+            progress_callback=self._progress_callback,
+        )

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
-from angr.analyses.decompiler.structured_codegen import CVariable, CFunction, CConstruct, CFunctionCall
+from angr.analyses.decompiler.structured_codegen.c import CVariable, CFunction, CConstruct, CFunctionCall
 
 if TYPE_CHECKING:
     from angrmanagement.ui.views.disassembly_view import DisassemblyView

--- a/angrmanagement/ui/documents/qcodedocument.py
+++ b/angrmanagement/ui/documents/qcodedocument.py
@@ -1,8 +1,9 @@
 from PySide2.QtGui import QTextDocument
 from PySide2.QtWidgets import QPlainTextDocumentLayout
 
-from angr.analyses.decompiler.structured_codegen.c import CConstant, CVariable, CFunctionCall, StructuredCodeGenerator, \
+from angr.analyses.decompiler.structured_codegen.c import CConstant, CVariable, CFunctionCall, \
     CStructField, CClosingObject, CFunction
+from angr.analyses.decompiler.structured_codegen.base import BaseStructuredCodeGenerator
 
 from ...config import Conf
 
@@ -14,7 +15,7 @@ class QCodeDocument(QTextDocument):
     def __init__(self, codegen):
         super().__init__()
 
-        self._codegen = codegen  # type: StructuredCodeGenerator
+        self._codegen = codegen  # type: BaseStructuredCodeGenerator
 
         # default font
         self.setDefaultFont(Conf.code_font)

--- a/angrmanagement/ui/documents/qcodedocument.py
+++ b/angrmanagement/ui/documents/qcodedocument.py
@@ -1,7 +1,7 @@
 from PySide2.QtGui import QTextDocument
 from PySide2.QtWidgets import QPlainTextDocumentLayout
 
-from angr.analyses.decompiler.structured_codegen import CConstant, CVariable, CFunctionCall, StructuredCodeGenerator, \
+from angr.analyses.decompiler.structured_codegen.c import CConstant, CVariable, CFunctionCall, StructuredCodeGenerator, \
     CStructField, CClosingObject, CFunction
 
 from ...config import Conf

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -5,7 +5,7 @@ from PySide2.QtWidgets import QHBoxLayout, QTextEdit, QMainWindow, QDockWidget
 from PySide2.QtGui import QTextCursor
 from PySide2.QtCore import Qt
 
-from angr.analyses.decompiler.structured_codegen import CFunctionCall, CConstant, StructuredCodeGenerator
+from angr.analyses.decompiler.structured_codegen.c import CFunctionCall, CConstant, CStructuredCodeGenerator
 from angr.knowledge_plugins.functions.function import Function
 
 from ..widgets.qccode_edit import QCCodeEdit
@@ -28,7 +28,7 @@ class CodeView(BaseView):
         self.function: Union[ObjectContainer, Function] = ObjectContainer(None, 'The function to decompile')
         self.current_node = ObjectContainer(None, 'Current selected C-code node')
         self.addr: Union[ObjectContainer, int] = ObjectContainer(0, "Current cursor address")
-        self.codegen: Union[ObjectContainer, StructuredCodeGenerator] = ObjectContainer(None, "The currently-displayed codegen object")
+        self.codegen: Union[ObjectContainer, CStructuredCodeGenerator] = ObjectContainer(None, "The currently-displayed codegen object")
 
         self._codeedit = None
         self._textedit: Optional[QCCodeEdit] = None

--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -178,7 +178,9 @@ class QCCodeEdit(api.CodeEdit):
                 self.rename_node(node=node)
             return True
 
-        return self._code_view.keyPressEvent(event)
+        if self._code_view.keyPressEvent(event):
+            return True
+        return super().keyPressEvent(event)
 
     def setDocument(self, document):
         super().setDocument(document)

--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -9,7 +9,7 @@ from pyqodeng.core import modes
 from pyqodeng.core import panels
 
 from angr.sim_variable import SimVariable, SimTemporaryVariable
-from angr.analyses.decompiler.structured_codegen import CBinaryOp, CVariable, CFunctionCall, CFunction
+from angr.analyses.decompiler.structured_codegen.c import CBinaryOp, CVariable, CFunctionCall, CFunction
 
 from ..dialogs.rename_node import RenameNode
 from ..widgets.qccode_highlighter import QCCodeHighlighter

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -21,10 +21,10 @@ class QCCodeHighlighter(SyntaxHighlighter):
 
     HIGHLIGHTING_RULES = [
         # quotation
-        (r"\"([^\\\"]|(\\.))*\"", 'quotation'),
+        #(r"\"([^\\\"]|(\\.))*\"", 'quotation'),
         # comment
-        (r"//[^\n]*", 'comment'),
-        (r"/\*[^\n]*\*/", 'comment'),
+        #(r"//[^\n]*", 'comment'),
+        #(r"/\*[^\n]*\*/", 'comment'),
         # keywords
         (r"\bbool\b", 'keyword'),
         (r"\bbreak\b", 'keyword'),
@@ -82,6 +82,7 @@ class QCCodeHighlighter(SyntaxHighlighter):
         super().__init__(parent, color_scheme=color_scheme)
 
         self.doc = parent  # type: QCodeDocument
+        self.comment_status = False
 
         if FORMATS['keyword'] is None:
             f = QTextCharFormat()
@@ -104,11 +105,62 @@ class QCCodeHighlighter(SyntaxHighlighter):
             FORMATS['comment'] = f
 
     def highlight_block(self, text, block):
+        # this code makes the assumption that this function is only ever called on lines in sequence in order
+        # it might also fuck up if it ever calls it starting in the middle...
+        if block.previous() is None:
+            self.comment_status = False
+
+        mark_in = 0
+
+        quote_status = False
+        quote_mark = None
+        escape_counter = 0
+        for col in range(len(text)):
+            if quote_status:
+                assert not self.comment_status
+                if escape_counter:
+                    escape_counter -= 1
+                elif text[col] == '\\':
+                    escape_counter = 1
+                elif text[col] == quote_mark:
+                    quote_status = False
+                    mark_out = col + 1
+                    self.setFormat(mark_in, mark_out - mark_in, FORMATS['quotation'])
+                    text = text[:mark_in] + " " * (mark_out - mark_in) + text[mark_out:]
+            else:
+                if self.comment_status:
+                    if text[col:col+2] == "*/":
+                        mark_out = col + 2
+                        self.comment_status = False
+                        self.setFormat(mark_in, mark_out - mark_in, FORMATS['comment'])
+                        text = text[:mark_in] + " " * (mark_out - mark_in) + text[mark_out:]
+                else:
+                    # regular mode is here
+                    if text[col] in ('"', "'"):
+                        mark_in = col
+                        quote_status = True
+                        quote_mark = text[col]
+                    elif text[col:col+2] == "/*":
+                        mark_in = col
+                        self.comment_status = True
+                    elif text[col:col+2] == '//':
+                        # do not set comment_status. just format the line and break.
+                        mark_in = col
+                        mark_out = len(text)
+                        self.setFormat(mark_in, mark_out - mark_in, FORMATS['comment'])
+                        text = text[:mark_in] + " " * (mark_out - mark_in) + text[mark_out:]
+                        break
+        if self.comment_status:
+            # do not unset. this is a multiline comment
+            mark_out = len(text)
+            self.setFormat(mark_in, mark_out - mark_in, FORMATS['comment'])
+            text = text[:mark_in] + " " * (mark_out - mark_in) + text[mark_out:]
+
         for pattern, format_id in self.HIGHLIGHTING_RULES:
             for mo in list(re.finditer(pattern, text)):
                 start = mo.start()
                 end = mo.end()
                 self.setFormat(start, end - start, FORMATS[format_id])
-                if format_id in {'quotation', 'comment'}:
-                    # remove the formatted parts so that we do not end up highlighting these parts again
-                    text = text[:start] + " " * (end-start) + text[end:]
+                #if format_id in {'quotation', 'comment'}:
+                #    # remove the formatted parts so that we do not end up highlighting these parts again
+                #    text = text[:start] + " " * (end-start) + text[end:]

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -25,6 +25,9 @@ class QCCodeHighlighter(SyntaxHighlighter):
         # comment
         #(r"//[^\n]*", 'comment'),
         #(r"/\*[^\n]*\*/", 'comment'),
+        # function
+        (r"\b[A-Za-z0-9_:]+\s*(?=\()", 'function'),
+        (r"\bNULL\b", 'function'),
         # keywords
         (r"\bbool\b", 'keyword'),
         (r"\bbreak\b", 'keyword'),
@@ -73,8 +76,6 @@ class QCCodeHighlighter(SyntaxHighlighter):
         (r"\bwhile\b", 'keyword'),
         (r"\bswitch\b", 'keyword'),
         (r"\breturn\b", 'keyword'),
-        # function
-        (r"\b[A-Za-z0-9_:]+(?=\()", 'function'),
     ]
 
     def __init__(self, parent, color_scheme=None):


### PR DESCRIPTION
Press space to tab back and forth between the decompiled code and the source code. Still missing: the ability to navigate the source code with double-click.