### PR TITLE
Show variables for AIL Register/Load

### DIFF
--- a/angrmanagement/ui/dialogs/rename.py
+++ b/angrmanagement/ui/dialogs/rename.py
@@ -1,0 +1,118 @@
+from typing import Optional, TYPE_CHECKING
+
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
+
+if TYPE_CHECKING:
+    from angrmanagement.ui.views.code_view import CodeView
+
+
+class NameLineEdit(QLineEdit):
+    """
+    Simple line edit with simple identifier validation.
+    """
+
+    def __init__(self, textchanged_callback, parent=None):
+        super().__init__(parent)
+
+        self.textChanged.connect(textchanged_callback)
+
+    @property
+    def name(self):
+        text = self.text()
+        if self._is_valid_node_name(text):
+            return text.strip()
+        return None
+
+    @staticmethod
+    def _is_valid_node_name(name):
+        return name and not ' ' in name.strip()
+
+
+class RenameDialog(QDialog):
+    """
+    A generic dialog box for renaming something.
+
+    If the user enters a valid name and clicks 'OK', the `result` property will
+    contain the resulting string. If a user clicks 'Cancel', the `result`
+    property will remain `None`.
+    """
+
+    def __init__(self, window_title:str = 'Rename', initial_text:str = '', parent=None):
+        super().__init__(parent)
+        self._initial_text: str = initial_text
+        self._name_box: NameLineEdit = None
+        self._status_label: QLabel = None
+        self._ok_button: QPushButton = None
+        self.main_layout: QVBoxLayout = QVBoxLayout()
+        self.result: Optional[str] = None
+        self._init_widgets()
+        self.setLayout(self.main_layout)
+        self.setWindowTitle(window_title)
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        name_label = QLabel(self)
+        name_label.setText('New name')
+        name_box = NameLineEdit(self._on_name_changed, self)
+        name_box.setText(self._initial_text)
+        name_box.selectAll()
+        self._name_box = name_box
+
+        label_layout = QHBoxLayout()
+        label_layout.addWidget(name_label)
+        label_layout.addWidget(name_box)
+        self.main_layout.addLayout(label_layout)
+
+        status_label = QLabel(self)
+        self.main_layout.addWidget(status_label)
+        self._status_label = status_label
+
+        ok_button = QPushButton(self)
+        ok_button.setText('OK')
+        ok_button.setEnabled(False)
+        ok_button.clicked.connect(self._on_ok_clicked)
+        self._ok_button = ok_button
+
+        cancel_button = QPushButton(self)
+        cancel_button.setText('Cancel')
+        cancel_button.clicked.connect(self._on_cancel_clicked)
+
+        buttons_layout = QHBoxLayout()
+        buttons_layout.addWidget(ok_button)
+        buttons_layout.addWidget(cancel_button)
+
+        self.main_layout.addLayout(buttons_layout)
+
+    #
+    # Event handlers
+    #
+
+    def _on_name_changed(self, new_text):  # pylint:disable=unused-argument
+        if self._name_box is None:
+            # initialization is not done yet
+            return
+
+        if self._name_box.name is None:
+            # the variable name is invalid
+            self._status_label.setText('Invalid')
+            self._status_label.setProperty('class', 'status_invalid')
+            self._ok_button.setEnabled(False)
+        else:
+            self._status_label.setText('Valid')
+            self._status_label.setProperty('class', 'status_valid')
+            self._ok_button.setEnabled(True)
+
+        self._status_label.style().unpolish(self._status_label)
+        self._status_label.style().polish(self._status_label)
+
+    def _on_ok_clicked(self):
+        node_name = self._name_box.name
+        if node_name is not None:
+            self.result = node_name
+            self.close()
+
+    def _on_cancel_clicked(self):
+        self.close()

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -57,6 +57,9 @@ class QBlock(QCachedGraphicsItem):
         self.addr_to_labels = { }
         self.qblock_annotations = { }
 
+        self._block_code_options: QBlockCodeOptions = QBlockCodeOptions()
+        self._update_block_code_options()
+
         self._init_widgets()
 
         self._objects_are_hidden = False
@@ -90,7 +93,13 @@ class QBlock(QCachedGraphicsItem):
         for obj in self.objects:
             obj.clear_cache()
 
+    def _update_block_code_options(self):
+        self._block_code_options.show_conditional_jump_targets = self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS
+        self._block_code_options.show_variables = self.disasm_view.show_variable
+        self._block_code_options.show_variable_identifiers = self.disasm_view.show_variable_identifier
+
     def refresh(self):
