### PR TITLE
Add `**kwargs` to `QTraceViewer._on_select_ins()`

### DIFF
--- a/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
+++ b/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
@@ -281,7 +281,7 @@ class QTraceViewer(QWidget):
             multiTrace.is_active_tab = False
             self._show_trace_ids()
 
-    def _on_select_ins(self):
+    def _on_select_ins(self, **kwargs): # pylint: disable=unused-argument
         if self.trace is None:
             return
 
@@ -341,7 +341,7 @@ class QTraceViewer(QWidget):
             func = self.trace.get_func_from_position(self.curr_position)
             self._jump_bbl(func, bbl_addr)
 
-    def eventFilter(self, object, event): #specifically to catch arrow keys
+    def eventFilter(self, obj, event): #specifically to catch arrow keys #pylint: disable=unused-argument
         # more elegant solution to link w/ self.view's scroll bar keypressevent?
         if event.type() == QEvent.Type.KeyPress:
             if not (event.modifiers() & Qt.ShiftModifier): #shift + arrowkeys


### PR DESCRIPTION
Fix follow crush:

```
Traceback (most recent call last):
  File "/home/yzm/angr-management/angrmanagement/ui/widgets/qdisasm_graph.py", line 186, in mousePressEvent
    self.disasm_view.jump_back()
  File "/home/yzm/angr-management/angrmanagement/ui/views/disassembly_view.py", line 529, in jump_back
    self._jump_to(addr, use_animation=False)
  File "/home/yzm/angr-management/angrmanagement/ui/views/disassembly_view.py", line 687, in _jump_to
    self.infodock.select_instruction(instr_addr, unique=True, use_animation=use_animation)
  File "/home/yzm/angr-management/angrmanagement/logic/disassembly/info_dock.py", line 119, in select_instruction
    self.selected_insns.am_event(insn_addr=insn_addr)
  File "/home/yzm/angr-management/angrmanagement/data/object_container.py", line 25, in am_event
    listener(**kwargs)
TypeError: _on_select_ins() got an unexpected keyword argument 'insn_addr'
```

and fix lint