### PR TITLE
Partial fix for #339: preserve zoom when jumping in disas view.

### DIFF
--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -655,6 +655,9 @@ class DisassemblyView(BaseView):
             if instr_addr is None:
                 instr_addr = addr
             self.infodock.select_instruction(instr_addr, unique=True, use_animation=use_animation)
+
+            # reset the zoom
+            self._flow_graph.zoom(restore=True)
             return True
 
         # it does not belong to any function - we need to switch to linear view mode

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -73,6 +73,9 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
+        # the zoom factor, for preserving the zoom
+        self.zoom_factor = None
+
         #self.setRenderHints(
                 #QPainter.Antialiasing | QPainter.SmoothPixmapTransform | QPainter.HighQualityAntialiasing)
 
@@ -93,7 +96,7 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
     def sizeHint(self):  # pylint:disable=no-self-use
         return QSize(300, 300)
 
-    def zoom(self, out=False, at=None, reset=False):
+    def zoom(self, out=False, at=None, reset=False, restore=False):
         if at is None:
             at = self.scene().sceneRect().center().toPoint()
         lod = QStyleOptionGraphicsItem.levelOfDetailFromTransform(self.transform())
@@ -102,6 +105,8 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
 
         if reset:
             zoomFactor = 1 / lod
+        elif restore:
+            zoomFactor = self.zoom_factor
         elif not out:
             zoomFactor = zoomInFactor
         else:
@@ -115,6 +120,7 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
 
         # Zoom
         self.scale(zoomFactor, zoomFactor)
+        self.zoom_factor = QStyleOptionGraphicsItem.levelOfDetailFromTransform(self.transform())
 
         # Get the new position
         newPos = self.mapToScene(at)


### PR DESCRIPTION
Unfortunately, the screen is positioned without taking the zoom into account...