### PR TITLE
Reload disassembly views on color scheme change

### DIFF
--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -206,6 +206,13 @@ class QDisassemblyGraph(QDisassemblyBaseControl, QZoomableDraggableGraphicsView)
         else:
             super().mousePressEvent(event)
 
+    def changeEvent(self, event: QEvent):
+        """
+        Redraw on color scheme update.
+        """
+        if event.type() == QEvent.PaletteChange:
+            self.reload()
+
     def on_background_click(self):
         pass
 

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -170,6 +170,13 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         event.accept()
         self.viewport().update()
 
+    def changeEvent(self, event: QEvent):
+        """
+        Redraw on color scheme update.
+        """
+        if event.type() == QEvent.PaletteChange:
+            self.reload()
+
     def _on_vertical_scroll_bar_triggered(self, action):
 
         if action == QAbstractSlider.SliderSingleStepAdd:


### PR DESCRIPTION
This patch reloads the disassembly views whenever there's a color scheme change event.

What I dislike about this is that when you change the scheme, it doesn't keep your exact same position in the viewport (it reloads everything). This is because the text color is set when the block widgets are created. Ideally all of the different objects could just be repainted with the new color, and we wouldn't lose the viewport position; however, I think the case of switching color schemes is infrequent enough to not warrant deeper refactoring to make this a smoother experience, so just make it work correctly with the simplest approach for now.

Fixes #374 
Fixes #381