### PR TITLE
Removed Redundant Function (dock_to_view)

### DIFF
--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -161,20 +161,6 @@ class ViewManager:
             return view
         return None
 
-    def dock_to_view(self, dock):
-        """
-        Return the view associated with provided
-        dock.
-
-        :param dock:    The dock to match a view with.
-        :return:        The view.
-        """
-
-        for view, value in self.view_to_dock.items():
-            if value == dock:
-                return view
-        return None
-
     def tabify_center_views(self):
         """
         Tabify all right-side dockable views.


### PR DESCRIPTION
I didn't notice the dock_to_view dictionary before - this makes the dock_to_view function unnecessary. 

I see @mborgerson already fixed the one instance `view = self.dock_to_view(current)` -> `view = self.dock_to_view[current]`. 