### PR TITLE
Remove view split feature, enable nested docking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ angr-management can then be run with `angr-management` or `python start.py`.
 
 - Next Tab: ```Ctrl+Tab```
 - Previous Tab: ```Ctrl+Shift+Tab```
-- Split / Unsplit View: ```Ctrl+D```
 
 ## Plugins
 

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -6,7 +6,7 @@ import time
 from typing import Optional, TYPE_CHECKING
 
 from PySide2.QtWidgets import QMainWindow, QTabWidget, QFileDialog, QProgressBar
-from PySide2.QtWidgets import QMessageBox, QSplitter, QShortcut, QTabBar
+from PySide2.QtWidgets import QMessageBox, QShortcut, QTabBar
 from PySide2.QtGui import QResizeEvent, QIcon, QDesktopServices, QKeySequence
 from PySide2.QtCore import Qt, QSize, QEvent, QTimer, QUrl
 
@@ -73,8 +73,7 @@ class MainWindow(QMainWindow):
 
         self.app: Optional['QApplication'] = app
         self.workspace: Workspace = None
-        self.central_widget = None
-        self.central_widget2 = None
+        self.central_widget: QMainWindow = None
 
         self._file_toolbar = None  # type: FileToolbar
         self._states_toolbar = None  # type: StatesToolbar
@@ -253,18 +252,13 @@ class MainWindow(QMainWindow):
 
         :return:    None
         """
-
-        self.central_widget_main = QSplitter(Qt.Horizontal)
-        self.setCentralWidget(self.central_widget_main)
         self.central_widget = QMainWindow()
-        self.central_widget2 = QMainWindow()
-        self.central_widget_main.addWidget(self.central_widget)
-        self.central_widget_main.addWidget(self.central_widget2)
+        self.setCentralWidget(self.central_widget)
         wk = Workspace(self, Instance())
         self.workspace = wk
         self.workspace.view_manager.tabify_center_views()
         self.central_widget.setTabPosition(Qt.RightDockWidgetArea, QTabWidget.North)
-        self.central_widget2.setTabPosition(Qt.LeftDockWidgetArea, QTabWidget.North)
+        self.central_widget.setDockNestingEnabled(True)
 
         def set_caption(**kwargs):  # pylint: disable=unused-argument
             if self.workspace.instance.project.am_none:

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -13,7 +13,6 @@ class ViewMenu(Menu):
             MenuEntry('Previous Tab', main_window.workspace.view_manager.previous_tab, shortcut=QKeySequence("Ctrl+Shift+Tab")),
             MenuSeparator(),
             MenuEntry('New Disassembly View', main_window.workspace.new_disassembly_view, shortcut=QKeySequence("Ctrl+N")),
-            MenuEntry('Split / Unsplit View', main_window.workspace.toggle_split, shortcut=QKeySequence("Ctrl+D")),
             MenuSeparator(),
             MenuEntry('Linear Disassembly', main_window.workspace.show_linear_disassembly_view),
             MenuEntry('Graph Disassembly', main_window.workspace.show_graph_disassembly_view),


### PR DESCRIPTION
- Removes the existing view splitting feature, which is problematic.
- Enables nested docking, providing support for more complex view arrangements. Users can just drag the view title bar to move the view wherever they please.

Example:
![image](https://user-images.githubusercontent.com/8210/130334556-de5bce8c-4df1-498b-b38c-ed831253815d.png)

Closes #359 
Closes #435
Closes #436
Closes #438
Closes #439

Note: Currently retains the concept of 'center' docked views (the main ones that are tabified) and non-center views (the console and function table view). This is kind of annoying because a user may want to stuff the functions into a tabbed window with strings, etc; and having them parented to a different window vs the 'window' in the center prevents this. This could actually be changed in the future but I've left it as-is for now.
