### PR TITLE
Support importing the initial configuration.

### DIFF
--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -117,6 +117,9 @@ def start_management(filepath=None, use_daemon=False):
     icon_location = os.path.join(IMG_LOCATION, 'angr.png')
     QApplication.setWindowIcon(QIcon(icon_location))
 
+    # try to import the initial configuration for the install
+    Conf.attempt_importing_initial_config()
+
     refresh_theme()
 
     # URL scheme

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -4,7 +4,8 @@ from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QL
 from PySide2.QtCore import QSize
 
 from ..widgets.qcolor_option import QColorOption
-from ...config.config_manager import ENTRIES, COLOR_SCHEMES
+from ...config.config_manager import ENTRIES
+from ...config.color_schemes import COLOR_SCHEMES
 from ...config import Conf
 from ...logic.url_scheme import AngrUrlScheme
 from ..css import refresh_theme

--- a/angrmanagement/utils/env.py
+++ b/angrmanagement/utils/env.py
@@ -1,9 +1,10 @@
+from typing import Union, List
 
 import sys
 import os
 
 
-def app_path(pythonw=None, as_list=False):
+def app_path(pythonw=None, as_list=False) -> Union[str,List[str]]:
     """
     Return the path of the application.
 
@@ -35,3 +36,22 @@ def app_path(pythonw=None, as_list=False):
                 python_path = '"%s"' % python_path
             app_path = python_path + " -m angrmanagement"
             return app_path
+
+
+def app_root() -> str:
+    """
+    Return the path of the application.
+
+    - In standalone mode (a PyInstaller module), we return the absolute path of the directory where the executable is.
+    - In development mode, we return the absolute path to the directory where the angr management package is.
+
+    :return:    A string that represents the path to the application that can be used to run angr management.
+    :rtype:     str|list
+    """
+
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # running as a PyInstaller bundle
+        return os.path.dirname(sys.executable)
+    else:
+        # running as a Python package
+        return os.path.normpath(os.path.join(os.path.abspath(__file__), "..", ".."))


### PR DESCRIPTION
angr management will search for `am_initial_config` in its root directory (and up to three levels of directories above its root directory) and import the configuration if it finds one. The `am_initial_config` file will be removed once loading is complete.