### PR TITLE
Add keybindings to zoom the pseudocode with Ctrl-minus and equals.

### DIFF
--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from PySide2.QtCore import Qt, QEvent
 from PySide2.QtGui import QTextCharFormat
-from PySide2.QtWidgets import QMenu, QAction, QInputDialog, QLineEdit
+from PySide2.QtWidgets import QMenu, QAction, QInputDialog, QLineEdit, QApplication
 
 from pyqodeng.core import api
 from pyqodeng.core import modes
@@ -181,6 +181,10 @@ class QCCodeEdit(api.CodeEdit):
         if key in (Qt.Key_Slash, Qt.Key_Question):
             self.comment(expr=event.modifiers() & Qt.ShiftModifier == Qt.ShiftModifier)
             return True
+        if key == Qt.Key_Minus and QApplication.keyboardModifiers() & Qt.CTRL != 0:
+            self.zoom_out()
+        if key == Qt.Key_Equal and QApplication.keyboardModifiers() & Qt.CTRL != 0:
+            self.zoom_in()
 
         if self._code_view.keyPressEvent(event):
             return True


### PR DESCRIPTION
Zooming was already possible with Ctrl-Scroll, but this additional behavior matches the disassembly view.