### PR TITLE
remove SrcAddrAnnotation

### DIFF
--- a/angrmanagement/ui/widgets/qconstraint_viewer.py
+++ b/angrmanagement/ui/widgets/qconstraint_viewer.py
@@ -1,40 +1,11 @@
-import angr
-import claripy
-
 from PySide2.QtWidgets import QFrame, QHeaderView, QSizePolicy, QVBoxLayout,QTableWidget, QTableWidgetItem
 
-
-class SrcAddrAnnotation(claripy.Annotation):
-    """
-    Src Address Annotation for a constraint
-    """
-    def __init__(self, addr):
-        self.addr = addr
-
-    @property
-    def eliminatable(self):
-        return False
-
-    @property
-    def relocatable(self):
-        return True
-
-    def relocate(self, src, dst):
-        return self
-
-
-def attach_addr_annotation(state):
-    for i in range(len(state.solver.constraints)):
-        if SrcAddrAnnotation not in [type(a) for a in state.solver.constraints[i].annotations]:
-            state.solver.constraints[i] = \
-                    state.solver.constraints[i].annotate(SrcAddrAnnotation(state.addr))
-    return state
 
 class QConstraintViewer(QFrame):
     """
     `QConstraintViewer` in `StateInspector`
     """
-    COLUMNS = [ "Constraint", "Src Addr", "Cardinality", "Depth", "# Variables" ]
+    COLUMNS = [ "Constraint", "Cardinality", "Depth", "# Variables" ]
 
     def __init__(self, state, parent, workspace):
         super().__init__(parent)
@@ -45,7 +16,6 @@ class QConstraintViewer(QFrame):
         self.table = None
 
         self._state.am_subscribe(self._watch_state)
-        self.workspace.instance.states.am_subscribe(self._insert_inspect_hook)
 
     #
     # Public methods
@@ -57,13 +27,9 @@ class QConstraintViewer(QFrame):
             count = self.table.rowCount()
             self.table.insertRow(count)
             self.table.setItem(count, 0, QTableWidgetItem(constraint.shallow_repr()))
-
-            src_addr = next(a for a in constraint.annotations if isinstance(a, SrcAddrAnnotation)).addr
-
-            self.table.setItem(count, 1, QTableWidgetItem(hex(src_addr)))
-            self.table.setItem(count, 2, QTableWidgetItem(str(constraint.cardinality)))
-            self.table.setItem(count, 3, QTableWidgetItem(str(constraint.depth)))
-            self.table.setItem(count, 4, QTableWidgetItem(str(len(list(constraint.recursive_leaf_asts)))))
+            self.table.setItem(count, 1, QTableWidgetItem(str(constraint.cardinality)))
+            self.table.setItem(count, 2, QTableWidgetItem(str(constraint.depth)))
+            self.table.setItem(count, 3, QTableWidgetItem(str(len(list(constraint.recursive_leaf_asts)))))
 
     #
     # Private methods
@@ -92,9 +58,3 @@ class QConstraintViewer(QFrame):
         if self.table is None:
             self._init_widgets()
         self.reload()
-
-    @staticmethod
-    def _insert_inspect_hook(**kwargs):
-        if kwargs.get("src","")  == "new":
-            state = kwargs.get("state")
-            state.inspect.b(event_type='constraints', when=angr.BP_AFTER, action=attach_addr_annotation)


### PR DESCRIPTION
I remove the second column of QConstraintViewer which show the SrcAddr of a constrain.
It caused crash when users hit explorer button double times.

This function should be added in angr, not there.
