### PR TITLE
Add disassembly view selector in view status bar

### DIFF
--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -2,7 +2,7 @@ import logging
 from typing import Union, Optional, TYPE_CHECKING
 
 from PySide2.QtWidgets import QHBoxLayout, QVBoxLayout, QApplication, QMessageBox
-from PySide2.QtCore import Qt, QSize
+from PySide2.QtCore import Qt, QSize, Signal
 
 from ...data.instance import ObjectContainer
 from ...utils import locate_function
@@ -27,6 +27,8 @@ _l = logging.getLogger(__name__)
 
 
 class DisassemblyView(BaseView):
+    view_visibility_changed = Signal()
+
     def __init__(self, workspace, *args, **kwargs):
         super().__init__('disassembly', workspace, *args, **kwargs)
 
@@ -369,6 +371,7 @@ class DisassemblyView(BaseView):
             self._flow_graph.show_instruction(self._current_function.addr)
 
         self._flow_graph.setFocus()
+        self.view_visibility_changed.emit()
 
     def display_linear_viewer(self):
 
@@ -382,6 +385,7 @@ class DisassemblyView(BaseView):
             self._linear_viewer.show_instruction(self._current_function.addr)
 
         self._linear_viewer.setFocus()
+        self.view_visibility_changed.emit()
 
     def display_function(self, function):
 


### PR DESCRIPTION
This patch adds a view selector in the bottom-right of the disassembly view, next to the options dropdown button. I think it's helpful as both a selector and an indicator for new users.

![Screenshot from 2021-05-26 04-37-41](https://user-images.githubusercontent.com/8210/119653418-27049a80-bddc-11eb-9c9b-8158766b2c30.png)

