### PR TITLE
Save enabled plugins to config

### DIFF
--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -177,7 +177,7 @@ ENTRIES = [
 
     # plugins
     CE('plugin_search_path', str, '$AM_BUILTIN_PLUGINS:~/.local/share/angr-management/plugins'),
-    CE('enabled_plugins', str, 'binsync,trace_viewer,dep_viewer'),
+    CE('enabled_plugins', str, ''),
 
     # configurations for individual plugins
     # TOOD: Move them to separate locations

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -12,7 +12,7 @@ from ..ui.toolbars.toolbar import ToolbarAction
 from ..daemon.url_handler import register_url_action, UrlActionBinaryAware
 from ..daemon.client import DaemonClient
 from ..ui.widgets.qblock import QBlock
-from ..config import Conf
+from ..config import Conf, save_config
 from . import load_plugins_from_dir
 from .base_plugin import BasePlugin
 
@@ -118,6 +118,11 @@ class PluginManager:
                       exc_info=True)
         else:
             l.info("Activated plugin %s", plugin_cls.get_display_name())
+
+    def save_enabled_plugins_to_config(self):
+        # pylint: disable=assigning-non-slot
+        Conf.enabled_plugins = ','.join(p.__class__.__name__ for p in self.active_plugins)
+        save_config()
 
     def _register_status_bar_widgets(self, plugin: BasePlugin) -> None:
         gen = plugin.status_bar_permanent_widgets()

--- a/angrmanagement/ui/dialogs/load_plugins.py
+++ b/angrmanagement/ui/dialogs/load_plugins.py
@@ -101,6 +101,7 @@ class LoadPlugins(QDialog):
             elif not checked and self._pm.get_plugin_instance(i.plugin_class) is not None:
                 self._pm.deactivate_plugin(i.plugin_class)
 
+        self._pm.save_enabled_plugins_to_config()
         self.close()
 
     def _on_cancel_clicked(self):

--- a/angrmanagement/ui/dialogs/load_plugins.py
+++ b/angrmanagement/ui/dialogs/load_plugins.py
@@ -100,8 +100,6 @@ class LoadPlugins(QDialog):
                 self._pm.activate_plugin(i.plugin_class)
             elif not checked and self._pm.get_plugin_instance(i.plugin_class) is not None:
                 self._pm.deactivate_plugin(i.plugin_class)
-            else:
-                self._pm.load_plugin(i.plugin_class)
 
         self.close()
 
@@ -127,4 +125,5 @@ class LoadPlugins(QDialog):
         for plugin in plugins:
             plugin_item = QPluginListWidgetItem(plugin_cls=plugin)
             plugin_item.setCheckState(Qt.Unchecked)
+            self._pm.load_plugin(plugin)
             self._installed_plugin_list.addItem(plugin_item)


### PR DESCRIPTION
* Don't re-load unchanged plugins on plugin dialog OK
* Save enabled plugins list config on plugin dialog OK (Fixes #534)
  * Note: Does not save paths to plugins outside configured search directories.
* Clear default enabled plugins list. An opinionated change; I don't think these plugins should be enabled by default, and they're easy enough to turn on if you do want them.