### PR TITLE
Properly support high-DPI displays.

### DIFF
--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -120,10 +120,19 @@ def start_management(filepath=None, use_daemon=False):
 
     from PySide2.QtWidgets import QApplication, QSplashScreen, QMessageBox
     from PySide2.QtGui import QFontDatabase, QPixmap, QIcon
-    from PySide2.QtCore import Qt
+    from PySide2.QtCore import Qt, QCoreApplication
 
     from .config import FONT_LOCATION, IMG_LOCATION, Conf
     from .ui.css import refresh_theme
+
+    # Enable High-DPI support
+    # https://stackoverflow.com/questions/35714837/how-to-get-sharp-ui-on-high-dpi-with-qt-5-6
+    if ("QT_DEVICE_PIXEL_RATIO" not in os.environ
+        and "QT_AUTO_SCREEN_SCALE_FACTOR" not in os.environ
+        and "QT_SCALE_FACTOR" not in os.environ
+        and "QT_SCREEN_SCALE_FACTORS" not in os.environ
+        ):
+        QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName("angr management")

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -133,6 +133,10 @@ def start_management(filepath=None, use_daemon=False):
         and "QT_SCREEN_SCALE_FACTORS" not in os.environ
         ):
         QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
+    # No more rounding
+    # https://github.com/pyqtgraph/pyqtgraph/issues/756
+    # https://lists.qt-project.org/pipermail/development/2019-September/037434.html
+    QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName("angr management")

--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -213,6 +213,10 @@ class ConfigurationManager:
             self._code_font_width,
             self._code_font_ascent)
 
+    disasm_font: QFont
+    symexec_font: QFont
+    code_font: QFont
+
     @property
     def disasm_font_metrics(self):
         self._disasm_manage_font_cache()

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -188,6 +188,7 @@ class PluginManager:
             return custom(*args)
         except Exception as ex:  # pylint:disable=broad-except
             self._handle_error(plugin, func, sensitive, ex)
+            return None
 
     def _handle_error(self, plugin, func, sensitive, exc):
         self.workspace.log("Plugin %s errored during %s" % (plugin.get_display_name(), func.__name__))

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -187,7 +187,7 @@ class PluginManager:
         try:
             return custom(*args)
         except Exception as ex:  # pylint:disable=broad-except
-            return None
+            self._handle_error(plugin, func, sensitive, ex)
 
     def _handle_error(self, plugin, func, sensitive, exc):
         self.workspace.log("Plugin %s errored during %s" % (plugin.get_display_name(), func.__name__))

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -125,7 +125,7 @@ class PluginManager:
             for action in plugin_cls.URL_ACTIONS:
                 register_url_action(action, UrlActionBinaryAware)
 
-        except Exception: #pylint: disable=broad-except
+        except Exception:  # pylint:disable=broad-except
             l.warning("Plugin %s failed to activate:", plugin_cls.get_display_name(),
                       exc_info=True)
         else:
@@ -162,7 +162,7 @@ class PluginManager:
 
         try:
             plugin.teardown()
-        except Exception: #pylint: disable=broad-except
+        except Exception:  # pylint:disable=broad-except
             l.warning("Plugin %s errored during removal. The UI may be unstable.", plugin.get_display_name(),
                       exc_info=True)
         self.active_plugins.remove(plugin)
@@ -177,19 +177,16 @@ class PluginManager:
             if custom.__func__ is not func:
                 try:
                     res = custom(*args)
-                except Exception as e: #pylint: disable=broad-except
-                    self._handle_error(plugin, func, sensitive, e)
+                except Exception as ex:  # pylint:disable=broad-except
+                    self._handle_error(plugin, func, sensitive, ex)
                 else:
                     yield res
-
-        return None
 
     def _dispatch_single(self, plugin, func, sensitive, *args):
         custom = getattr(plugin, func.__name__)
         try:
             return custom(*args)
-        except Exception as e: #pylint: disable=broad-except
-            self._handle_error(plugin, func, sensitive, e)
+        except Exception as ex:  # pylint:disable=broad-except
             return None
 
     def _handle_error(self, plugin, func, sensitive, exc):
@@ -283,9 +280,9 @@ class PluginManager:
             else:
                 try:
                     return plugin.extract_func_column(func, idx)
-                except Exception as e: #pylint: disable=broad-except
+                except Exception as ex:  # pylint:disable=broad-except
                     # this should really be a "sensitive" operation but like
-                    self.workspace.log(e)
+                    self.workspace.log(ex)
                     self.workspace.log("PLEASE FIX YOUR PLUGIN AHHHHHHHHHHHHHHHHH")
                     return 0, ''
         raise IndexError("Not enough columns")

--- a/angrmanagement/plugins/sample_plugin.py
+++ b/angrmanagement/plugins/sample_plugin.py
@@ -3,6 +3,7 @@ from angrmanagement.ui.widgets.qblock import QBlock
 from angrmanagement.plugins import BasePlugin
 from typing import List, Iterator
 
+
 class SamplePlugin(BasePlugin):
     def __init__(self, workspace):
         super().__init__(workspace)

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -237,7 +237,7 @@ class CodeView(BaseView):
             elif isinstance(selected_node, CConstant):
                 # jump to highlighted constants
                 if selected_node.reference_values is not None and selected_node.value is not None:
-                    self.workspace.jump_to(selected_node.value.value)
+                    self.workspace.jump_to(selected_node.value)
 
     def keyPressEvent(self, event):
         key = event.key()

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -213,7 +213,7 @@ class QGraphBlock(QBlock):
         return 'graph'
 
     def layout_widgets(self):
-        x, y = self.LEFT_PADDING * self.currentDevicePixelRatioF(), self.TOP_PADDING * self.currentDevicePixelRatioF()
+        x, y = self.LEFT_PADDING, self.TOP_PADDING
 
         if self.qblock_annotations and self.qblock_annotations.scene():
             self.qblock_annotations.scene().removeItem(self.qblock_annotations)
@@ -321,7 +321,7 @@ class QLinearBlock(QBlock):
         max_width = 0
 
         for obj in self.objects:
-            y_offset += self.SPACING * self.currentDevicePixelRatioF()
+            y_offset += self.SPACING
             obj_start = 0
             obj.setPos(obj_start, y_offset)
             if obj_start + obj.width > max_width:

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -201,6 +201,7 @@ class QGraphBlock(QBlock):
     AIL_SHOW_CONDITIONAL_JUMP_TARGETS = False
     SHADOW_OFFSET_X = 5
     SHADOW_OFFSET_Y = 5
+    BLOCK_ANNOTATIONS_LEFT_PADDING = 2
 
     @property
     def mode(self):
@@ -215,7 +216,10 @@ class QGraphBlock(QBlock):
         self.qblock_annotations = self.disasm_view.fetch_qblock_annotations(self)
 
         for obj in self.objects:
-            obj.setPos(x + self.qblock_annotations.width + self.LEFT_PADDING, y)
+            if self.qblock_annotations.width > 0:
+                obj.setPos(self.BLOCK_ANNOTATIONS_LEFT_PADDING + self.qblock_annotations.width + x, y)
+            else:
+                obj.setPos(x, y)
             if isinstance(obj, QInstruction) and self.qblock_annotations.get(obj.addr):
                 qinsn_annotations = self.qblock_annotations.get(obj.addr)
                 for qinsn_annotation in qinsn_annotations:

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -33,8 +33,8 @@ class QBlock(QCachedGraphicsItem):
     SHADOW_OFFSET_Y = 0
 
     def __init__(self, workspace, func_addr, disasm_view, disasm, infodock, addr, cfg_nodes, out_branches, scene,
-                 parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+                 parent=None):
+        super().__init__(parent=parent)
 
         # initialization
         self.workspace = workspace
@@ -136,15 +136,14 @@ class QBlock(QCachedGraphicsItem):
         if bn.addr in self.disasm.kb.labels:
             label = QBlockLabel(bn.addr, get_label_text(bn.addr, self.disasm.kb),
                                 self._config, self.disasm_view, self.workspace,
-                                self.infodock, parent=self, container=self._container)
+                                self.infodock, parent=self)
             self.objects.append(label)
             self.addr_to_labels[bn.addr] = label
         for stmt in bn.statements:
-            code_obj = QAilObj(stmt, self.infodock, parent=None, container=self._container,
-                options={'show_conditional_jump_targets': self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS})
+            code_obj = QAilObj(stmt, self.infodock, parent=None,
+                               options={'show_conditional_jump_targets': self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS})
             obj = QBlockCode(stmt.ins_addr, code_obj, self._config, self.disasm_view,
-                             self.workspace, self.infodock, parent=self,
-                             container=self._container)
+                             self.workspace, self.infodock, parent=self)
             code_obj.parent = obj # Reparent
             self.objects.append(obj)
 
@@ -153,36 +152,31 @@ class QBlock(QCachedGraphicsItem):
             if isinstance(obj, Instruction):
                 out_branch = get_out_branches_for_insn(self.out_branches, obj.addr)
                 insn = QInstruction(self.workspace, self.func_addr, self.disasm_view, self.disasm,
-                                    self.infodock, obj, out_branch, self._config, parent=self,
-                                    container=self._container)
+                                    self.infodock, obj, out_branch, self._config, parent=self)
                 self.objects.append(insn)
                 self.addr_to_insns[obj.addr] = insn
             elif isinstance(obj, Label):
                 label = QBlockLabel(obj.addr, obj.text, self._config, self.disasm_view, self.workspace, self.infodock,
-                                    parent=self, container=self._container)
+                                    parent=self)
                 self.objects.append(label)
                 self.addr_to_labels[obj.addr] = label
             elif isinstance(obj, IROp):
-                code_obj = QIROpObj(obj, self.infodock, parent=None, container=self._container)
+                code_obj = QIROpObj(obj, self.infodock, parent=None)
                 disp_obj = QBlockCode(obj.addr, code_obj, self._config, self.disasm_view,
-                                 self.workspace, self.infodock, parent=self,
-                                 container=self._container)
+                                 self.workspace, self.infodock, parent=self)
                 code_obj.parent = disp_obj # Reparent
                 self.objects.append(disp_obj)
             elif isinstance(obj, PhiVariable):
                 if not isinstance(obj.variable, SimRegisterVariable):
-                    phivariable = QPhiVariable(self.workspace, self.disasm_view, obj, self._config, parent=self,
-                                               container=self._container)
+                    phivariable = QPhiVariable(self.workspace, self.disasm_view, obj, self._config, parent=self)
                     self.objects.append(phivariable)
             elif isinstance(obj, Variables):
                 for var in obj.variables:
-                    variable = QVariable(self.workspace, self.disasm_view, var, self._config, parent=self,
-                                         container=self._container)
+                    variable = QVariable(self.workspace, self.disasm_view, var, self._config, parent=self)
                     self.objects.append(variable)
             elif isinstance(obj, FunctionHeader):
                 self.objects.append(QFunctionHeader(self.func_addr, obj.name, obj.prototype, obj.args, self._config,
-                                                    self.disasm_view, self.workspace, self.infodock, parent=self,
-                                                    container=self._container))
+                                                    self.disasm_view, self.workspace, self.infodock, parent=self))
 
     def _init_widgets(self):
         if self.scene is not None:

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -24,18 +24,16 @@ class QBlockCodeObj(QObject):
     obj: Any
     infodock: InfoDock
     parent: Any
-    container: Any
     options: Mapping[str, Any]
     span: Optional[Tuple[int,int]]
     subobjs: Sequence['QBlockCodeObj']
     _fmt_current: QTextCharFormat
 
-    def __init__(self, obj:Any, infodock:InfoDock, parent:Any, container:Any, options:Mapping[str, Any]=None):
+    def __init__(self, obj:Any, infodock:InfoDock, parent:Any, options:Mapping[str, Any]=None):
         super().__init__()
         self.obj = obj
         self.infodock = infodock
         self.parent = parent
-        self.container = container
         self.options = options or {}
         self.span = None
         self.subobjs = []
@@ -125,7 +123,7 @@ class QBlockCodeObj(QObject):
         self._add_subobj(text)
 
     def add_variable(self, var):
