### PR TITLE
Closes 357: restore the zoom level on DisassemblyLevel change

### DIFF
--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -85,6 +85,7 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
     def _reset_view(self):
         self.resetMatrix()
         self.centerOn(self._initial_position())
+        self.zoom(restore=True)
 
     def _reset_scene(self):
         if self.scene() is None:


### PR DESCRIPTION
We should probably make a better way to save and load both zoom and scroll state (for example, for navigation history).