### PR TITLE
Support synchronization of Hex and Disassembly views

### DIFF
--- a/angrmanagement/logic/disassembly/info_dock.py
+++ b/angrmanagement/logic/disassembly/info_dock.py
@@ -107,6 +107,8 @@ class InfoDock(QObject):
             self.selected_blocks.am_event()
 
     def select_instruction(self, insn_addr, unique=True, insn_pos=None, use_animation=True):
+        self.disasm_view.set_synchronized_cursor_address(insn_addr)
+
         self.unselect_all_labels()
         if insn_addr not in self.selected_insns:
             if unique:
@@ -158,6 +160,8 @@ class InfoDock(QObject):
             self.selected_operands.am_event()
 
     def select_label(self, label_addr):
+        self.disasm_view.set_synchronized_cursor_address(label_addr)
+
         # only one label can be selected at a time
         # also, clear selection of instructions and operands
         self.unselect_all_instructions()

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -53,11 +53,11 @@ class Menu:
                     self.entries if isinstance(ent, MenuEntry))
         return self._keyed_entries.get(key, None)
 
-    def qmenu(self, extra_entries=None):
+    def qmenu(self, extra_entries=None, cached=True):
         if extra_entries is None:
             extra_entries = []
 
-        if not extra_entries and self._qmenu is not None:
+        if cached and not extra_entries and self._qmenu is not None:
             # in order to use the cached result, must not have extra entries
             return self._qmenu
 

--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 import logging
 import functools
 
@@ -80,7 +80,7 @@ class ViewManager:
         if retab:
             self.tabify_center_views()
 
-    def remove_view(self, view):
+    def remove_view(self, view: BaseView):
         """
         Remove a view from this workspace
 
@@ -116,7 +116,7 @@ class ViewManager:
         if retab:
             self.tabify_center_views()
 
-    def raise_view(self, view):
+    def raise_view(self, view: BaseView):
         """
         Find the dock widget of a view, and then bring that dock widget to front.
 
@@ -133,7 +133,7 @@ class ViewManager:
         dock.raise_()
         view.focusWidget()
 
-    def get_center_views(self):
+    def get_center_views(self) -> Sequence[QSmartDockWidget]:
         """
         Get the right dockable views
 
@@ -147,7 +147,7 @@ class ViewManager:
                     docks.append(dock)
         return docks
 
-    def first_view_in_category(self, category) -> Optional['BaseView']:
+    def first_view_in_category(self, category: str) -> Optional['BaseView']:
         """
         Return the first view in a specific category.
 
@@ -159,7 +159,7 @@ class ViewManager:
             return self.views_by_category[category][0]
         return None
 
-    def current_view_in_category(self, category) -> Optional['BaseView']:
+    def current_view_in_category(self, category: str) -> Optional['BaseView']:
         """
         Return the current in a specific category.
 
@@ -181,12 +181,11 @@ class ViewManager:
 
         :return:    None
         """
-
         center_dockable_views = self.get_center_views()
         for d0, d1 in zip(center_dockable_views, center_dockable_views[1:]):
             self.workspace._main_window.central_widget.tabifyDockWidget(d0, d1)
 