-        self._add_subobj(QVariableObj(var, self.infodock, parent=self, container=self.container))
+        self._add_subobj(QVariableObj(var, self.infodock, parent=self))
 
     def on_click(self):
         """
@@ -172,8 +170,7 @@ class QAilObj(QBlockCodeObj):
             ailment.expression.Convert: QAilConvertObj,
             ailment.expression.Load: QAilLoadObj,
         }.get(type(obj), QAilTextObj)
-        subobj = subobjcls(obj, self.infodock, parent=self,
-                           container=self.container, options=self.options)
+        subobj = subobjcls(obj, self.infodock, parent=self, options=self.options)
         self._add_subobj(subobj)
 
 
@@ -340,8 +337,7 @@ class QIROpObj(QBlockCodeObj):
             VexIRTmpWrapper: QIROpVexTmpObj,
             VexIRRegWrapper: QIROpVexRegObj,
         }.get(type(obj), QIROpTextObj)
-        subobj = subobjcls(obj, self.infodock, parent=self,
-                           container=self.container, options=self.options, irobj=self.irobj)
+        subobj = subobjcls(obj, self.infodock, parent=self, options=self.options, irobj=self.irobj)
         self._add_subobj(subobj)
 
 
@@ -520,12 +516,11 @@ class QBlockCode(QCachedGraphicsItem):
     workspace: 'Workspace'
     infodock: InfoDock
     parent: Any
-    container: Any
 
     def __init__(self, addr:int, obj:QBlockCodeObj, config:ConfigurationManager,
         disasm_view:'QDisassemblyBaseControl', workspace:'Workspace',
-        infodock:InfoDock, parent:Any=None, container:Any=None):
-        super().__init__(parent=parent, container=container)
+        infodock:InfoDock, parent:Any=None):
+        super().__init__(parent=parent)
         self.addr = addr
         self._addr_str = "%08x" % self.addr
         self._addr_item: QGraphicsSimpleTextItem = None
@@ -534,7 +529,6 @@ class QBlockCode(QCachedGraphicsItem):
         self._height = 0
         self._config = config
         self.parent = parent
-        self.container = container
         self.workspace = workspace
         self.infodock = infodock
         self._disasm_view = disasm_view

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -1,5 +1,6 @@
 from PySide2.QtGui import QPainter, QTextDocument, QTextCursor, QTextCharFormat, QFont
 from PySide2.QtCore import Qt, QPointF, QRectF, QObject
+from PySide2.QtWidgets import QGraphicsSimpleTextItem
 from typing import Any, Mapping, Sequence, Optional, Tuple
 
 import ailment
@@ -513,7 +514,6 @@ class QBlockCode(QCachedGraphicsItem):
 
     addr: int
     _addr_str: str
-    _addr_width: int
     obj: QBlockCodeObj
     _config: ConfigurationManager
     disasm_view: 'QDisassemblyBaseControl'
@@ -528,8 +528,10 @@ class QBlockCode(QCachedGraphicsItem):
         super().__init__(parent=parent, container=container)
         self.addr = addr
         self._addr_str = "%08x" % self.addr
-        self._addr_width = self.p2p(config.disasm_font_metrics.width(self._addr_str))
+        self._addr_item: QGraphicsSimpleTextItem = None
         self.obj = obj
+        self._width = 0
+        self._height = 0
         self._config = config
         self.parent = parent
         self.container = container
@@ -539,8 +541,19 @@ class QBlockCode(QCachedGraphicsItem):
         self._qtextdoc = QTextDocument()
         self._qtextdoc.setDefaultFont(self._config.disasm_font)
         self._qtextdoc.setDocumentMargin(0)
+
+        self._addr_item = QGraphicsSimpleTextItem(self._addr_str, self)
+        self._addr_item.setBrush(Conf.disasm_view_node_address_color)
+        self._addr_item.setFont(Conf.disasm_font)
+
         self.update_document()
         self.setToolTip("Address: " + self._addr_str)
+
+        self._layout_items_and_update_size()
+
+    def refresh(self):
+        self._addr_item.setVisible(self._disasm_view.show_address)
+        self._layout_items_and_update_size()
 
     def update_document(self):
         self._qtextdoc.clear()
@@ -560,16 +573,12 @@ class QBlockCode(QCachedGraphicsItem):
             painter.drawRect(0, 0, self.width, self.height)
 
         x = 0
-        y = self._config.disasm_font_ascent
 
         if self._disasm_view.show_address:
-            painter.setPen(self._config.disasm_view_node_address_color)
-            painter.drawText(x, y, self._addr_str)
-            x += self._addr_width + self.GRAPH_ADDR_SPACING
+            x += self._addr_item.boundingRect().width() + self.GRAPH_ADDR_SPACING
 
         painter.translate(QPointF(x, 0))
         self._qtextdoc.drawContents(painter)
-
 
     #
     # Event handlers
@@ -582,7 +591,7 @@ class QBlockCode(QCachedGraphicsItem):
             # Propagate event to rendered object
             p = event.pos()
             if self._disasm_view.show_address:
-                offset = self._addr_width + self.GRAPH_ADDR_SPACING
+                offset = self._addr_item.boundingRect().width() + self.GRAPH_ADDR_SPACING
                 p.setX(p.x() - offset)
             if p.x() >= 0:
                 hitpos = self._qtextdoc.documentLayout().hitTest(p, Qt.HitTestAccuracy.ExactHit)
@@ -593,9 +602,18 @@ class QBlockCode(QCachedGraphicsItem):
     # Private methods
     #
 
-    def _boundingRect(self):
-        width = self._qtextdoc.size().width()
-        height = self._qtextdoc.size().height()
+    def _layout_items_and_update_size(self):
+
+        x, y = 0, 0
         if self._disasm_view.show_address:
-            width += self._addr_width + self.GRAPH_ADDR_SPACING
-        return QRectF(0, 0, width, height)
+            self._addr_item.setPos(x, y)
+            x += self._addr_item.boundingRect().width() + self.GRAPH_ADDR_SPACING
+
+        x += self._qtextdoc.size().width()
+        y += self._qtextdoc.size().height()
+        self._width = x
+        self._height = y
+        self.recalculate_size()
+
+    def _boundingRect(self):
+        return QRectF(0, 0, self._width, self._height)

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -528,7 +528,7 @@ class QBlockCode(QCachedGraphicsItem):
         super().__init__(parent=parent, container=container)
         self.addr = addr
         self._addr_str = "%08x" % self.addr
-        self._addr_width = config.disasm_font_metrics.width(self._addr_str) * self.currentDevicePixelRatioF()
+        self._addr_width = self.p2p(config.disasm_font_metrics.width(self._addr_str))
         self.obj = obj
         self._config = config
         self.parent = parent
@@ -565,7 +565,7 @@ class QBlockCode(QCachedGraphicsItem):
         if self._disasm_view.show_address:
             painter.setPen(self._config.disasm_view_node_address_color)
             painter.drawText(x, y, self._addr_str)
-            x += self._addr_width + self.GRAPH_ADDR_SPACING * self.currentDevicePixelRatioF()
+            x += self._addr_width + self.GRAPH_ADDR_SPACING
 
         painter.translate(QPointF(x, 0))
         self._qtextdoc.drawContents(painter)
@@ -597,5 +597,5 @@ class QBlockCode(QCachedGraphicsItem):
         width = self._qtextdoc.size().width()
         height = self._qtextdoc.size().height()
         if self._disasm_view.show_address:
-            width += self._addr_width + self.GRAPH_ADDR_SPACING * self.currentDevicePixelRatioF()
+            width += self._addr_width + self.GRAPH_ADDR_SPACING
         return QRectF(0, 0, width, height)

--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -46,6 +46,6 @@ class QBlockLabel(QCachedGraphicsItem):
     #
 
     def _boundingRect(self):
-        width = self._config.disasm_font_metrics.width(self.text) * self.currentDevicePixelRatioF()
-        height = self._config.disasm_font_height * self.currentDevicePixelRatioF()
+        width = self.p2p(self._config.disasm_font_metrics.width(self.text))
+        height = self._config.disasm_font_height
         return QRectF(0, 0, width, height)

--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -1,5 +1,6 @@
 
 from PySide2.QtGui import QPainter
+from PySide2.QtWidgets import QGraphicsSimpleTextItem
 from PySide2.QtCore import Qt, QRectF
 
 from ...config import Conf
@@ -14,24 +15,28 @@ class QBlockLabel(QCachedGraphicsItem):
         self.workspace = workspace
         self.addr = addr
         self.text = text
+        self._width = 0
+        self._height = 0
         self.infodock = infodock
 
         self._config = config
         self._disasm_view = disasm_view
+
+        self._text_item: QGraphicsSimpleTextItem = None
+
+        self._init_widgets()
 
     def paint(self, painter, option, widget):  #pylint: disable=unused-argument
         painter.setRenderHints(
                 QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.HighQualityAntialiasing)
         painter.setFont(self._config.code_font)
 
+        # background
         if self.infodock.is_label_selected(self.addr):
             highlight_color = Conf.disasm_view_label_highlight_color
             painter.setBrush(highlight_color)
             painter.setPen(highlight_color)
             painter.drawRect(0, 0, self.width, self.height)
-
-        painter.setPen(Conf.disasm_view_label_color)
-        painter.drawText(0, self._config.disasm_font_ascent, self.text)
 
     #
     # Event handlers
@@ -45,7 +50,19 @@ class QBlockLabel(QCachedGraphicsItem):
     # Private methods
     #
 
+    def _init_widgets(self):
+        self._text_item = QGraphicsSimpleTextItem(self.text, self)
+        self._text_item.setBrush(Conf.disasm_view_label_color)
+        self._text_item.setFont(self._config.disasm_font)
+
+        self._layout_items_and_update_size()
+
+    def _layout_items_and_update_size(self):
+        self._text_item.setPos(0, 0)
+
+        self._width = self._text_item.boundingRect().width()
+        self._height = self._text_item.boundingRect().height()
+        self.recalculate_size()
+
     def _boundingRect(self):
-        width = self.p2p(self._config.disasm_font_metrics.width(self.text))
-        height = self._config.disasm_font_height
-        return QRectF(0, 0, width, height)
+        return QRectF(0, 0, self._width, self._height)

--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -9,8 +9,8 @@ from .qgraph_object import QCachedGraphicsItem
 
 class QBlockLabel(QCachedGraphicsItem):
 
-    def __init__(self, addr, text, config, disasm_view, workspace, infodock, parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+    def __init__(self, addr, text, config, disasm_view, workspace, infodock, parent=None):
+        super().__init__(parent=parent)
 
         self.workspace = workspace
         self.addr = addr

--- a/angrmanagement/ui/widgets/qdepgraph_block.py
+++ b/angrmanagement/ui/widgets/qdepgraph_block.py
@@ -174,7 +174,7 @@ class QDepGraphBlock(QCachedGraphicsItem):
         addr_label_x = x + self.HORIZONTAL_PADDING
         painter.setPen(Qt.black)
         painter.drawText(addr_label_x, y + self._config.symexec_font_ascent, self._instruction_str)
-        x = addr_label_x + self._config.symexec_font_metrics.width(self._instruction_str)
+        x = addr_label_x + self.p2p(self._config.symexec_font_metrics.width(self._instruction_str))
 
         # The text
         if self._text:
@@ -201,22 +201,16 @@ class QDepGraphBlock(QCachedGraphicsItem):
 
     def _update_size(self):
         fm = self._config.symexec_font_metrics
-        dpr = self.currentDevicePixelRatioF()
         width_candidates = [
             # definition string
-            fm.width(self._definition_str) * dpr,
+            self.p2p(fm.width(self._definition_str)),
             # instruction & text
-            (self.HORIZONTAL_PADDING * 2 + fm.width(self._instruction_str) +
-             ((10 + fm.width(self._text)) if self._text else 0)
-             ) * dpr,
-            # # function string
-            # self.HORIZONTAL_PADDING * 2 * dpr +
-            # fm.width(self._function_str) * dpr,
+            self.HORIZONTAL_PADDING * 2 + self.p2p(fm.width(self._instruction_str)) +
+             ((10 + self.p2p(fm.width(self._text))) if self._text else 0),
         ]
 
         self._width = max(width_candidates)
         self._height = self.VERTICAL_PADDING * 2 + (self.LINE_MARGIN + self._config.symexec_font_height) * 2
-        self._height *= dpr
 
         self._width = max(100, self._width)
         self._height = max(50, self._height)

--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -130,7 +130,7 @@ class QDisassemblyGraph(QDisassemblyBaseControl, QZoomableDraggableGraphicsView)
 
         for n in self._supergraph.nodes():
             block = QGraphBlock(self.workspace, self._function_graph.function.addr, self.disasm_view, self.disasm,
-                                self.infodock, n.addr, nodefunc(n), branchfunc(n), scene, container=self)
+                                self.infodock, n.addr, nodefunc(n), branchfunc(n), scene)
             if n.addr == self._function_graph.function.addr:
                 self.entry_block = block
             scene.addItem(block)

--- a/angrmanagement/ui/widgets/qfunction_header.py
+++ b/angrmanagement/ui/widgets/qfunction_header.py
@@ -81,18 +81,18 @@ class QFunctionHeader(QCachedGraphicsItem):
         # args
         painter.setPen(Qt.darkBlue)
         x = 0
-        y += self._config.disasm_font_height * self.currentDevicePixelRatioF()
+        y += self._config.disasm_font_height
         if self._arg_str_list is not None:
             prefix = 'Args: ('
             painter.drawText(x, y + font_ascent, prefix)
-            x += font_metrics.width(prefix) * self.currentDevicePixelRatioF()
+            x += self.p2p(font_metrics.width(prefix))
 
             for i, arg_str in enumerate(self._arg_str_list):
                 painter.drawText(x, y + font_ascent, arg_str)
-                x += font_metrics.width(arg_str) * self.currentDevicePixelRatioF()
+                x += self.p2p(font_metrics.width(arg_str))
                 if i < len(self._arg_str_list) - 1:
                     painter.drawText(x, y + font_ascent, ", ")
-                    x += font_metrics.width(", ") * self.currentDevicePixelRatioF()
+                    x += self.p2p(font_metrics.width(", "))
 
             painter.drawText(x, y + font_ascent, ")")
 
@@ -121,61 +121,61 @@ class QFunctionHeader(QCachedGraphicsItem):
         if self.prototype is None:
             # function name
             if painter: painter.drawText(x, y + font_ascent, self.name)
-            x += font_metrics.width(self.name) * self.currentDevicePixelRatioF()
+            x += self.p2p(font_metrics.width(self.name))
 
         else:
             # type of the return value
             rt = type2str(self.prototype.returnty)
-            self._return_type_width = font_metrics.width(rt) * self.currentDevicePixelRatioF()
+            self._return_type_width = self.p2p(font_metrics.width(rt))
             if painter: painter.drawText(x, y + font_ascent, rt)
             x += self._return_type_width
 
             # space
-            x += font_metrics.width(" ")
+            x += self.p2p(font_metrics.width(" "))
 
             # function name
             if painter: painter.drawText(x, y + font_ascent, self.name)
-            x += font_metrics.width(self.name) * self.currentDevicePixelRatioF()
+            x += self.p2p(font_metrics.width(self.name))
 
             # left parenthesis
             if painter: painter.drawText(x, y + font_ascent, "(")
-            x += font_metrics.width("(") * self.currentDevicePixelRatioF()
+            x += self.p2p(font_metrics.width("("))
 
             # arguments
             self._prototype_args = [ ]
             for i, arg_type in enumerate(self.prototype.args):
                 type_str = type2str(arg_type)
-                type_str_width = font_metrics.width(type_str) * self.currentDevicePixelRatioF()
+                type_str_width = self.p2p(font_metrics.width(type_str))
 
                 if self.prototype.arg_names and i < len(self.prototype.arg_names):
                     arg_name = self.prototype.arg_names[i]
                 else:
                     arg_name = "arg_%d" % i
-                arg_name_width = font_metrics.width(arg_name) * self.currentDevicePixelRatioF()
+                arg_name_width = self.p2p(font_metrics.width(arg_name))
 
                 proto_arg = PrototypeArgument(
                     type_str,
                     (x, y + font_ascent),
                     type_str_width,
                     arg_name,
-                    (x + type_str_width + font_metrics.width(" ") * self.currentDevicePixelRatioF(), y + font_ascent),
+                    (x + type_str_width + self.p2p(font_metrics.width(" ")), y + font_ascent),
                     arg_name_width,
                 )
                 self._prototype_args.append(proto_arg)
 
                 if painter: painter.drawText(x, y + font_ascent, type_str)
-                x += type_str_width + font_metrics.width(" ") * self.currentDevicePixelRatioF()
+                x += type_str_width + self.p2p(font_metrics.width(" "))
                 if painter: painter.drawText(x, y + font_ascent, arg_name)
                 x += arg_name_width
 
                 if i < len(self.prototype.args) - 1:
                     # splitter
                     if painter: painter.drawText(x, y + font_ascent, ", ")
-                    x += font_metrics.width(", ") * self.currentDevicePixelRatioF()
+                    x += self.p2p(font_metrics.width(", "))
 
             # right parenthesis
             if painter: painter.drawText(x, y + font_ascent, ")")
-            x += font_metrics.width(")") * self.currentDevicePixelRatioF()
+            x += self.p2p(font_metrics.width(")"))
 
         return x, y, x - _x
 
@@ -197,13 +197,13 @@ class QFunctionHeader(QCachedGraphicsItem):
         self._update_sizes()
 
     def _update_sizes(self):
-        self._args_str_width = self._config.disasm_font_metrics.width(self._args_str)
-        self._name_width = self._config.disasm_font_metrics.width(self.name) * self.currentDevicePixelRatioF()
+        self._args_str_width = self.p2p(self._config.disasm_font_metrics.width(self._args_str))
+        self._name_width = self.p2p(self._config.disasm_font_metrics.width(self.name))
 
     def _boundingRect(self):
-        height = self._config.disasm_font_height * self.currentDevicePixelRatioF()
+        height = self._config.disasm_font_height
         if self._args_str:
-            height += self._config.disasm_font_height * self.currentDevicePixelRatioF()
+            height += self._config.disasm_font_height
 
         width = max(
             self._prototype_width,

--- a/angrmanagement/ui/widgets/qfunction_header.py
+++ b/angrmanagement/ui/widgets/qfunction_header.py
@@ -155,7 +155,7 @@ class QFunctionHeader(QCachedGraphicsItem):
             # prototype
             self._prototype_arg_item.setPos(x, y)
             x += self._prototype_arg_item.boundingRect().width()
-            height = self._function_name_item.boundingRect().height()
+            height = self._prototype_arg_item.boundingRect().height()
         else:
             height = 0
 
@@ -173,6 +173,7 @@ class QFunctionHeader(QCachedGraphicsItem):
         max_x = max(x, max_x)
         self._width = max_x
         self._height = y
+        self.recalculate_size()
 
     def _boundingRect(self):
         return QRectF(0, 0, self._width, self._height)

--- a/angrmanagement/ui/widgets/qfunction_header.py
+++ b/angrmanagement/ui/widgets/qfunction_header.py
@@ -14,8 +14,8 @@ from .qgraph_object import QCachedGraphicsItem
 
 class QFunctionHeader(QCachedGraphicsItem):
 
-    def __init__(self, addr, name, prototype, args, config, disasm_view, workspace, infodock, parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+    def __init__(self, addr, name, prototype, args, config, disasm_view, workspace, infodock, parent=None):
+        super().__init__(parent=parent)
 
         self.workspace = workspace
         self.addr = addr

--- a/angrmanagement/ui/widgets/qfunction_header.py
+++ b/angrmanagement/ui/widgets/qfunction_header.py
@@ -1,33 +1,15 @@
+from typing import Optional
 
 from PySide2.QtGui import QPainter, QCursor
 from PySide2.QtCore import Qt, QRectF
-from PySide2.QtWidgets import QApplication
+from PySide2.QtWidgets import QApplication, QGraphicsSimpleTextItem
 
-from angr.sim_type import SimType, SimTypeFunction, SimTypePointer
+from angr.sim_type import SimTypeFunction
 from angr.calling_conventions import SimRegArg
 
 from ...utils.func import type2str
 from ...config import Conf
 from .qgraph_object import QCachedGraphicsItem
-
-
-class PrototypeArgument:
-
-    __slots__ = ('ty', 'ty_pos', 'ty_width', 'arg', 'arg_pos', 'arg_width', )
-
-    def __init__(self, ty, ty_pos, ty_width, arg, arg_pos, arg_width):
-        self.ty = ty
-        self.ty_pos = ty_pos
-        self.ty_width = ty_width
-        self.arg = arg
-        self.arg_pos = arg_pos
-        self.arg_width = arg_width
-
-    def width(self):
-        if self.arg is not None:
-            return self.arg_pos[0] + self.arg_width - self.ty_pos[0]
-        else:
-            return self.ty_width
 
 
 class QFunctionHeader(QCachedGraphicsItem):
@@ -42,20 +24,24 @@ class QFunctionHeader(QCachedGraphicsItem):
         self.args = args
         self.infodock = infodock
 
+        self._width = 0
+        self._height = 0
+
         self._config = config
         self._disasm_view = disasm_view
 
-        self._name_width = None
         self._return_type_width = None
-        self._prototype_args = [ ]
         self._arg_str_list = None
         self._args_str = None
-        self._args_str_width = None
+
+        self._function_name_item: QGraphicsSimpleTextItem = None
+        self._args_str_item: QGraphicsSimpleTextItem = None
+        self._prototype_arg_item: Optional[QGraphicsSimpleTextItem] = None
 
         self._init_widgets()
 
     def refresh(self):
-        self._update_sizes()
+        pass
 
     def paint(self, painter, option, widget):
         painter.setRenderHints(
@@ -66,35 +52,6 @@ class QFunctionHeader(QCachedGraphicsItem):
             painter.setBrush(highlight_color)
             painter.setPen(highlight_color)
             painter.drawRect(0, 0, self.width, self.height)
-
-        painter.setFont(self._config.code_font)
-        painter.setPen(self._config.disasm_view_function_color)
-
-        font_ascent = self._config.disasm_font_ascent
-        font_metrics = self._config.disasm_font_metrics
-
-        x = 0
-        y = 0
-
-        x, y, _ = self._paint_prototype(x, y, painter=painter)
-
-        # args
-        painter.setPen(Qt.darkBlue)
-        x = 0
-        y += self._config.disasm_font_height
-        if self._arg_str_list is not None:
-            prefix = 'Args: ('
-            painter.drawText(x, y + font_ascent, prefix)
-            x += self.p2p(font_metrics.width(prefix))
-
-            for i, arg_str in enumerate(self._arg_str_list):
-                painter.drawText(x, y + font_ascent, arg_str)
-                x += self.p2p(font_metrics.width(arg_str))
-                if i < len(self._arg_str_list) - 1:
-                    painter.drawText(x, y + font_ascent, ", ")
-                    x += self.p2p(font_metrics.width(", "))
-
-            painter.drawText(x, y + font_ascent, ")")
 
     #
     # Event handlers
@@ -112,75 +69,7 @@ class QFunctionHeader(QCachedGraphicsItem):
     # Private methods
     #
 
-    def _paint_prototype(self, x, y, painter=None):
-
-        _x = x
-        font_ascent = self._config.disasm_font_ascent
-        font_metrics = self._config.disasm_font_metrics
-
-        if self.prototype is None:
-            # function name
-            if painter: painter.drawText(x, y + font_ascent, self.name)
-            x += self.p2p(font_metrics.width(self.name))
-
-        else:
-            # type of the return value
-            rt = type2str(self.prototype.returnty)
-            self._return_type_width = self.p2p(font_metrics.width(rt))
-            if painter: painter.drawText(x, y + font_ascent, rt)
-            x += self._return_type_width
-
-            # space
-            x += self.p2p(font_metrics.width(" "))
-
-            # function name
-            if painter: painter.drawText(x, y + font_ascent, self.name)
-            x += self.p2p(font_metrics.width(self.name))
-
-            # left parenthesis
-            if painter: painter.drawText(x, y + font_ascent, "(")
-            x += self.p2p(font_metrics.width("("))
-
-            # arguments
-            self._prototype_args = [ ]
-            for i, arg_type in enumerate(self.prototype.args):
-                type_str = type2str(arg_type)
-                type_str_width = self.p2p(font_metrics.width(type_str))
-
-                if self.prototype.arg_names and i < len(self.prototype.arg_names):
-                    arg_name = self.prototype.arg_names[i]
-                else:
-                    arg_name = "arg_%d" % i
-                arg_name_width = self.p2p(font_metrics.width(arg_name))
-
-                proto_arg = PrototypeArgument(
-                    type_str,
-                    (x, y + font_ascent),
-                    type_str_width,
-                    arg_name,
-                    (x + type_str_width + self.p2p(font_metrics.width(" ")), y + font_ascent),
-                    arg_name_width,
-                )
-                self._prototype_args.append(proto_arg)
-
-                if painter: painter.drawText(x, y + font_ascent, type_str)
-                x += type_str_width + self.p2p(font_metrics.width(" "))
-                if painter: painter.drawText(x, y + font_ascent, arg_name)
-                x += arg_name_width
-
-                if i < len(self.prototype.args) - 1:
-                    # splitter
-                    if painter: painter.drawText(x, y + font_ascent, ", ")
-                    x += self.p2p(font_metrics.width(", "))
-
-            # right parenthesis
-            if painter: painter.drawText(x, y + font_ascent, ")")
-            x += self.p2p(font_metrics.width(")"))
-
-        return x, y, x - _x
-
     def _init_widgets(self):
-        _, _, self._prototype_width = self._paint_prototype(0, 0)
 
         if self.args is not None:
             self._arg_str_list = [ ]
@@ -194,20 +83,96 @@ class QFunctionHeader(QCachedGraphicsItem):
         else:
             self._args_str = ""
 
-        self._update_sizes()
+        #
+        # prototype
+        #
 
-    def _update_sizes(self):
-        self._args_str_width = self.p2p(self._config.disasm_font_metrics.width(self._args_str))
-        self._name_width = self.p2p(self._config.disasm_font_metrics.width(self.name))
+        if self.prototype is None:
+            # Just print the function name
+            self._function_name_item = QGraphicsSimpleTextItem(self.name, self)
+            self._function_name_item.setFont(self._config.code_font)
+            self._function_name_item.setBrush(self._config.disasm_view_function_color)
+
+        else:
+            # print the prototype
+
+            proto_str = ""
+
+            # type of the return value
+            rt = type2str(self.prototype.returnty)
+            proto_str += rt
+
+            # space
+            proto_str += " "
+
+            # function name
+            proto_str += self.name
+
+            # left parenthesis
+            proto_str += "("
+
+            # arguments
+            for i, arg_type in enumerate(self.prototype.args):
+                type_str = type2str(arg_type)
+                proto_str += type_str + " "
+
+                if self.prototype.arg_names and i < len(self.prototype.arg_names):
+                    arg_name = self.prototype.arg_names[i]
+                else:
+                    arg_name = "arg_%d" % i
+                proto_str += arg_name
+
+                if i < len(self.prototype.args) - 1:
+                    # splitter
+                    proto_str += ", "
+
+            # right parenthesis
+            proto_str += ")"
+
+            self._prototype_arg_item = QGraphicsSimpleTextItem(proto_str, self)
+            self._prototype_arg_item.setFont(self._config.code_font)
+            self._prototype_arg_item.setBrush(self._config.disasm_view_function_color)
+
+        # arguments
+        if self._arg_str_list is not None:
+            s = 'Args: (' + ", ".join(self._arg_str_list) + ")"
+            self._args_str_item = QGraphicsSimpleTextItem(s, self)
+            self._args_str_item.setFont(self._config.code_font)
+            self._args_str_item.setBrush(self._config.disasm_view_function_color)
+
+        self._layout_items_and_update_size()
+
+    def _layout_items_and_update_size(self):
+
+        x, y = 0, 0
+
+        if self._function_name_item is not None:
+            # function anme
+            self._function_name_item.setPos(x, y)
+            x += self._function_name_item.boundingRect().width()
+            height = self._function_name_item.boundingRect().height()
+        elif self._prototype_arg_item is not None:
+            # prototype
+            self._prototype_arg_item.setPos(x, y)
+            x += self._prototype_arg_item.boundingRect().width()
+            height = self._function_name_item.boundingRect().height()
+        else:
+            height = 0
+
+        # new line
+        max_x = x
+        x = 0
+        y += height
+
+        # arguments
+        if self._args_str_item is not None:
+            self._args_str_item.setPos(x, y)
+            x += self._args_str_item.boundingRect().width()
+            y += self._args_str_item.boundingRect().height()
+
+        max_x = max(x, max_x)
+        self._width = max_x
+        self._height = y
 
     def _boundingRect(self):
-        height = self._config.disasm_font_height
-        if self._args_str:
-            height += self._config.disasm_font_height
-
-        width = max(
-            self._prototype_width,
-            self._args_str_width,
-        )
-
-        return QRectF(0, 0, width, height)
+        return QRectF(0, 0, self._width, self._height)

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -33,7 +33,7 @@ class QSaveableGraphicsView(QBaseGraphicsView):
         # on MacOS with Retina displays, it seems that font widths are always in device pixels, not virtual pixels
         if sys.platform != "darwin":
             return 1.0
-        return self.devicePixelRatioF()
+        return super().devicePixelRatioF()
 
     def save_image_to(self, path, top_margin=50, bottom_margin=50, left_margin=50, right_margin=50):
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -26,24 +26,14 @@ class QBaseGraphicsView(QGraphicsView):
             scene.update(self.sceneRect())
 
 
-class QDevicePixelRatioAwareGraphicsView(QBaseGraphicsView):
-
-    def currentDevicePixelRatioF(self) -> float:
-        # getting devicePixelRatio is currently broken in Qt 5.14
-        # see https://bugreports.qt.io/browse/QTBUG-53022
-        # before it is fixed, fall back to manually calculating the ratio using logicalDpiX()
-        if sys.platform == "darwin":
-            return self.logicalDpiX() / 72.0
-        elif sys.platform == "win32":
-            return self.logicalDpiX() / 96.0
-        else:
-            return self.devicePixelRatioF()
-
-
 class QSaveableGraphicsView(QBaseGraphicsView):
 
-    def currentDevicePixelRatioF(self) -> float:
-        return 1.0
+    def devicePixelRatioF(self) -> float:
+        # on Windows and Linux, we depend on Qt's AA_EnableHighDpiScaling
+        # on MacOS with Retina displays, it seems that font widths are always in device pixels, not virtual pixels
+        if sys.platform != "darwin":
+            return 1.0
+        return self.devicePixelRatioF()
 
     def save_image_to(self, path, top_margin=50, bottom_margin=50, left_margin=50, right_margin=50):
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -26,14 +26,17 @@ class QBaseGraphicsView(QGraphicsView):
             scene.update(self.sceneRect())
 
 
-class QSaveableGraphicsView(QBaseGraphicsView):
+class QDevicePixelRatioAwareGraphicsView(QBaseGraphicsView):
 
     def devicePixelRatioF(self) -> float:
         # on Windows and Linux, we depend on Qt's AA_EnableHighDpiScaling
         # on MacOS with Retina displays, it seems that font widths are always in device pixels, not virtual pixels
         if sys.platform != "darwin":
             return 1.0
-        return super().devicePixelRatioF()
+        return 1.33
+
+
+class QSaveableGraphicsView(QDevicePixelRatioAwareGraphicsView):
 
     def save_image_to(self, path, top_margin=50, bottom_margin=50, left_margin=50, right_margin=50):
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 
 from PySide2.QtWidgets import QGraphicsScene, QGraphicsView, QStyleOptionGraphicsItem, QApplication,\
@@ -243,7 +242,7 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
                                  event.buttons(),
                                  event.modifiers())
 
-            press_event = self.dispatchMouseEventToScene(pressy)
+            _ = self.dispatchMouseEventToScene(pressy)
 
             releasy = QMouseEvent(QEvent.MouseButtonRelease,
                                   event.pos(),

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -40,7 +40,10 @@ class QDevicePixelRatioAwareGraphicsView(QBaseGraphicsView):
             return self.devicePixelRatioF()
 
 
-class QSaveableGraphicsView(QDevicePixelRatioAwareGraphicsView):
+class QSaveableGraphicsView(QBaseGraphicsView):
+
+    def currentDevicePixelRatioF(self) -> float:
+        return 1.0
 
     def save_image_to(self, path, top_margin=50, bottom_margin=50, left_margin=50, right_margin=50):
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -26,17 +26,7 @@ class QBaseGraphicsView(QGraphicsView):
             scene.update(self.sceneRect())
 
 
-class QDevicePixelRatioAwareGraphicsView(QBaseGraphicsView):
-
-    def devicePixelRatioF(self) -> float:
-        # on Windows and Linux, we depend on Qt's AA_EnableHighDpiScaling
-        # on MacOS with Retina displays, it seems that font widths are always in device pixels, not virtual pixels
-        if sys.platform != "darwin":
-            return 1.0
-        return 1.33
-
-
-class QSaveableGraphicsView(QDevicePixelRatioAwareGraphicsView):
+class QSaveableGraphicsView(QBaseGraphicsView):
 
     def save_image_to(self, path, top_margin=50, bottom_margin=50, left_margin=50, right_margin=50):
 

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -46,13 +46,23 @@ class QCachedGraphicsItem(QGraphicsItem):
         rect.setHeight(rect.height() * ratio)
         return rect
 
-    def currentDevicePixelRatioF(self):
+    def pixelToPoint(self, pixel):
+        return pixel / self.dpr()
+
+    p2p = pixelToPoint
+
+    def devicePixelRatioF(self):
         if self._cached_device_pixel_ratio is None:
             if self._container is None:
                 self._cached_device_pixel_ratio = 1.0
             else:
-                self._cached_device_pixel_ratio = self._container.currentDevicePixelRatioF()
+                self._cached_device_pixel_ratio = self._container.devicePixelRatioF()
         return self._cached_device_pixel_ratio
+
+    dpr = devicePixelRatioF
+
+    def currentDevicePixelRatioF(self):
+        return 1.0
 
 
 class QGraphObject:

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -5,9 +5,8 @@ from PySide2.QtGui import QPainter
 
 
 class QCachedGraphicsItem(QGraphicsItem):
-    def __init__(self, parent=None, container=None):
+    def __init__(self, parent=None):
         super().__init__(parent=parent)
-        self._container = container
         self._cached_bounding_rect = None
         self._cached_device_pixel_ratio = None
 

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from PySide2.QtWidgets import QGraphicsItem
 from PySide2.QtGui import QPainter
 
@@ -40,16 +42,7 @@ class QCachedGraphicsItem(QGraphicsItem):
 
     def _boundingRectAdjusted(self):
         # adjust according to devicePixelRatioF
-        ratio = self.currentDevicePixelRatioF()
-        rect = self._boundingRect()
-        rect.setWidth(rect.width() * ratio)
-        rect.setHeight(rect.height() * ratio)
-        return rect
-
-    def pixelToPoint(self, pixel):
-        return pixel / self.dpr()
-
-    p2p = pixelToPoint
+        return self._boundingRect()
 
     def devicePixelRatioF(self):
         if self._cached_device_pixel_ratio is None:
@@ -61,8 +54,17 @@ class QCachedGraphicsItem(QGraphicsItem):
 
     dpr = devicePixelRatioF
 
-    def currentDevicePixelRatioF(self):
-        return 1.0
+    def pixelToPoint(self, pixel: Union[int,float]) -> int:
+        """
+        Convert pixels to points. Call this method in places where such conversion is necessary, e.g., for return
+        values of fontMetrics.width().
+
+        :param pixel:   The number of pixels.
+        :return:        The number of points.
+        """
+        return int(pixel // self.dpr())
+
+    p2p = pixelToPoint
 
 
 class QGraphObject:

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -1,7 +1,4 @@
-from typing import Union
-
 from PySide2.QtWidgets import QGraphicsItem
-from PySide2.QtGui import QPainter
 
 
 class QCachedGraphicsItem(QGraphicsItem):
@@ -95,10 +92,10 @@ class QGraphObject:
 
         return self.width, self.height
 
-    def paint(self, painter):
+    def paint(self, painter: 'QPainter'):
         """
 
