### PR TITLE
Force-reload newly created disassembly views so they actually work

### DIFF
--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -366,6 +366,7 @@ class Workspace:
             # Create a new disassembly view
             view = DisassemblyView(self, 'center')
             self.add_view(view, view.caption, view.category)
+            view.reload()
 
         return view
 


### PR DESCRIPTION
Closes #266

I don't know if this is the right solution. It seems a bit blunt to me but I'm not sure where else we could tweak in order to make it work.