### PR TITLE
Add edit feature to Hex view

### DIFF
--- a/angrmanagement/ui/dialogs/input_prompt.py
+++ b/angrmanagement/ui/dialogs/input_prompt.py
@@ -1,0 +1,54 @@
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QDialogButtonBox
+
+
+class InputPromptDialog(QDialog):
+    """
+    A generic dialog to prompt for text input.
+    """
+
+    def __init__(self, window_title: str, prompt_text: str, initial_input_text: str = '', parent=None):
+        super().__init__(parent)
+        self.prompt_text: str = prompt_text
+        self.initial_input_text: str = initial_input_text
+        self.input_edt: QLineEdit = None
+        self.result = None
+
+        self.setWindowTitle(window_title)
+        self.main_layout = QVBoxLayout()
+        self._init_widgets()
+        self.setLayout(self.main_layout)
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        prompt_lbl = QLabel(self)
+        prompt_lbl.setText(self.prompt_text)
+
+        input_edt = QLineEdit(parent=self)
+        input_edt.setText(self.initial_input_text)
+        input_edt.selectAll()
+        self.input_edt = input_edt
+
+        prompt_input_lyt = QHBoxLayout()
+        prompt_input_lyt.addWidget(prompt_lbl)
+        prompt_input_lyt.addWidget(input_edt)
+        self.main_layout.addLayout(prompt_input_lyt)
+
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel
+                                   | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        buttons_lyt = QHBoxLayout()
+        buttons_lyt.addWidget(buttons)
+        self.main_layout.addLayout(buttons_lyt)
+
+    #
+    # Event handlers
+    #
+
+    def _on_ok_clicked(self):
+        self.result = self.input_edt.text()
+        self.close()

--- a/angrmanagement/ui/widgets/qpatch_table.py
+++ b/angrmanagement/ui/widgets/qpatch_table.py
@@ -6,6 +6,10 @@ from PySide2.QtCore import Qt
 
 
 class QPatchTableItem:
+    """
+    Item in the patch table describing a patch.
+    """
+
     def __init__(self, patch, old_bytes):
         self.patch = patch
         self.old_bytes = old_bytes
@@ -18,6 +22,7 @@ class QPatchTableItem:
             QTableWidgetItem("%d bytes" % len(patch)),
             QTableWidgetItem(binascii.hexlify(self.old_bytes).decode("ascii") if self.old_bytes else "<unknown>"),
             QTableWidgetItem(binascii.hexlify(patch.new_bytes).decode("ascii")),
+            QTableWidgetItem(patch.comment or ''),
         ]
 
         for w in widgets:
@@ -27,11 +32,14 @@ class QPatchTableItem:
 
 
 class QPatchTable(QTableWidget):
+    """
+    Table of all patches.
+    """
 
-    HEADER = ['Address', 'Size', 'Old Bytes', 'New Bytes']
+    HEADER = ['Address', 'Size', 'Old Bytes', 'New Bytes', 'Comment']
 
     def __init__(self, instance, parent):
-        super(QPatchTable, self).__init__(parent)
+        super().__init__(parent)
 
         self.setColumnCount(len(self.HEADER))
         self.setHorizontalHeaderLabels(self.HEADER)
@@ -50,7 +58,6 @@ class QPatchTable(QTableWidget):
             return None
 
     def reload(self):
-        current_row = self.currentRow()
         self.clearContents()
 
         self.items = [QPatchTableItem(item,
@@ -63,14 +70,11 @@ class QPatchTable(QTableWidget):
             for i, it in enumerate(item.widgets()):
                 self.setItem(idx, i, it)
 
-        #if 0 <= current_row < len(self.items):
-        #    self.setCurrentItem(current_row, 0)
-
-    def _on_state_selected(self, *args):
+    def _on_state_selected(self, *args):  # pylint: disable=unused-argument
         if self._selected is not None:
             self._selected(self.current_state_record())
 
-    def _watch_patches(self, **kwargs):
+    def _watch_patches(self, **kwargs):  # pylint: disable=unused-argument
         if not self.instance.patches.am_none:
             self.reload()
 


### PR DESCRIPTION
Add edit feature to Hex view. Simply place the cursor where the edit should happen and begin typing. Edits are stored as patches in the knowledge base and can be split, merged, and removed via context menus. Patches are naturally synchronized with Patches view. Basic copy-paste support is added.

There is definitely room for improvement here, but I've deferred it for now. Some thoughts:
* Upon edit, running targeted analyses to, for instance, let edits to code be reflected in disassembly view. This will require more thought.
* Integrating into system clipboard to support copy of bytes (optionally formatted as C/Python code, Hex, binary, etc) out or in; similarly permit import/export of file at location.
 
Demo:

https://user-images.githubusercontent.com/8210/133179617-e5029a20-3e64-450d-bb70-fc8d2c6cc18d.mp4

Closes #463 

