### PR TITLE
Use theme colors in simgr_toolbar

### DIFF
--- a/angrmanagement/ui/toolbars/simgr_toolbar.py
+++ b/angrmanagement/ui/toolbars/simgr_toolbar.py
@@ -2,9 +2,12 @@ from typing import TYPE_CHECKING
 import qtawesome as qta
 from .toolbar import Toolbar, ToolbarAction
 
+from ...config import Conf
+
 if TYPE_CHECKING:
     from ..main_window import MainWindow
     from ..widgets.qsimulation_managers import QSimulationManagers
+
 
 class SimgrToolbar(Toolbar):
     '''
@@ -13,18 +16,22 @@ class SimgrToolbar(Toolbar):
     def __init__(self, main_window: 'MainWindow'):
         super().__init__(main_window, 'Simgr')
         self.main_window = main_window
+
+        ico = lambda name: qta.icon(name, color=Conf.palette_buttontext)
+
         # pylint: disable=unnecessary-lambda
         # lambda added for late bind to simulation_managers which is not ready yet
         self.actions = [
-            ToolbarAction(qta.icon("fa5s.plus"),"New", "Start a new Simulation...",
+            ToolbarAction(ico("fa5s.plus"),"New", "Start a new Simulation...",
                 self.main_window.open_newstate_dialog),
-            ToolbarAction(qta.icon("fa5s.play"),"Explore", "",
+            ToolbarAction(ico("fa5s.play"),"Explore", "",
                 lambda : self.simulation_managers._on_explore_clicked()),
-            ToolbarAction(qta.icon("fa5s.step-forward"), "Step", "",
+            ToolbarAction(ico("fa5s.step-forward"), "Step", "",
                 lambda : self.simulation_managers._on_step_clicked()),
-            ToolbarAction(qta.icon("fa5s.code-branch"),"Step Until Branch", "",
+            ToolbarAction(ico("fa5s.code-branch"),"Step Until Branch", "",
                 lambda : self.simulation_managers._on_step_until_branch_clicked()),
-            ToolbarAction(qta.icon("fa5s.pause"), "Interrupt", "", main_window.interrupt_current_job),
+            ToolbarAction(ico("fa5s.pause"), "Interrupt", "",
+                          main_window.interrupt_current_job),
         ]
 
     @property


### PR DESCRIPTION
Renders SimgrToolbar's FontAwesome icons with current button text color.

![image](https://user-images.githubusercontent.com/8210/140437943-66e2769c-67e4-4b63-83de-dddab2fef3ec.png)

Doesn't update when scheme changes. You'll need to restart the app.

Ideally the icon would properly update on a palette change, but the original library should be patched to support it

Fixes #515 