-        :param QPainter painter: The painter object.
+        :param painter: The painter object.
         :return:                 None
         """
 
@@ -111,7 +108,6 @@ class QGraphObject:
         :param pos:
         :return:
         """
-
         pass
 
     def on_mouse_released(self, button, pos):

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -44,28 +44,6 @@ class QCachedGraphicsItem(QGraphicsItem):
         # adjust according to devicePixelRatioF
         return self._boundingRect()
 
-    def devicePixelRatioF(self):
-        if self._cached_device_pixel_ratio is None:
-            if self._container is None:
-                self._cached_device_pixel_ratio = 1.0
-            else:
-                self._cached_device_pixel_ratio = self._container.devicePixelRatioF()
-        return self._cached_device_pixel_ratio
-
-    dpr = devicePixelRatioF
-
-    def pixelToPoint(self, pixel: Union[int,float]) -> int:
-        """
-        Convert pixels to points. Call this method in places where such conversion is necessary, e.g., for return
-        values of fontMetrics.width().
-
-        :param pixel:   The number of pixels.
-        :return:        The number of points.
-        """
-        return int(pixel // self.dpr())
-
-    p2p = pixelToPoint
-
 
 class QGraphObject:
     def __init__(self):

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -142,7 +142,7 @@ class QInstruction(QCachedGraphicsItem):
         if self.disasm_view.show_address:
             painter.setPen(self._config.disasm_view_node_address_color)
             painter.drawText(x, y, self._addr)
-            x += self._addr_width + self.GRAPH_ADDR_SPACING * self.currentDevicePixelRatioF()
+            x += self._addr_width + self.GRAPH_ADDR_SPACING # * self.currentDevicePixelRatioF()
 
         # mnemonic
         painter.setPen(self._config.disasm_view_node_mnemonic_color)
@@ -213,15 +213,14 @@ class QInstruction(QCachedGraphicsItem):
 
     def _update_size(self):
 
-        self._addr_width = self._config.disasm_font_metrics.width(self._addr) * self.currentDevicePixelRatioF()
-        self._mnemonic_width = self._config.disasm_font_metrics.width(self._mnemonic) * self.currentDevicePixelRatioF()
+        self._addr_width = self.p2p(self._config.disasm_font_metrics.width(self._addr))
+        self._mnemonic_width = self.p2p(self._config.disasm_font_metrics.width(self._mnemonic))
         if self._string is not None:
-            self._string_width = self._config.disasm_font_metrics.width(self._string) * self.currentDevicePixelRatioF()
+            self._string_width = self.p2p(self._config.disasm_font_metrics.width(self._string))
         else:
             self._string_width = 0
         if self._comment is not None:
-            self._comment_width = self._config.disasm_font_metrics.width(self.COMMENT_PREFIX + self._comment) * \
-                                  self.currentDevicePixelRatioF()
+            self._comment_width = self.p2p(self._config.disasm_font_metrics.width(self.COMMENT_PREFIX + self._comment))
         else:
             self._comment_width = 0
 
@@ -231,8 +230,8 @@ class QInstruction(QCachedGraphicsItem):
             x += self._addr_width + self.GRAPH_ADDR_SPACING * self.currentDevicePixelRatioF()
 
         # mnemonic
-        x += self._mnemonic_width + self.GRAPH_MNEMONIC_SPACING * self.currentDevicePixelRatioF()
-        intersperse_width = self._config.disasm_font_metrics.width(self.INTERSPERSE_ARGS) * self.currentDevicePixelRatioF()
+        x += self._mnemonic_width # + self.GRAPH_MNEMONIC_SPACING * self.currentDevicePixelRatioF()
+        intersperse_width = self.p2p(self._config.disasm_font_metrics.width(self.INTERSPERSE_ARGS)) * self.currentDevicePixelRatioF()
 
         # operands
         if self._operands:

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -142,7 +142,7 @@ class QInstruction(QCachedGraphicsItem):
         if self.disasm_view.show_address:
             painter.setPen(self._config.disasm_view_node_address_color)
             painter.drawText(x, y, self._addr)
-            x += self._addr_width + self.GRAPH_ADDR_SPACING # * self.currentDevicePixelRatioF()
+            x += self._addr_width + self.GRAPH_ADDR_SPACING
 
         # mnemonic
         painter.setPen(self._config.disasm_view_node_mnemonic_color)
@@ -161,13 +161,13 @@ class QInstruction(QCachedGraphicsItem):
         # comment or string - comments have precedence
         if self._comment is not None:
             lines = self._comment.split('\n')
-            x += self.GRAPH_COMMENT_STRING_SPACING * self.currentDevicePixelRatioF()
+            x += self.GRAPH_COMMENT_STRING_SPACING
             for line in lines:
                 painter.setPen(Qt.darkGreen)
                 painter.drawText(x, y, self.COMMENT_PREFIX + line)
-                y += self._config.disasm_font_height * self.currentDevicePixelRatioF()
+                y += self._config.disasm_font_height
         elif self._string is not None:
-            x += self.GRAPH_COMMENT_STRING_SPACING * self.currentDevicePixelRatioF()
+            x += self.GRAPH_COMMENT_STRING_SPACING
             painter.setPen(Qt.gray)
             painter.drawText(x, y, self._string)
 
@@ -227,11 +227,11 @@ class QInstruction(QCachedGraphicsItem):
         x = 0
         # address
         if self.disasm_view.show_address:
-            x += self._addr_width + self.GRAPH_ADDR_SPACING * self.currentDevicePixelRatioF()
+            x += self._addr_width + self.GRAPH_ADDR_SPACING
 
         # mnemonic
-        x += self._mnemonic_width # + self.GRAPH_MNEMONIC_SPACING * self.currentDevicePixelRatioF()
-        intersperse_width = self.p2p(self._config.disasm_font_metrics.width(self.INTERSPERSE_ARGS)) * self.currentDevicePixelRatioF()
+        x += self._mnemonic_width # + self.GRAPH_MNEMONIC_SPACING
+        intersperse_width = self.p2p(self._config.disasm_font_metrics.width(self.INTERSPERSE_ARGS))
 
         # operands
         if self._operands:
@@ -245,13 +245,13 @@ class QInstruction(QCachedGraphicsItem):
         # comments/string
         lines = 1
         if self._comment is not None:
-            x += self.GRAPH_COMMENT_STRING_SPACING * self.currentDevicePixelRatioF() + self._comment_width
+            x += self.GRAPH_COMMENT_STRING_SPACING + self._comment_width
             lines = self._comment.count('\n') + 1
         elif self._string is not None:
-            x += self.GRAPH_COMMENT_STRING_SPACING * self.currentDevicePixelRatioF() + self._string_width
+            x += self.GRAPH_COMMENT_STRING_SPACING + self._string_width
 
         self._width = x
-        self._height = self._config.disasm_font_height * self.currentDevicePixelRatioF() * lines
+        self._height = self._config.disasm_font_height * lines
 
     def _boundingRect(self):
         return QRectF(0, 0, self._width, self._height)

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -25,9 +25,8 @@ class QInstruction(QCachedGraphicsItem):
     LINEAR_INSTRUCTION_OFFSET = 120
     COMMENT_PREFIX = "// "
 
-    def __init__(self, workspace, func_addr, disasm_view, disasm, infodock, insn, out_branch, config, parent=None,
-                 container=None):
-        super().__init__(parent=parent, container=container)
+    def __init__(self, workspace, func_addr, disasm_view, disasm, infodock, insn, out_branch, config, parent=None):
+        super().__init__(parent=parent)
 
         # initialization
         self.workspace = workspace
@@ -176,7 +175,7 @@ class QInstruction(QCachedGraphicsItem):
                         branch_targets = (operand.children[0].val,)
             qoperand = QOperand(self.workspace, self.func_addr, self.disasm_view, self.disasm, self.infodock,
                                 self.insn, operand, i, is_branch_target, is_indirect_branch, branch_targets,
-                                self._config, parent=self, container=self._container)
+                                self._config, parent=self)
             self._operands.append(qoperand)
 
         # all commas

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -440,11 +440,11 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
                             ail_obj = n
                     assert(ail_obj is not None)
                     qobject = QLinearBlock(self.workspace, func_addr, self.disasm_view, disasm,
-                                           self.disasm_view.infodock, obj.addr, ail_obj, None, None, container=self._viewer,
+                                           self.disasm_view.infodock, obj.addr, ail_obj, None, None
                                            )
                 else:
                     qobject = QLinearBlock(self.workspace, func_addr, self.disasm_view, disasm,
-                                           self.disasm_view.infodock, obj.addr, [obj], {}, None, container=self._viewer,
+                                           self.disasm_view.infodock, obj.addr, [obj], {}, None
                                            )
             else:
                 # TODO: Get disassembly even if the function does not exist