-    def get_current_tab_id(self):
+    def get_current_tab_id(self) -> int:
         """
         Get Current Tab ID
 
@@ -225,13 +224,13 @@ class ViewManager:
         center_dockable_views[self.get_current_tab_id()-1].raise_()
 
     @property
-    def current_tab(self):
+    def current_tab(self) -> BaseView:
         return self.get_center_views()[self.get_current_tab_id()].widget()
 
-    def _handle_raise_view(self, view):
+    def _handle_raise_view(self, view: BaseView):
         self.workspace.plugins.handle_raise_view(view)
 
-    def handle_center_tab_click(self, index):
+    def handle_center_tab_click(self, index: int):
         center_docks = self.get_center_views()
         dock = center_docks[index]
         view = self.dock_to_view[dock]

--- a/angrmanagement/ui/views/view.py
+++ b/angrmanagement/ui/views/view.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import PySide2.QtGui
-from PySide2.QtWidgets import QFrame
+from PySide2.QtWidgets import QFrame, QMenu, QAction
 from PySide2.QtCore import QSize
 
 if TYPE_CHECKING:
@@ -9,9 +9,12 @@ if TYPE_CHECKING:
 
 
 class BaseView(QFrame):
-    def __init__(self, category: str, workspace, default_docking_position, *args, **kwargs):
+    """
+    Base class for all main views.
+    """
 
-        super(BaseView, self).__init__(*args, **kwargs)
+    def __init__(self, category: str, workspace, default_docking_position, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.workspace: 'Workspace' = workspace
         self.category = category
@@ -41,7 +44,7 @@ class BaseView(QFrame):
     def is_shown(self):
         return self.visibleRegion().isEmpty() is False
 
-    def closeEvent(self, event:PySide2.QtGui.QCloseEvent):
+    def closeEvent(self, event: PySide2.QtGui.QCloseEvent):
         self.workspace.view_manager.remove_view(self)
         event.accept()
 
@@ -55,3 +58,117 @@ class BaseView(QFrame):
         if self.index > 1:
             s += f'-{self.index}'
         return s
+
+
+class SynchronizedViewState:
+    """
+    Simple state tracking for synchronized views.
+    """
+
+    def __init__(self):
+        self.views = set()
+        self.cursor_address: Optional[int] = None
+
+    def register_view(self, view: 'SynchronizedView'):
+        """
+        Register a synchronized view.
+        """
+        self.views.add(view)
+        for v in self.views:
+            v.on_synchronized_view_group_changed()
+
+    def unregister_view(self, view: 'SynchronizedView'):
+        """
+        Unregister a synchronized view.
+        """
+        self.views.remove(view)
+        for v in self.views:
+            v.on_synchronized_view_group_changed()
+
+
+class SynchronizedView(BaseView):
+    """
+    Base class for views which can be synchronized.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._processing_synchronized_cursor_update: bool = False
+        self.sync_state: SynchronizedViewState = SynchronizedViewState()
+        self.sync_state.register_view(self)
+
+    def desync(self):
+        """
+        Stop synchronization with any previously synchronized views.
+        """
+        self.sync_with_state_object()
+
+    def sync_with_state_object(self, state: Optional[SynchronizedViewState] = None):
+        """
+        Synchronize with another view state.
+        """
+        self.sync_state.unregister_view(self)
+        self.sync_state = state or SynchronizedViewState()
+        self.sync_state.register_view(self)
+        self.sync_from_state()
+
+    def sync_with_view(self, view: 'SynchronizedView'):
+        """
+        Synchronize with another view.
+        """
+        self.sync_with_state_object(view.sync_state)
+
+    def sync_from_state(self):
+        """
+        Update this view to reflect the synchronized view state.
+        """
+        assert not self._processing_synchronized_cursor_update
+        self._processing_synchronized_cursor_update = True
+        try:
+            if self.sync_state.cursor_address is not None:
+                self.jump_to(self.sync_state.cursor_address)
+        finally:
+            self._processing_synchronized_cursor_update = False
+
+    def set_synchronized_cursor_address(self, address: Optional[int]):
+        """
+        Set synchronized cursor address.
+        """
+        if not self._processing_synchronized_cursor_update:
+            self.sync_state.cursor_address = address
+            for view in self.sync_state.views:
+                if view is not self:
+                    view.on_synchronized_cursor_address_changed()
+
+    def on_synchronized_cursor_address_changed(self):
+        """
+        Handle synchronized cursor address change event.
+        """
+        self.sync_from_state()
+
+    def on_synchronized_view_group_changed(self):
+        """
+        Handle view being added to or removed from the view synchronization group.
+        """
+
+    def closeEvent(self, event: PySide2.QtGui.QCloseEvent):
+        """
+        View close event handler.
+        """
+        self.desync()
+        super().closeEvent(event)
+
+    def get_synchronize_with_submenu(self) -> QMenu:
+        """
+        Get submenu for 'Synchronize with' context menu.
+        """
+        mnu = QMenu("&Synchronize with", self)
+        groups = {v.sync_state for v in self.workspace.view_manager.views
+                  if (v is not self) and isinstance(v, SynchronizedView)}
+        for group in groups:
+            act = QAction(', '.join([v.caption for v in group.views if v is not self]), self)
+            act.setCheckable(True)
+            act.setChecked(group is self.sync_state)
+            act.toggled.connect(lambda checked, s=group: self.sync_with_state_object(s if checked else None))
+            mnu.addAction(act)
+        return mnu

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 import logging
 
+import PySide2
 from PySide2.QtGui import QPainter, QCursor, QBrush
 from PySide2.QtCore import Qt, QRectF
 from PySide2.QtWidgets import QApplication, QGraphicsSceneMouseEvent, QGraphicsSimpleTextItem
@@ -55,6 +56,9 @@ class QInstruction(QCachedGraphicsItem):
         self._height = 0
 
         self._init_widgets()
+
+    def contextMenuEvent(self, event:PySide2.QtWidgets.QGraphicsSceneContextMenuEvent) -> None:
+        pass
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):
         if self.workspace.plugins.handle_click_insn(self, event):


### PR DESCRIPTION
Similar to Ida, adds a context menu item to Disassembly View and Hex View that allows the user to select one or more views to "synchronize" with such that moving about in one view also moves around in all views that are synchronized with it. Multiple instances of disassembly and hex views can be synchronized, and there can be separate synchronization groups.

Synchronization with other views (e.g. pseudocode) is left for future PRs.

Closes #241 
Closes #431 
Closes #446 

https://user-images.githubusercontent.com/8210/131608744-23fae7d7-f658-44b6-b7c0-0250b11bceac.mp4