+        self._update_block_code_options()
         for obj in self.objects:
             obj.refresh()
         self.layout_widgets()
@@ -140,9 +149,7 @@ class QBlock(QCachedGraphicsItem):
             self.objects.append(label)
             self.addr_to_labels[bn.addr] = label
         for stmt in bn.statements:
-            options = QBlockCodeOptions()
-            options.show_conditional_jump_targets = self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS
-            code_obj = QAilObj(stmt, self.infodock, parent=None, options=options)
+            code_obj = QAilObj(stmt, self.infodock, parent=None, options=self._block_code_options)
             obj = QBlockCode(stmt.ins_addr, code_obj, self._config, self.disasm_view,
                              self.workspace, self.infodock, parent=self)
             code_obj.parent = obj # Reparent

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -13,7 +13,7 @@ from ...config import Conf
 from .qinstruction import QInstruction
 from .qfunction_header import QFunctionHeader
 from .qblock_label import QBlockLabel
-from .qblock_code import QBlockCode, QAilObj, QIROpObj
+from .qblock_code import QBlockCode, QBlockCodeOptions, QAilObj, QIROpObj
 from .qphivariable import QPhiVariable
 from .qvariable import QVariable
 from .qgraph_object import QCachedGraphicsItem
@@ -140,8 +140,9 @@ class QBlock(QCachedGraphicsItem):
             self.objects.append(label)
             self.addr_to_labels[bn.addr] = label
         for stmt in bn.statements:
-            code_obj = QAilObj(stmt, self.infodock, parent=None,
-                               options={'show_conditional_jump_targets': self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS})
+            options = QBlockCodeOptions()
+            options.show_conditional_jump_targets = self.AIL_SHOW_CONDITIONAL_JUMP_TARGETS
+            code_obj = QAilObj(stmt, self.infodock, parent=None, options=options)
             obj = QBlockCode(stmt.ins_addr, code_obj, self._config, self.disasm_view,
                              self.workspace, self.infodock, parent=self)
             code_obj.parent = obj # Reparent

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -786,6 +786,7 @@ class QBlockCode(QCachedGraphicsItem):
     #
 
     def _layout_items_and_update_size(self):
+        self.update_document()
 
         x, y = 0, 0
         if self._disasm_view.show_address:

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -382,8 +382,9 @@ class QAilRegisterObj(QAilTextObj):
             self.add_text(s)
 
     def should_highlight(self) -> bool:
-        return (isinstance(self.infodock.selected_qblock_code_obj, QAilRegisterObj) and
-                self.infodock.selected_qblock_code_obj.obj.reg_name == self.obj.reg_name)
+        sel = self.infodock.selected_qblock_code_obj
+        return (isinstance(sel, QAilRegisterObj)
+                and sel.obj == self.obj)
 
 
 class QAilUnaryOpObj(QAilTextObj):

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -303,8 +303,17 @@ class QAilCallObj(QAilTextObj):
     """
 
     def create_subobjs(self, obj:ailment.statement.Call):
-        self.add_text('call ')
+        if obj.ret_expr is not None and self.stmt is self.obj:
+            self.add_ailobj(obj.ret_expr)
+            self.add_text(' = ')
         self.add_ailobj(obj.target)
+        self.add_text('(')
+        if obj.args:
+            for i, arg in enumerate(obj.args):
+                if i > 0:
+                    self.add_text(', ')
+                self.add_ailobj(arg)
+        self.add_text(')')
 
 
 class QAilConstObj(QAilTextObj):

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -731,7 +731,7 @@ class QBlockCode(QCachedGraphicsItem):
         self.update_document()
         self.setToolTip("Address: " + self._addr_str)
 
-        self._layout_items_and_update_size()
+        self.refresh()
 
     def refresh(self):
         self._addr_item.setVisible(self._disasm_view.show_address)

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -343,13 +343,14 @@ class QAilRegisterObj(QAilTextObj):
         return fmt
 
     def create_subobjs(self, obj: ailment.expression.Register):
-        if hasattr(obj, 'reg_name'):
-            s = "%s" % (obj.reg_name,)
-        elif obj.variable is None:
-            s = "reg_%d<%d>" % (obj.reg_offset, obj.bits // 8)
+        if obj.variable is not None:
+            self.add_variable(obj.variable)
         else:
-            s = "%s" % str(obj.variable.name)
-        self.add_text(s)
+            if hasattr(obj, 'reg_name'):
+                s = "%s" % (obj.reg_name,)
+            else:
+                s = "reg_%d<%d>" % (obj.reg_offset, obj.bits // 8)
+            self.add_text(s)
 
     def should_highlight(self) -> bool:
         return (isinstance(self.infodock.selected_qblock_code_obj, QAilRegisterObj) and
@@ -398,9 +399,12 @@ class QAilLoadObj(QAilTextObj):
     """
 
     def create_subobjs(self, obj:ailment.expression.Load):