@@ -452,10 +452,9 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
                            func_addr, obj)
                 qobject = None
         elif isinstance(obj, MemoryData):
-            qobject = QMemoryDataBlock(self.workspace, self.disasm_view.infodock, obj_addr, obj, parent=None,
-                                       container=self._viewer)
+            qobject = QMemoryDataBlock(self.workspace, self.disasm_view.infodock, obj_addr, obj, parent=None)
         elif isinstance(obj, Unknown):
-            qobject = QUnknownBlock(self.workspace, obj_addr, obj.bytes, container=self._viewer)
+            qobject = QUnknownBlock(self.workspace, obj_addr, obj.bytes)
         else:
             qobject = None
         return qobject

--- a/angrmanagement/ui/widgets/qmemory_data_block.py
+++ b/angrmanagement/ui/widgets/qmemory_data_block.py
@@ -66,7 +66,7 @@ class QMemoryDataBlock(QCachedGraphicsItem):
         painter.drawText(x, y + Conf.disasm_font_ascent, self._addr_text)
         x += self._addr_text_width
         # label
-        x += self.ADDRESS_LABEL_OFFSET * self.currentDevicePixelRatioF()
+        x += self.ADDRESS_LABEL_OFFSET
         lbl_text = get_label_text(self.addr, self.workspace.instance.kb)
         if lbl_text:
             painter.setFont(Conf.code_font)
@@ -113,9 +113,9 @@ class QMemoryDataBlock(QCachedGraphicsItem):
 
         painter.setPen(Qt.black)
         painter.drawText(x, y + Conf.disasm_font_ascent, addr_text)
-        x += Conf.disasm_font_metrics.width(addr_text) * self.currentDevicePixelRatioF()
+        x += self.p2p(Conf.disasm_font_metrics.width(addr_text))
 
-        x += self.LINEAR_INSTRUCTION_OFFSET * self.currentDevicePixelRatioF()
+        x += self.LINEAR_INSTRUCTION_OFFSET
 
         # skip byte_offset
         x += byte_offset * (self.byte_width + self.byte_spacing)
@@ -203,15 +203,15 @@ class QMemoryDataBlock(QCachedGraphicsItem):
 
     def _update_sizes(self):
 
-        self.byte_width = Conf.disasm_font_metrics.width("aa") * self.currentDevicePixelRatioF()
-        self.byte_spacing = Conf.disasm_font_metrics.width("-") * self.currentDevicePixelRatioF()
-        self.character_width = Conf.disasm_font_metrics.width("a") * self.currentDevicePixelRatioF()
-        self._addr_text_width = Conf.disasm_font_metrics.width(self._addr_text) * self.currentDevicePixelRatioF()
+        self.byte_width = self.p2p(Conf.disasm_font_metrics.width("aa"))
+        self.byte_spacing = self.p2p(Conf.disasm_font_metrics.width("-"))
+        self.character_width = self.p2p(Conf.disasm_font_metrics.width("a"))
+        self._addr_text_width = self.p2p(Conf.disasm_font_metrics.width(self._addr_text))
 
         self._width = (self._addr_text_width +
-                       self.LINEAR_INSTRUCTION_OFFSET * self.currentDevicePixelRatioF() +
-                       self.bytes_per_line * (self.byte_width + self.byte_width * self.currentDevicePixelRatioF()) +
-                       self.BYTE_AREA_SPACING * self.currentDevicePixelRatioF() +
+                       self.LINEAR_INSTRUCTION_OFFSET +
+                       self.bytes_per_line * (self.byte_width + self.byte_width) +
+                       self.BYTE_AREA_SPACING +
                        self.bytes_per_line * self.character_width
                        )
         lines = 1 + math.ceil(((self.addr + self.memory_data.size) - (self.addr - (self.addr % self.bytes_per_line))) / self.bytes_per_line)

--- a/angrmanagement/ui/widgets/qmemory_data_block.py
+++ b/angrmanagement/ui/widgets/qmemory_data_block.py
@@ -17,8 +17,8 @@ class QMemoryDataBlock(QCachedGraphicsItem):
     LINEAR_INSTRUCTION_OFFSET = 120
     BYTE_AREA_SPACING = 15
 