-        self.add_text('*(')
-        self.add_ailobj(obj.addr)
-        self.add_text(')')
+        if obj.variable is not None:
+            self.add_variable(obj.variable)
+        else:
+            self.add_text('*(')
+            self.add_ailobj(obj.addr)
+            self.add_text(')')
 
 
 class QIROpObj(QBlockCodeObj):

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Sequence, Optional, Tuple
+from typing import Any, Sequence, Optional, Tuple
 
 from PySide2.QtGui import QPainter, QTextDocument, QTextCursor, QTextCharFormat, QFont, QMouseEvent
 from PySide2.QtCore import Qt, QPointF, QRectF, QObject
@@ -13,6 +13,13 @@ from ...logic.disassembly.info_dock import InfoDock
 from .qgraph_object import QCachedGraphicsItem
 
 
+class QBlockCodeOptions:
+    """
+    Various options to control display of QBlockCodeObj's
+    """
+    show_conditional_jump_targets: bool = True
+
+
 class QBlockCodeObj(QObject):
     """
     Renders a generic "code" object and handles display related events.
@@ -25,17 +32,17 @@ class QBlockCodeObj(QObject):
     obj: Any
     infodock: InfoDock
     parent: Any
-    options: Mapping[str, Any]
+    options: QBlockCodeOptions
     span: Optional[Tuple[int,int]]
     subobjs: Sequence['QBlockCodeObj']
     _fmt_current: QTextCharFormat
 
-    def __init__(self, obj:Any, infodock:InfoDock, parent:Any, options:Mapping[str, Any]=None):
+    def __init__(self, obj:Any, infodock:InfoDock, parent:Any, options:QBlockCodeOptions=None):
         super().__init__()
         self.obj = obj
         self.infodock = infodock
         self.parent = parent
-        self.options = options or {}
+        self.options = options or QBlockCodeOptions()
         self.span = None
         self.subobjs = []
         self._fmt_current = None
@@ -259,7 +266,7 @@ class QAilConditionalJumpObj(QAilTextObj):
         self.add_text('if ')
         self.add_ailobj(obj.condition)
 
-        if self.options.get('show_conditional_jump_targets', True):
+        if self.options.show_conditional_jump_targets:
             self.add_text(' goto ')
             self.add_ailobj(obj.true_target)
             self.add_text(' else goto ')

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -77,7 +77,6 @@ class QBlockCodeObj(QObject):
         """
         Initialize any display subobjects for this object
         """
-        raise NotImplementedError()
 
     def update(self):
         """
@@ -135,6 +134,8 @@ class QBlockCodeObj(QObject):
 
     def mousePressEvent(self, event:QMouseEvent): # pylint: disable=unused-argument
         self.infodock.select_qblock_code_obj(self)
+        if event.button() == Qt.RightButton:
+            self.infodock.disasm_view.show_context_menu_for_selected_object()
 
     def mouseDoubleClickEvent(self, event:QMouseEvent):
         pass

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -78,6 +78,10 @@ class QBlockCodeObj(QObject):
         Initialize any display subobjects for this object
         """
 
+    def recreate_subobjs(self):
+        self.subobjs.clear()
+        self.create_subobjs(self.obj)
+
     def update(self):
         """
         Update self and parent objects
@@ -157,6 +161,10 @@ class QVariableObj(QBlockCodeObj):
         fmt = QTextCharFormat()
         fmt.setForeground(Conf.disasm_view_variable_label_color)
         return fmt
+
+    def render_to_doc(self, cursor):
+        self.recreate_subobjs()
+        super().render_to_doc(cursor)
 
     def create_subobjs(self, obj):
         self.add_text(obj.name)


### PR DESCRIPTION
This patch:
* Fixes display of variables in AIL view, controllable by disassembly view options
* Adds very basic renaming support for variables, with scaffolding to support interactivity on other items
* Show AIL call return expression and arguments

![image](https://user-images.githubusercontent.com/8210/125137637-f0e85500-e0c1-11eb-818e-93f8f5d1fd7c.png)