-    def __init__(self, workspace, infodock, addr, memory_data, bytes_per_line=16, parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+    def __init__(self, workspace, infodock, addr, memory_data, bytes_per_line=16, parent=None):
+        super().__init__(parent=parent)
         self.workspace = workspace
         self.infodock = infodock
         self.addr = addr

--- a/angrmanagement/ui/widgets/qoperand.py
+++ b/angrmanagement/ui/widgets/qoperand.py
@@ -19,8 +19,8 @@ class QOperand(QCachedGraphicsItem):
     VARIABLE_IDENT_SPACING = 5
 
     def __init__(self, workspace, func_addr, disasm_view, disasm, infodock, insn, operand, operand_index,
-                 is_branch_target, is_indirect_branch, branch_targets, config, parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+                 is_branch_target, is_indirect_branch, branch_targets, config, parent=None):
+        super().__init__(parent=parent)
 
         self.workspace = workspace
         self.func_addr = func_addr

--- a/angrmanagement/ui/widgets/qoperand.py
+++ b/angrmanagement/ui/widgets/qoperand.py
@@ -191,7 +191,7 @@ class QOperand(QCachedGraphicsItem):
         # draw variable
         # {s_10}
         if self.disasm_view.show_variable and self._variable_label:
-            x += self.LABEL_VARIABLE_SPACING * self.currentDevicePixelRatioF()
+            x += self.LABEL_VARIABLE_SPACING
             painter.setPen(self._config.disasm_view_variable_label_color)
             painter.drawText(x, y, self._variable_label)
             painter.setPen(self._config.disasm_view_operand_color)
@@ -200,7 +200,7 @@ class QOperand(QCachedGraphicsItem):
         # draw additional branch targets
         if self._branch_targets_text:
             painter.setPen(Qt.darkYellow)
-            x += self.BRANCH_TARGETS_SPACING * self.currentDevicePixelRatioF()
+            x += self.BRANCH_TARGETS_SPACING
             painter.drawText(x, y, self._branch_targets_text)
             x += self._branch_targets_text_width
 
@@ -367,30 +367,30 @@ class QOperand(QCachedGraphicsItem):
     def _update_size(self):
 
         if self._label is not None:
-            self._label_width = self._config.disasm_font_metrics.width(self._label) * self.currentDevicePixelRatioF()
+            self._label_width = self.p2p(self._config.disasm_font_metrics.width(self._label))
         else:
             self._label_width = 0
         if self._branch_targets_text is not None:
-            self._branch_targets_text_width = self._config.disasm_font_metrics.width(self._branch_targets_text) * self.currentDevicePixelRatioF()
+            self._branch_targets_text_width = self.p2p(self._config.disasm_font_metrics.width(self._branch_targets_text))
         else:
             self._branch_targets_text_width = 0
         if self._variable_label is not None:
-            self._variable_label_width = self._config.disasm_font_metrics.width(self._variable_label) * self.currentDevicePixelRatioF()
+            self._variable_label_width = self.p2p(self._config.disasm_font_metrics.width(self._variable_label))
         else:
             self._variable_label_width = 0
         if self.variable is not None:
-            self._variable_ident_width = self._config.disasm_font_metrics.width(self._variable_ident) * self.currentDevicePixelRatioF()
+            self._variable_ident_width = self.p2p(self._config.disasm_font_metrics.width(self._variable_ident))
         else:
             self._variable_ident_width = 0
 
         self._width = self._label_width
         if self.disasm_view.show_variable and self._variable_label:
-            self._width += self.LABEL_VARIABLE_SPACING * self.currentDevicePixelRatioF() + self._variable_label_width
+            self._width += self.LABEL_VARIABLE_SPACING + self._variable_label_width
         if self.disasm_view.show_variable_identifier and self._variable_ident_width:
-            self._width += self.VARIABLE_IDENT_SPACING * self.currentDevicePixelRatioF() + self._variable_ident_width
+            self._width += self.VARIABLE_IDENT_SPACING + self._variable_ident_width
         if self._branch_targets_text_width:
-            self._width += self.BRANCH_TARGETS_SPACING * self.currentDevicePixelRatioF() + self._branch_targets_text_width
-        self._height = self._config.disasm_font_height * self.currentDevicePixelRatioF()
+            self._width += self.BRANCH_TARGETS_SPACING + self._branch_targets_text_width
+        self._height = self._config.disasm_font_height
         self.recalculate_size()
 
     def _boundingRect(self):

--- a/angrmanagement/ui/widgets/qoperand.py
+++ b/angrmanagement/ui/widgets/qoperand.py
@@ -371,6 +371,7 @@ class QOperand(QCachedGraphicsItem):
 
         self._width = x
         self._height = self._label_item.boundingRect().height()
+        self.recalculate_size()
 
     def _boundingRect(self):
         return QRectF(0, 0, self._width, self._height)
@@ -440,7 +441,6 @@ class QOperand(QCachedGraphicsItem):
             l.error('_pick_variable: Unsupported operand type %s.', self.operand.__class__)
 
             return None, None
-
 
     def _variable_has_access(self, variable, ins_addr, access_type):
 

--- a/angrmanagement/ui/widgets/qphivariable.py
+++ b/angrmanagement/ui/widgets/qphivariable.py
@@ -11,7 +11,7 @@ class QPhiVariable(QCachedGraphicsItem):
 
     IDENT_LEFT_PADDING = 5
 
-    def __init__(self, workspace, disasm_view, phi_variable, config, parent=None, container=None):
+    def __init__(self, workspace, disasm_view, phi_variable, config, parent=None):
         """
 
         :param workspace:
@@ -20,7 +20,7 @@ class QPhiVariable(QCachedGraphicsItem):
         :param config:
         """
 
-        super().__init__(parent=parent, container=container)
+        super().__init__(parent=parent)
 
         # initialization
         self.workspace = workspace

--- a/angrmanagement/ui/widgets/qproximitygraph_block.py
+++ b/angrmanagement/ui/widgets/qproximitygraph_block.py
@@ -180,15 +180,13 @@ class QProximityGraphFunctionBlock(QProximityGraphBlock):
 
     def _update_size(self):
         fm = self._config.symexec_font_metrics
-        dpr = self.currentDevicePixelRatioF()
 
         width_candidates = [
-            (self.HORIZONTAL_PADDING * 2 + self._config.symexec_font_metrics.width(self._text)) * dpr,
+            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(self._text)),
         ]
 
         self._width = max(width_candidates)
         self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
-        self._height *= dpr
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)
@@ -244,10 +242,10 @@ class QProximityGraphCallBlock(QProximityGraphBlock):
         painter.setPen(pen_color)
         # func name
         painter.drawText(x, y + self._config.symexec_font_ascent, self._func_name)
-        x += self._config.symexec_font_metrics.width(self._func_name)
+        x += self.p2p(self._config.symexec_font_metrics.width(self._func_name))
         # left parenthesis
         painter.drawText(x, y + self._config.symexec_font_ascent, "(")
-        x += self._config.symexec_font_metrics.width("(")
+        x += self.p2p(self._config.symexec_font_metrics.width("("))
 
         # arguments
         for i, (type_, arg) in enumerate(self._args):
@@ -257,32 +255,30 @@ class QProximityGraphCallBlock(QProximityGraphBlock):
                 painter.setPen(self.INTEGER_NODE_TEXT_COLOR)
             else:
                 painter.setPen(self.CALL_NODE_TEXT_COLOR)
-            width = self._config.symexec_font_metrics.width(arg)
+            width = self.p2p(self._config.symexec_font_metrics.width(arg))
             painter.drawText(x, y + self._config.symexec_font_ascent, arg)
             x += width
             if i != len(self._args) - 1:
                 painter.setPen(pen_color)
                 painter.drawText(x, y + self._config.symexec_font_ascent, ", ")
-                x += self._config.symexec_font_metrics.width(", ")
+                x += self.p2p(self._config.symexec_font_metrics.width(", "))
 
         # right parenthesis
         painter.setPen(pen_color)
         painter.drawText(x, y + self._config.symexec_font_ascent, ")")
-        x += self._config.symexec_font_metrics.width(")")
+        x += self.p2p(self._config.symexec_font_metrics.width(")"))
 
     def _update_size(self):
         fm = self._config.symexec_font_metrics
-        dpr = self.currentDevicePixelRatioF()
 
         text = self._func_name + "(" + ", ".join(arg for _, arg in self._args) + ")"
 
         width_candidates = [
-            (self.HORIZONTAL_PADDING * 2 + self._config.symexec_font_metrics.width(text)) * dpr,
+            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(text))
         ]
 
         self._width = max(width_candidates)
         self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
-        self._height *= dpr
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)
@@ -309,15 +305,13 @@ class QProximityGraphStringBlock(QProximityGraphBlock):
 
     def _update_size(self):
         fm = self._config.symexec_font_metrics
-        dpr = self.currentDevicePixelRatioF()
 
         width_candidates = [
-            (self.HORIZONTAL_PADDING * 2 + self._config.symexec_font_metrics.width(self._text)) * dpr,
+            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(self._text)),
         ]
 
         self._width = max(width_candidates)
         self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
-        self._height *= dpr
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)

--- a/angrmanagement/ui/widgets/qproximitygraph_block.py
+++ b/angrmanagement/ui/widgets/qproximitygraph_block.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, List, Tuple, Type, Optional
+from typing import TYPE_CHECKING, List, Tuple, Type
 import logging
 
 import PySide2.QtWidgets
-from PySide2.QtGui import QColor, QPen
+from PySide2.QtGui import QColor, QPen, QPainter
 from PySide2.QtCore import Qt, QRectF
 
 from angr.analyses.proximity_graph import BaseProxiNode, FunctionProxiNode, CallProxiNode, StringProxiNode, \
@@ -135,16 +135,17 @@ class QProximityGraphBlock(QCachedGraphicsItem):
     #
 
     def _update_size(self):
-        fm = self._config.symexec_font_metrics
-        dpr = self.currentDevicePixelRatioF()
+
+        painter = QPainter(self)
+        painter.setFont(self._config.symexec_font)
+        fm = painter.fontMetrics()
 
         width_candidates = [
-            self.HORIZONTAL_PADDING * 2 * dpr,
+            self.HORIZONTAL_PADDING * 2,
         ]
 
         self._width = max(width_candidates)
-        self._height = self.VERTICAL_PADDING * 2 + (self.LINE_MARGIN + self._config.symexec_font_height) * 2
-        self._height *= dpr
+        self._height = self.VERTICAL_PADDING * 2 + (self.LINE_MARGIN + fm.height()) * 2
 
         self._width = max(100, self._width)
         self._height = max(50, self._height)

--- a/angrmanagement/ui/widgets/qproximitygraph_block.py
+++ b/angrmanagement/ui/widgets/qproximitygraph_block.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING, List, Tuple, Type
 import logging
 
 import PySide2.QtWidgets
-from PySide2.QtGui import QColor, QPen, QPainter
+from PySide2.QtWidgets import QGraphicsSimpleTextItem
+from PySide2.QtGui import QColor, QPen
 from PySide2.QtCore import Qt, QRectF
 
 from angr.analyses.proximity_graph import BaseProxiNode, FunctionProxiNode, CallProxiNode, StringProxiNode, \
@@ -118,14 +119,10 @@ class QProximityGraphBlock(QCachedGraphicsItem):
         x += self.HORIZONTAL_PADDING
         y += self.VERTICAL_PADDING
 
-        # The text
+        # text
         text_label_x = x
         painter.setPen(Qt.gray)
         painter.drawText(text_label_x, y + self._config.symexec_font_ascent, "Unknown block")
-
-        painter.setPen(Qt.black)
-        y += self._config.symexec_font_height + self.LINE_MARGIN
-        x = 0
 
     def _boundingRect(self):
         return QRectF(0, 0, self._width, self._height)
@@ -135,21 +132,8 @@ class QProximityGraphBlock(QCachedGraphicsItem):
     #
 
     def _update_size(self):
-
-        painter = QPainter(self)
-        painter.setFont(self._config.symexec_font)
-        fm = painter.fontMetrics()
-
-        width_candidates = [
-            self.HORIZONTAL_PADDING * 2,
-        ]
-
-        self._width = max(width_candidates)
-        self._height = self.VERTICAL_PADDING * 2 + (self.LINE_MARGIN + fm.height()) * 2
-
-        self._width = max(100, self._width)
-        self._height = max(50, self._height)
-
+        self._width = 100
+        self._height = 50
         self.recalculate_size()
 
 
@@ -157,10 +141,15 @@ class QProximityGraphFunctionBlock(QProximityGraphBlock):
 
     def __init__(self, is_selected, proximity_view: 'ProximityView', node: FunctionProxiNode):
         self._text = None
+        self._text_item: QGraphicsSimpleTextItem = None
         super().__init__(is_selected, proximity_view, node)
 
     def _init_widgets(self):
         self._text = "Function %s" % self._node.func.name
+        self._text_item = QGraphicsSimpleTextItem(self._text, self)
+        self._text_item.setFont(Conf.symexec_font)
+        self._text_item.setBrush(self.FUNCTION_NODE_TEXT_COLOR)
+        self._text_item.setPos(self.HORIZONTAL_PADDING, self.VERTICAL_PADDING)
 
     def mouseDoubleClickEvent(self, event):
         if event.button() == Qt.LeftButton and (event.modifiers() & Qt.ControlModifier) == Qt.ControlModifier:
@@ -174,24 +163,16 @@ class QProximityGraphFunctionBlock(QProximityGraphBlock):
     def paint(self, painter, option, widget):
         self._paint_boundary(painter)
 
-        x = self.HORIZONTAL_PADDING
-        y = self.VERTICAL_PADDING
-        painter.setPen(self.FUNCTION_NODE_TEXT_COLOR)
-        painter.drawText(x, y + self._config.symexec_font_ascent, self._text)
-
     def _update_size(self):
-        fm = self._config.symexec_font_metrics
-
         width_candidates = [
-            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(self._text)),
+            self.HORIZONTAL_PADDING * 2 + self._text_item.boundingRect().width(),
         ]
 
         self._width = max(width_candidates)
-        self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
+        self._height = self.VERTICAL_PADDING * 2 + self._text_item.boundingRect().height()
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)
-
         self.recalculate_size()
 
 
@@ -200,6 +181,12 @@ class QProximityGraphCallBlock(QProximityGraphBlock):
     def __init__(self, is_selected, proximity_view: 'ProximityView', node: CallProxiNode):
         self._func_name: str = None
         self._args: List[Tuple[Type,str]] = None
+
+        self._func_name_item: QGraphicsSimpleTextItem = None
+        self._left_parenthesis_item: QGraphicsSimpleTextItem = None
+        self._args_list: List[QGraphicsSimpleTextItem] = None
+        self._right_parenthesis_item: QGraphicsSimpleTextItem = None
+
         super().__init__(is_selected, proximity_view, node)
 
     def _init_widgets(self):
@@ -209,6 +196,59 @@ class QProximityGraphCallBlock(QProximityGraphBlock):
             self._args = [ self._argument_text(arg) for arg in self._node.args ]
         else:
             self._args = [ ]
+
+        # func name
+        self._func_name_item = QGraphicsSimpleTextItem(self._func_name, self)
+        if self._node.callee.is_simprocedure:
+            pen_color = self.CALL_NODE_TEXT_COLOR_SIMPROC
+        elif self._node.callee.is_plt:
+            pen_color = self.CALL_NODE_TEXT_COLOR_SIMPROC
+        else:
+            pen_color = self.CALL_NODE_TEXT_COLOR
+        self._func_name_item.setBrush(pen_color)
+        self._func_name_item.setFont(Conf.symexec_font)
+        self._func_name_item.setPos(self.HORIZONTAL_PADDING, self.VERTICAL_PADDING)
+
+        x = self.HORIZONTAL_PADDING + self._func_name_item.boundingRect().width()
+        y = self.VERTICAL_PADDING
+        # left parenthesis
+        self._left_parenthesis_item = QGraphicsSimpleTextItem("(", self)
+        self._left_parenthesis_item.setBrush(pen_color)
+        self._left_parenthesis_item.setFont(Conf.symexec_font)
+        self._left_parenthesis_item.setPos(x, y)
+
+        x += self._left_parenthesis_item.boundingRect().width()
+
+        # arguments
+        self._args_list = [ ]
+        for i, (type_, arg) in enumerate(self._args):
+            if type_ is str:
+                color = self.STRING_NODE_TEXT_COLOR
+            elif type_ is int:
+                color = self.INTEGER_NODE_TEXT_COLOR
+            else:
+                color = self.CALL_NODE_TEXT_COLOR
+            o = QGraphicsSimpleTextItem(arg, self)
+            o.setBrush(color)
+            o.setFont(Conf.symexec_font)
+            o.setPos(x, y)
+            self._args_list.append(o)
+            x += o.boundingRect().width()
+
+            # comma
+            if i != len(self._args) - 1:
+                comma = QGraphicsSimpleTextItem(", ", self)
+                comma.setBrush(pen_color)
+                comma.setFont(Conf.symexec_font)
+                comma.setPos(x, y)
+                self._args_list.append(comma)
+                x += comma.boundingRect().width()
+
+        # right parenthesis
+        self._right_parenthesis_item = QGraphicsSimpleTextItem(")", self)
+        self._right_parenthesis_item.setBrush(pen_color)
+        self._right_parenthesis_item.setFont(Conf.symexec_font)
+        self._right_parenthesis_item.setPos(x, y)
 
     def _argument_text(self, arg) -> Tuple[Type,str]:
         if isinstance(arg, StringProxiNode):
@@ -231,59 +271,20 @@ class QProximityGraphCallBlock(QProximityGraphBlock):
     def paint(self, painter, option, widget):
         self._paint_boundary(painter)
 
-        x = self.HORIZONTAL_PADDING
-        y = self.VERTICAL_PADDING
-        if self._node.callee.is_simprocedure:
-            pen_color = self.CALL_NODE_TEXT_COLOR_SIMPROC
-        elif self._node.callee.is_plt:
-            pen_color = self.CALL_NODE_TEXT_COLOR_SIMPROC
-        else:
-            pen_color = self.CALL_NODE_TEXT_COLOR
-
-        painter.setPen(pen_color)
-        # func name
-        painter.drawText(x, y + self._config.symexec_font_ascent, self._func_name)
-        x += self.p2p(self._config.symexec_font_metrics.width(self._func_name))
-        # left parenthesis
-        painter.drawText(x, y + self._config.symexec_font_ascent, "(")
-        x += self.p2p(self._config.symexec_font_metrics.width("("))
-
-        # arguments
-        for i, (type_, arg) in enumerate(self._args):
-            if type_ is str:
-                painter.setPen(self.STRING_NODE_TEXT_COLOR)
-            elif type_ is int:
-                painter.setPen(self.INTEGER_NODE_TEXT_COLOR)
-            else:
-                painter.setPen(self.CALL_NODE_TEXT_COLOR)
-            width = self.p2p(self._config.symexec_font_metrics.width(arg))
-            painter.drawText(x, y + self._config.symexec_font_ascent, arg)
-            x += width
-            if i != len(self._args) - 1:
-                painter.setPen(pen_color)
-                painter.drawText(x, y + self._config.symexec_font_ascent, ", ")
-                x += self.p2p(self._config.symexec_font_metrics.width(", "))
-
-        # right parenthesis
-        painter.setPen(pen_color)
-        painter.drawText(x, y + self._config.symexec_font_ascent, ")")
-        x += self.p2p(self._config.symexec_font_metrics.width(")"))
-
     def _update_size(self):
-        fm = self._config.symexec_font_metrics
-
-        text = self._func_name + "(" + ", ".join(arg for _, arg in self._args) + ")"
-
         width_candidates = [
-            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(text))
+            self.HORIZONTAL_PADDING * 2 +
+            self._func_name_item.boundingRect().width() +
+            self._left_parenthesis_item.boundingRect().width() +
+            sum(map(lambda x: x.boundingRect().width(), self._args_list)) +
+            self._right_parenthesis_item.boundingRect().width()
         ]
 
         self._width = max(width_candidates)
-        self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
+        self._height = self.VERTICAL_PADDING * 2 + self._func_name_item.boundingRect().height()
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)
-
         self.recalculate_size()
 
 
@@ -291,30 +292,28 @@ class QProximityGraphStringBlock(QProximityGraphBlock):
 
     def __init__(self, is_selected, proximity_view: 'ProximityView', node: StringProxiNode):
         self._text = None
+        self._text_item: QGraphicsSimpleTextItem = None
         super().__init__(is_selected, proximity_view, node)
 
     def _init_widgets(self):
         self._text = '"' + self._node.content.decode("utf-8") + '"'
 
+        self._text_item = QGraphicsSimpleTextItem(self._text, self)
+        self._text_item.setBrush(self.STRING_NODE_TEXT_COLOR)
+        self._text_item.setFont(Conf.symexec_font)
+        self._text_item.setPos(self.HORIZONTAL_PADDING, self.VERTICAL_PADDING)
+
     def paint(self, painter, option, widget):
         self._paint_boundary(painter)
 
-        x = self.HORIZONTAL_PADDING
-        y = self.VERTICAL_PADDING
-        painter.setPen(self.STRING_NODE_TEXT_COLOR)
-        painter.drawText(x, y + self._config.symexec_font_ascent, self._text)
-
     def _update_size(self):
-        fm = self._config.symexec_font_metrics
-
         width_candidates = [
-            self.HORIZONTAL_PADDING * 2 + self.p2p(self._config.symexec_font_metrics.width(self._text)),
+            self.HORIZONTAL_PADDING * 2 + self._text_item.boundingRect().width(),
         ]
 
         self._width = max(width_candidates)
-        self._height = self.VERTICAL_PADDING * 2 + self._config.symexec_font_height
+        self._height = self.VERTICAL_PADDING * 2 + self._text_item.boundingRect().height()
 
         self._width = max(30, self._width)
         self._height = max(10, self._height)
-
         self.recalculate_size()

--- a/angrmanagement/ui/widgets/qunknown_block.py
+++ b/angrmanagement/ui/widgets/qunknown_block.py
@@ -12,8 +12,8 @@ class QUnknownBlock(QCachedGraphicsItem):
     LINEAR_INSTRUCTION_OFFSET = 120
     DEFAULT_TEXT = 'Unknown'
 
-    def __init__(self, workspace, addr, bytes_, parent=None, container=None):
-        super().__init__(parent=parent, container=container)
+    def __init__(self, workspace, addr, bytes_, parent=None):
+        super().__init__(parent=parent)
 
         self.workspace = workspace
         self.addr = addr

--- a/angrmanagement/ui/widgets/qunknown_block.py
+++ b/angrmanagement/ui/widgets/qunknown_block.py
@@ -1,11 +1,10 @@
+from typing import List
 
-from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QGraphicsSimpleTextItem
+from PySide2.QtCore import Qt, QRectF
 
 from ...config import Conf
 from .qgraph_object import QCachedGraphicsItem
-from PySide2.QtWidgets import QGraphicsItem
-from PySide2.QtCore import QRectF
-from PySide2.QtGui import QPainter
 
 
 class QUnknownBlock(QCachedGraphicsItem):
@@ -20,11 +19,12 @@ class QUnknownBlock(QCachedGraphicsItem):
         self.addr = addr
         self.bytes = bytes_
 
-        self._bytes_text = None
+        self._width = 0
+        self._height = 0
+
         self._addr_text = None
-        self._addr_width = None
-        self._bytes_width = None
-        self._bytes_height = None
+        self._addr_item: QGraphicsSimpleTextItem = None
+        self._byte_lines: List[QGraphicsSimpleTextItem] = None
 
         self._config = Conf
 
@@ -34,53 +34,15 @@ class QUnknownBlock(QCachedGraphicsItem):
     # Public methods
     #
 
-    @property
-    def width(self):
-        return self.boundingRect().width()
-
-    @property
-    def height(self):
-        return self.boundingRect().height()
-
     def paint(self, painter, option, widget): #pylint: disable=unused-argument
 
-        painter.setRenderHints(
-                QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.HighQualityAntialiasing)
-        painter.setFont(self._config.disasm_font)
-
-        x, y = 0, 0
-
-        # Address
-        painter.setPen(Qt.black)
-        painter.drawText(x, y+Conf.disasm_font_ascent, self._addr_text)
-        x += self._addr_width
-
-        x += self.LINEAR_INSTRUCTION_OFFSET
-
-        # Content
-        if self._bytes_text:
-            for line in self._bytes_text:
-                painter.drawText(x, y+Conf.disasm_font_ascent, line)
-                y += Conf.disasm_font_height
-        else:
-            painter.drawText(x, y+Conf.disasm_font_ascent, QUnknownBlock.DEFAULT_TEXT)
+        # painter.setRenderHints(
+        #         QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.HighQualityAntialiasing)
+        # painter.setFont(self._config.disasm_font)
+        pass
 
     def _boundingRect(self):
-        height, width = 0, 0
-
-        width += self._addr_width
-        width += self.LINEAR_INSTRUCTION_OFFSET
-
-        if self._bytes_text:
-            height += Conf.disasm_font_height * len(self._bytes_text)
-        else:
-            height += Conf.disasm_font_height
-
-        if self._bytes_text:
-            width += max(len(line) for line in self._bytes_text) * Conf.disasm_font_width
-        else:
-            width += Conf.disasm_font_metrics.width(QUnknownBlock.DEFAULT_TEXT)
-        return QRectF(0, 0, width, height)
+        return QRectF(0, 0, self._width, self._height)
 
     #
     # Private methods
@@ -89,11 +51,13 @@ class QUnknownBlock(QCachedGraphicsItem):
     def _init_widgets(self):
         # Address
         self._addr_text = "%08x" % self.addr
-        self._addr_width = Conf.disasm_font_width * len(self._addr_text)
+        self._addr_item = QGraphicsSimpleTextItem(self._addr_text, self)
+        self._addr_item.setBrush(Qt.black)
+        self._addr_item.setFont(Conf.disasm_font)
 
         # Bytes
+        self._byte_lines = [ ]
         if self.bytes:
-            self._bytes_text = [ ]
             line = ""
             for i, b in enumerate(self.bytes):
                 line += "%02x " % b
@@ -102,9 +66,37 @@ class QUnknownBlock(QCachedGraphicsItem):
                     line = ""
 
             if line:
-                self._bytes_text.append(line)
-
-            self._bytes_height = Conf.disasm_font_height * len(self._bytes_text)
+                o = QGraphicsSimpleTextItem(line, self)
+                o.setFont(Conf.disasm_font)
+                o.setBrush(Qt.black)
+                self._byte_lines.append(o)
 
         else:
-            self._bytes_height = Conf.disasm_font_height
+            o = QGraphicsSimpleTextItem(QUnknownBlock.DEFAULT_TEXT, self)
+            o.setBrush(Qt.black)
+            o.setFont(Conf.disasm_font)
+            self._byte_lines.append(o)
+
+        self._layout_items_and_update_size()
+
+    def _layout_items_and_update_size(self):
+
+        x, y = 0, 0
+
+        # address
+        self._addr_item.setPos(x, y)
+
+        x += self._addr_item.boundingRect().width()
+        x += self.LINEAR_INSTRUCTION_OFFSET
+
+        # lines
+        max_x = x
+        for line in self._byte_lines:
+            line.setPos(x, y)
+            y += line.boundingRect().height()
+            max_x = max(max_x, line.boundingRect().width())
+
+        self._width = max_x
+        self._height = y
+
+        self.recalculate_size()

--- a/angrmanagement/ui/widgets/qunknown_block.py
+++ b/angrmanagement/ui/widgets/qunknown_block.py
@@ -55,13 +55,13 @@ class QUnknownBlock(QCachedGraphicsItem):
         painter.drawText(x, y+Conf.disasm_font_ascent, self._addr_text)
         x += self._addr_width
 
-        x += self.LINEAR_INSTRUCTION_OFFSET * self.currentDevicePixelRatioF()
+        x += self.LINEAR_INSTRUCTION_OFFSET
 
         # Content
         if self._bytes_text:
             for line in self._bytes_text:
                 painter.drawText(x, y+Conf.disasm_font_ascent, line)
-                y += Conf.disasm_font_height * self.currentDevicePixelRatioF()
+                y += Conf.disasm_font_height
         else:
             painter.drawText(x, y+Conf.disasm_font_ascent, QUnknownBlock.DEFAULT_TEXT)
 
@@ -72,14 +72,14 @@ class QUnknownBlock(QCachedGraphicsItem):
         width += self.LINEAR_INSTRUCTION_OFFSET
 
         if self._bytes_text:
-            height += Conf.disasm_font_height * len(self._bytes_text) * self.currentDevicePixelRatioF()
+            height += Conf.disasm_font_height * len(self._bytes_text)
         else:
-            height += Conf.disasm_font_height * self.currentDevicePixelRatioF()
+            height += Conf.disasm_font_height
 
         if self._bytes_text:
-            width += max(len(line) for line in self._bytes_text) * Conf.disasm_font_width * self.currentDevicePixelRatioF()
+            width += max(len(line) for line in self._bytes_text) * Conf.disasm_font_width
         else:
-            width += Conf.disasm_font_metrics.width(QUnknownBlock.DEFAULT_TEXT) * self.currentDevicePixelRatioF()
+            width += Conf.disasm_font_metrics.width(QUnknownBlock.DEFAULT_TEXT)
         return QRectF(0, 0, width, height)
 
     #
@@ -89,7 +89,7 @@ class QUnknownBlock(QCachedGraphicsItem):
     def _init_widgets(self):
         # Address
         self._addr_text = "%08x" % self.addr
-        self._addr_width = Conf.disasm_font_width * len(self._addr_text) * self.currentDevicePixelRatioF()
+        self._addr_width = Conf.disasm_font_width * len(self._addr_text)
 
         # Bytes
         if self.bytes:
@@ -104,7 +104,7 @@ class QUnknownBlock(QCachedGraphicsItem):
             if line:
                 self._bytes_text.append(line)
 
-            self._bytes_height = Conf.disasm_font_height * len(self._bytes_text) * self.currentDevicePixelRatioF()
+            self._bytes_height = Conf.disasm_font_height * len(self._bytes_text)
 
         else:
-            self._bytes_height = Conf.disasm_font_height * self.currentDevicePixelRatioF()
+            self._bytes_height = Conf.disasm_font_height

--- a/angrmanagement/ui/widgets/qvariable.py
+++ b/angrmanagement/ui/widgets/qvariable.py
@@ -77,16 +77,16 @@ class QVariable(QCachedGraphicsItem):
 
     def _update_size(self):
 
-        self._variable_name_width = len(self._variable_name) * self._config.disasm_font_width * self.currentDevicePixelRatioF()
-        self._variable_ident_width = len(self._variable_ident) * self._config.disasm_font_width * self.currentDevicePixelRatioF()
-        self._variable_offset_width = len(self._variable_offset) * self._config.disasm_font_width * self.currentDevicePixelRatioF()
+        self._variable_name_width = len(self._variable_name) * self._config.disasm_font_width
+        self._variable_ident_width = len(self._variable_ident) * self._config.disasm_font_width
+        self._variable_offset_width = len(self._variable_offset) * self._config.disasm_font_width
 
         self._width = self._variable_name_width + \
-                      self.OFFSET_LEFT_PADDING * self.currentDevicePixelRatioF() + self._variable_offset_width
+                      self.OFFSET_LEFT_PADDING + self._variable_offset_width
         if self.disasm_view.show_variable_identifier:
-            self._width += self.IDENT_LEFT_PADDING * self.currentDevicePixelRatioF() + self._variable_ident_width
+            self._width += self.IDENT_LEFT_PADDING + self._variable_ident_width
 
-        self._height = self._config.disasm_font_height * self.currentDevicePixelRatioF()
+        self._height = self._config.disasm_font_height
 
         self.recalculate_size()
 

--- a/angrmanagement/ui/widgets/qvariable.py
+++ b/angrmanagement/ui/widgets/qvariable.py
@@ -9,8 +9,8 @@ class QVariable(QCachedGraphicsItem):
     IDENT_LEFT_PADDING = 5
     OFFSET_LEFT_PADDING = 12
 
-    def __init__(self, workspace, disasm_view, variable, config, parent=None, container=None):
-        super(QVariable, self).__init__(parent=parent, container=container)
+    def __init__(self, workspace, disasm_view, variable, config, parent=None):
+        super(QVariable, self).__init__(parent=parent)
 
         # initialization
         self.workspace = workspace

--- a/angrmanagement/ui/widgets/qvariable.py
+++ b/angrmanagement/ui/widgets/qvariable.py
@@ -1,4 +1,4 @@
-
+from PySide2.QtWidgets import QGraphicsSimpleTextItem
 from PySide2.QtCore import Qt, QRectF
 
 from .qgraph_object import QCachedGraphicsItem
@@ -19,11 +19,11 @@ class QVariable(QCachedGraphicsItem):
         self._config = config
 
         self._variable_name = None
-        self._variable_name_width = None
+        self._variable_name_item: QGraphicsSimpleTextItem = None
         self._variable_ident = None
-        self._variable_ident_width = None
+        self._variable_ident_item: QGraphicsSimpleTextItem = None
         self._variable_offset = None
-        self._variable_offset_width = None
+        self._variable_offset_item: QGraphicsSimpleTextItem = None
 
         self._init_widgets()
 
@@ -32,33 +32,15 @@ class QVariable(QCachedGraphicsItem):
     #
 
     def paint(self, painter, option, widget):  # pylint: disable=unused-argument
-
-        x = 0
-
-        painter.setFont(self._config.disasm_font)
-
-        # variable name
-        painter.setPen(Qt.darkGreen)
-        painter.drawText(x, self._config.disasm_font_ascent, self._variable_name)
-        x += self._variable_name_width
-        x += self.IDENT_LEFT_PADDING
-
-
-        # variable ident
-        if self.disasm_view.show_variable_identifier:
-            painter.setPen(Qt.blue)
-            painter.drawText(x, self._config.disasm_font_ascent, self._variable_ident)
-            x += self._variable_ident_width
-            x += self.OFFSET_LEFT_PADDING
-
-        # variable offset
-        painter.setPen(Qt.darkYellow)
-        painter.drawText(x, self._config.disasm_font_ascent, self._variable_offset)
-        x += self._variable_offset_width
+        pass
 
     def refresh(self):
         super(QVariable, self).refresh()
-        self._update_size()
+
+        if self._variable_ident_item is not None:
+            self._variable_ident_item.setVisible(self.disasm_view.show_variable_identifier)
+
+        self._layout_items_and_update_size()
 
     #
     # Private methods
@@ -68,26 +50,46 @@ class QVariable(QCachedGraphicsItem):
 
         # variable name
         self._variable_name = "" if not self.variable.name else self.variable.name
+        self._variable_name_item = QGraphicsSimpleTextItem(self._variable_name, self)
+        self._variable_name_item.setFont(self._config.disasm_font)
+        self._variable_name_item.setBrush(Qt.darkGreen)  # TODO: Expose it as a configuration entry in Config
+
         # variable ident
         self._variable_ident = "<%s>" % ("" if not self.variable.ident else self.variable.ident)
+        self._variable_ident_item = QGraphicsSimpleTextItem(self._variable_ident, self)
+        self._variable_ident_item.setFont(self._config.disasm_font)
+        self._variable_ident_item.setBrush(Qt.blue)  # TODO: Expose it as a configuration entry in Config
+        self._variable_ident_item.setVisible(self.disasm_view.show_variable_identifier)
+
         # variable offset
         self._variable_offset = "%#x" % self.variable.offset
+        self._variable_offset_item = QGraphicsSimpleTextItem(self._variable_offset, self)
+        self._variable_offset_item.setFont(self._config.disasm_font)
+        self._variable_offset_item.setBrush(Qt.darkYellow)  # TODO: Expose it as a configuration entry in Config
 
-        self._update_size()
+        self._layout_items_and_update_size()
 
-    def _update_size(self):
+    def _layout_items_and_update_size(self):
 
-        self._variable_name_width = len(self._variable_name) * self._config.disasm_font_width
-        self._variable_ident_width = len(self._variable_ident) * self._config.disasm_font_width
-        self._variable_offset_width = len(self._variable_offset) * self._config.disasm_font_width
+        x, y = 0, 0
 
-        self._width = self._variable_name_width + \
-                      self.OFFSET_LEFT_PADDING + self._variable_offset_width
+        # variable name
+        self._variable_name_item.setPos(x, y)
+        x += self._variable_name_item.boundingRect().width() + self.IDENT_LEFT_PADDING
+
         if self.disasm_view.show_variable_identifier:
-            self._width += self.IDENT_LEFT_PADDING + self._variable_ident_width
+            # identifier
+            x += self.IDENT_LEFT_PADDING
+            self._variable_ident_item.setPos(x, y)
+            x += self._variable_ident_item.boundingRect().width()
 
-        self._height = self._config.disasm_font_height
+        # variable offset
+        x += self.OFFSET_LEFT_PADDING
+        self._variable_offset_item.setPos(x, y)
+        x += self._variable_offset_item.boundingRect().width()
 
+        self._width = x
+        self._height = self._variable_name_item.boundingRect().height()
         self.recalculate_size()
 
     def _boundingRect(self):


### PR DESCRIPTION
We should never draw text manually using `painter.drawText()` since it's impossible to calculate the bounding rect of the text before possessing a painter instance. Use `QGraphicsSimpleText` instead. This is the root cause for the ugly disassembly graph on MacBooks (since the text lengths that we calculate in `Conf` are different from the actual text lengths in the `painter` when painting the graph).

Reference: https://stackoverflow.com/questions/34828777/why-does-qpainter-seem-to-scale-fonts-unpredictably-when-using-drawtext-on-a-qim

TODO:

- [x] Migrate `QUnknownBlock`.
- [x] Migrate `QDepGraphBlock`.
- [x] Migrate `QProximityGraphBlock`.
- [x] Drop `devicePixelRatioF` and `QCachedGraphicsItem._cached_device_pixel_ratio`. Maybe also `QCachedGraphicsItem._container`.
- [x] Drop `QCachedGraphicsItem.pixelToPoint`.