### PR TITLE
Convert dialogs OK/Cancel buttons to use standard QDialogButtonBox

### DIFF
--- a/angrmanagement/ui/dialogs/about.py
+++ b/angrmanagement/ui/dialogs/about.py
@@ -2,15 +2,19 @@ import angr
 
 import os
 
-from PySide2.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout, QApplication
-from PySide2.QtGui import QIcon, QDesktopServices, QPixmap, QFont
-from PySide2.QtCore import Qt, QSize, QEvent, QUrl
+from PySide2.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout
+from PySide2.QtGui import QIcon, QPixmap, QFont
+from PySide2.QtCore import Qt
 from ...config import IMG_LOCATION
 
 
 class LoadAboutDialog(QDialog):
+    """
+    Dialog that shows application version, credits, etc.
+    """
+
     def __init__(self):
-        super(LoadAboutDialog, self).__init__()
+        super().__init__()
         self.setWindowFlags(Qt.WindowTitleHint | Qt.WindowCloseButtonHint)
         self.setWindowTitle('About')
         #mdiIcon

--- a/angrmanagement/ui/dialogs/about.py
+++ b/angrmanagement/ui/dialogs/about.py
@@ -2,7 +2,7 @@ import angr
 
 import os
 
-from PySide2.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout, QHBoxLayout, QPushButton, QApplication
+from PySide2.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout, QApplication
 from PySide2.QtGui import QIcon, QDesktopServices, QPixmap, QFont
 from PySide2.QtCore import Qt, QSize, QEvent, QUrl
 from ...config import IMG_LOCATION
@@ -36,18 +36,11 @@ class LoadAboutDialog(QDialog):
         credits_text.setTextFormat(Qt.RichText)
         credits_text.setTextInteractionFlags(Qt.TextBrowserInteraction)
         credits_text.setOpenExternalLinks(True)
-        # buttons
-        btn_ok = QPushButton('OK')
-        btn_ok.clicked.connect(self._on_close_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(btn_ok)
 
         structure = QVBoxLayout()
         structure.addWidget(angr_text)
         structure.addWidget(version_text)
         structure.addWidget(credits_text)
-        structure.addLayout(buttons_layout)
 
         layout = QHBoxLayout()
         layout.addWidget(icon_label)
@@ -58,6 +51,3 @@ class LoadAboutDialog(QDialog):
         #
         # Event handlers
         #
-
-    def _on_close_clicked(self):
-        self.close()

--- a/angrmanagement/ui/dialogs/about.py
+++ b/angrmanagement/ui/dialogs/about.py
@@ -1,10 +1,10 @@
-import angr
-
 import os
 
 from PySide2.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout
 from PySide2.QtGui import QIcon, QPixmap, QFont
 from PySide2.QtCore import Qt
+import angr
+
 from ...config import IMG_LOCATION
 
 

--- a/angrmanagement/ui/dialogs/func_doc.py
+++ b/angrmanagement/ui/dialogs/func_doc.py
@@ -1,6 +1,5 @@
 from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, \
-    QGridLayout, QTextEdit
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QTextEdit
 
 from ...config import Conf
 from ...data.instance import Instance
@@ -22,14 +21,10 @@ class FuncDocDialog(QDialog):
         self._doc = doc_tuple[0].strip()
         self._url = doc_tuple[1].strip()
         self._ftype = doc_tuple[2].strip()
-        self._ok_button = None
         self.setWindowTitle('Function Documentation')
         self.main_layout = QVBoxLayout()
         self._init_widgets()
         self.setLayout(self.main_layout)
-
-    def _ok_method(self):
-        self.close()
 
     def _init_widgets(self):
         layout = QGridLayout()
@@ -60,8 +55,4 @@ class FuncDocDialog(QDialog):
         layout.addWidget(text_edit)
         layout.addWidget(url_label)
 
-        self._ok_button = QPushButton('Close', self)
-        self._ok_button.clicked.connect(self._ok_method)
-
         self.main_layout.addLayout(layout)
-        self.main_layout.addWidget(self._ok_button)

--- a/angrmanagement/ui/dialogs/hook.py
+++ b/angrmanagement/ui/dialogs/hook.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, \
-    QGridLayout, QRadioButton, QGroupBox, QScrollArea, QWidget
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QGridLayout, QRadioButton, QGroupBox, \
+    QScrollArea, QWidget, QDialogButtonBox
 from PySide2.QtGui import QTextOption
 from pyqodeng.core.api import CodeEdit
 from pyqodeng.core.modes import CaretLineHighlighterMode, PygmentsSyntaxHighlighter, AutoIndentMode
@@ -123,28 +123,15 @@ def enable_unicorn(state):
         layout.addWidget(function_box, row, 0)
         row += 1
 
-        # buttons
-        ok_button = QPushButton(self)
-        ok_button.setText('Append to Console')
+        self.main_layout.addLayout(layout)
 
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.button(QDialogButtonBox.Ok).setText('Append to Console')
         def do_ok():
             code = function_box.toPlainText()
             self.instance.append_code_to_console(code)
             self.close()
-
-        ok_button.clicked.connect(do_ok)
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-
-        def do_cancel():
-            self.close()
-
-        cancel_button.clicked.connect(do_cancel)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(layout)
-        self.main_layout.addLayout(buttons_layout)
+        buttons.accepted.connect(do_ok)
+        buttons.rejected.connect(self.close)
+        self.main_layout.addWidget(buttons)

--- a/angrmanagement/ui/dialogs/hook.py
+++ b/angrmanagement/ui/dialogs/hook.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QGridLayout, QRadioButton, QGroupBox, \
-    QScrollArea, QWidget, QDialogButtonBox
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QRadioButton, QGroupBox, QScrollArea, \
+    QWidget, QDialogButtonBox
 from PySide2.QtGui import QTextOption
 from pyqodeng.core.api import CodeEdit
 from pyqodeng.core.modes import CaretLineHighlighterMode, PygmentsSyntaxHighlighter, AutoIndentMode

--- a/angrmanagement/ui/dialogs/jumpto.py
+++ b/angrmanagement/ui/dialogs/jumpto.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox, QLineEdit
 from PySide2.QtCore import Qt
 
 from ..widgets import QAddressInput
@@ -50,22 +50,13 @@ class JumpTo(QDialog):
         self._status_label = status_label
 
         # buttons
-
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.setEnabled(False)
-        ok_button.clicked.connect(self._on_ok_clicked)
-        self._ok_button = ok_button
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -93,7 +84,3 @@ class JumpTo(QDialog):
             r = self._disasm_view.jump_to(addr)
             if r:
                 self.close()
-
-    def _on_cancel_clicked(self):
-        self.cfg_args = None
-        self.close()

--- a/angrmanagement/ui/dialogs/jumpto.py
+++ b/angrmanagement/ui/dialogs/jumpto.py
@@ -1,12 +1,15 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox, QLineEdit
-from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox
 
 from ..widgets import QAddressInput
 
 
 class JumpTo(QDialog):
+    """
+    Dialog to jump to an address.
+    """
+
     def __init__(self, disasm_view, parent=None):
-        super(JumpTo, self).__init__(parent)
+        super().__init__(parent)
 
         # initialization
         self._disasm_view = disasm_view
@@ -62,7 +65,7 @@ class JumpTo(QDialog):
     # Event handlers
     #
 
-    def _on_address_changed(self, new_text):
+    def _on_address_changed(self, new_text):  # pylint: disable=unused-argument
 
         if self._address_box.target is None:
             # the address is invalid

--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -5,8 +5,8 @@ import logging
 import archinfo
 from cle import Blob
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWidget, QPushButton, QCheckBox, QFrame, \
-    QGroupBox, QListWidgetItem, QListWidget, QMessageBox, QLineEdit, QGridLayout, QComboBox, QSizePolicy
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWidget, QCheckBox, QFrame, QGroupBox, \
+    QListWidgetItem, QListWidget, QMessageBox, QLineEdit, QGridLayout, QComboBox, QSizePolicy, QDialogButtonBox
 from PySide2.QtCore import Qt
 
 
@@ -128,19 +128,11 @@ class LoadBinary(QDialog):
 
         # buttons
 
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.clicked.connect(self._on_ok_clicked)
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self._on_cancel_clicked)
+        self.main_layout.addWidget(buttons)
 
     def _init_central_tab(self, tab):
         self._init_load_options_tab(tab)

--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -14,10 +14,16 @@ l = logging.getLogger('dialogs.load_binary')
 
 
 class LoadBinaryError(Exception):
-    pass
+    """
+    An error loading the binary.
+    """
 
 
 class LoadBinary(QDialog):
+    """
+    Dialog displaying loading options for a binary.
+    """
+
     def __init__(self, partial_ld, parent=None):
         super().__init__(parent)
 
@@ -318,4 +324,4 @@ class LoadBinary(QDialog):
         # TODO: Normalize the path for Windows
         QMessageBox.critical(None,
                              "Failed to load binary",
-                             "angr failed to load binary %s." % filename)
+                             f"angr failed to load binary {filename}.")

--- a/angrmanagement/ui/dialogs/load_plugins.py
+++ b/angrmanagement/ui/dialogs/load_plugins.py
@@ -2,7 +2,7 @@ import logging
 from typing import Type, List
 
 from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QFrame, QGroupBox, QListWidgetItem, \
-    QListWidget, QFileDialog, QMessageBox
+    QListWidget, QFileDialog, QMessageBox, QDialogButtonBox
 from PySide2.QtCore import Qt
 
 from angrmanagement.plugins import load_plugins_from_file
@@ -72,20 +72,11 @@ class LoadPlugins(QDialog):
 
         self._init_plugin_list()
 
-        # buttons
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.clicked.connect(self._on_ok_clicked)
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -102,9 +93,6 @@ class LoadPlugins(QDialog):
                 self._pm.deactivate_plugin(i.plugin_class)
 
         self._pm.save_enabled_plugins_to_config()
-        self.close()
-
-    def _on_cancel_clicked(self):
         self.close()
 
     def _on_load_clicked(self):

--- a/angrmanagement/ui/dialogs/load_plugins.py
+++ b/angrmanagement/ui/dialogs/load_plugins.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Type, List
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QFrame, QGroupBox, QListWidgetItem, \
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QPushButton, QFrame, QGroupBox, QListWidgetItem, \
     QListWidget, QFileDialog, QMessageBox, QDialogButtonBox
 from PySide2.QtCore import Qt
 
@@ -11,6 +11,10 @@ _l = logging.getLogger(__name__)
 
 
 class QPluginListWidgetItem(QListWidgetItem):
+    """
+    Plugin list item.
+    """
+
     def __init__(self, plugin_cls, **kwargs):
         super().__init__(**kwargs)
         self.plugin_class = plugin_cls  # type: Type[BasePlugin]
@@ -20,8 +24,12 @@ class QPluginListWidgetItem(QListWidgetItem):
 # TODO: Add plugin settings, reloading, etc.
 
 class LoadPlugins(QDialog):
+    """
+    Dialog to display loaded plugins, enable/disable plugins, and load new plugins.
+    """
+
     def __init__(self, plugin_mgr, parent=None):
-        super(LoadPlugins, self).__init__(parent)
+        super().__init__(parent)
 
         self._pm = plugin_mgr  # type: PluginManager
         self._installed_plugin_list = None  # type: QListWidget

--- a/angrmanagement/ui/dialogs/new_state.py
+++ b/angrmanagement/ui/dialogs/new_state.py
@@ -1,8 +1,8 @@
 import os
 from typing import List
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDialogButtonBox, QGridLayout, \
-    QComboBox, QLineEdit, QTextEdit, QTreeWidget, QTreeWidgetItem
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QDialogButtonBox, QGridLayout, QComboBox, \
+    QLineEdit, QTextEdit, QTreeWidget, QTreeWidgetItem
 from PySide2.QtCore import Qt
 import angr
 
@@ -12,6 +12,10 @@ from ...ui.dialogs.fs_mount import FilesystemMount
 
 
 class StateMetadata(angr.SimStatePlugin):
+    """
+    Helper class for metadata.
+    """
+
     def __init__(self):
         super().__init__()
         self.name = None                # the state's name
@@ -39,6 +43,10 @@ def is_option(o):
 
 
 class NewState(QDialog):
+    """
+    Dialog to create a new simulation state.
+    """
+
     def __init__(self, instance, addr=None, create_simgr=False, parent=None, push_to_instance=True):
         super().__init__(parent)
 

--- a/angrmanagement/ui/dialogs/new_state.py
+++ b/angrmanagement/ui/dialogs/new_state.py
@@ -1,9 +1,11 @@
 import os
 from typing import List
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, \
-    QGridLayout, QComboBox, QLineEdit, QTextEdit, QTreeWidget, QTreeWidgetItem
+
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDialogButtonBox, QGridLayout, \
+    QComboBox, QLineEdit, QTextEdit, QTreeWidget, QTreeWidgetItem
 from PySide2.QtCore import Qt
 import angr
+
 from ..widgets import QStateComboBox
 from ...utils.namegen import NameGenerator
 from ...ui.dialogs.fs_mount import FilesystemMount
@@ -287,8 +289,8 @@ class NewState(QDialog):
 
         # buttons
 
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
         def do_ok():
             name = name_box.text()
             template = template_combo.currentData()
@@ -335,19 +337,12 @@ class NewState(QDialog):
 
             self.close()
 
-        ok_button.clicked.connect(do_ok)
+        ok_button = buttons.button(QDialogButtonBox.Ok)
+        buttons.accepted.connect(do_ok)
         def validation_update():
             ok_button.setDisabled(bool(validation_failures))
 
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        def do_cancel():
-            self.close()
-        cancel_button.clicked.connect(do_cancel)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
+        buttons.rejected.connect(self.close)
 
         self.main_layout.addLayout(layout)
-        self.main_layout.addLayout(buttons_layout)
+        self.main_layout.addWidget(buttons)

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -1,6 +1,7 @@
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
-    QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, QSizePolicy
+    QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, \
+    QSizePolicy, QDialogButtonBox
 from PySide2.QtCore import QSize
 
 from ..widgets.qcolor_option import QColorOption
@@ -185,14 +186,11 @@ class Preferences(QDialog):
             contents.addItem(list_item)
 
         # buttons
-        ok_button = QPushButton("OK")
-        ok_button.clicked.connect(self._on_ok_clicked)
-        cancel_button = QPushButton("Cancel")
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        button_layout = QHBoxLayout()
-        button_layout.addWidget(ok_button)
-        button_layout.addWidget(cancel_button)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Close | QDialogButtonBox.StandardButton.Ok)
+        buttons.button(QDialogButtonBox.Ok).setText('Save')
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
 
         # layout
         top_layout = QHBoxLayout()
@@ -201,7 +199,7 @@ class Preferences(QDialog):
 
         main_layout = QVBoxLayout()
         main_layout.addLayout(top_layout)
-        main_layout.addLayout(button_layout)
+        main_layout.addWidget(buttons)
 
         self.setLayout(main_layout)
 
@@ -209,7 +207,4 @@ class Preferences(QDialog):
         for page in self._pages:
             page.save_config()
         save_config()
-        self.close()
-
-    def _on_cancel_clicked(self):
         self.close()

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -13,6 +13,10 @@ from ..css import refresh_theme
 
 
 class Page(QWidget):
+    """
+    Base class for pages.
+    """
+
     def save_config(self):
         raise NotImplementedError()
 
@@ -23,6 +27,7 @@ class Integration(Page):
     """
     The integration page.
     """
+
     NAME = 'OS Integration'
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -80,6 +85,10 @@ class Integration(Page):
 
 
 class ThemeAndColors(Page):
+    """
+    Theme and Colors preferences page.
+    """
+
     NAME = "Theme and Colors"
 
     def __init__(self, parent=None):
@@ -143,6 +152,7 @@ class ThemeAndColors(Page):
         self.save_config()
 
     def save_config(self):
+        # pylint: disable=assigning-non-slot
         Conf.theme_name = self._schemes_combo.currentText()
         for ce, row in self._to_save.values():
             setattr(Conf, ce.name, row.color.am_obj)

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -160,6 +160,10 @@ class ThemeAndColors(Page):
 
 
 class Preferences(QDialog):
+    """
+    Application preferences dialog.
+    """
+
     def __init__(self, workspace, parent=None):
         super().__init__(parent)
 

--- a/angrmanagement/ui/dialogs/rename.py
+++ b/angrmanagement/ui/dialogs/rename.py
@@ -1,6 +1,6 @@
 from typing import Optional, TYPE_CHECKING
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
 
 if TYPE_CHECKING:
     from angrmanagement.ui.views.code_view import CodeView
@@ -70,21 +70,13 @@ class RenameDialog(QDialog):
         self.main_layout.addWidget(status_label)
         self._status_label = status_label
 
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.setEnabled(False)
-        ok_button.clicked.connect(self._on_ok_clicked)
-        self._ok_button = ok_button
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -113,6 +105,3 @@ class RenameDialog(QDialog):
         if node_name is not None:
             self.result = node_name
             self.close()
-
-    def _on_cancel_clicked(self):
-        self.close()

--- a/angrmanagement/ui/dialogs/rename_label.py
+++ b/angrmanagement/ui/dialogs/rename_label.py
@@ -2,6 +2,10 @@ from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushBu
 
 
 class LabelNameBox(QLineEdit):
+    """
+    A QLineEdit that sanitizes label names.
+    """
+
     def __init__(self, textchanged_callback, parent=None):
         super().__init__(parent)
 
@@ -15,12 +19,16 @@ class LabelNameBox(QLineEdit):
         return None
 
     def _is_valid_label_name(self, input_):  # pylint: disable=no-self-use
-        return input_ and not (' ' in input_.strip())
+        return input_ and not ' ' in input_.strip()
 
 
 class RenameLabel(QDialog):
+    """
+    Dialog to rename labels.
+    """
+
     def __init__(self, disasm_view, label_addr, parent=None):
-        super(RenameLabel, self).__init__(parent)
+        super().__init__(parent)
 
         # initialization
         self._disasm_view = disasm_view

--- a/angrmanagement/ui/dialogs/rename_label.py
+++ b/angrmanagement/ui/dialogs/rename_label.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
 
 
 class LabelNameBox(QLineEdit):
@@ -66,22 +66,13 @@ class RenameLabel(QDialog):
         self._status_label = status_label
 
         # buttons
-
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.setEnabled(False)
-        ok_button.clicked.connect(self._on_ok_clicked)
-        self._ok_button = ok_button
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -112,6 +103,3 @@ class RenameLabel(QDialog):
         if label is not None:
             self._disasm_view.rename_label(self._label_addr, label)
             self.close()
-
-    def _on_cancel_clicked(self):
-        self.close()

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -1,7 +1,8 @@
 from typing import Optional, TYPE_CHECKING
 from collections import OrderedDict
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QListWidget
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QListWidget, \
+    QDialogButtonBox
 from angr.analyses.decompiler.structured_codegen.c import CVariable, CFunction, CConstruct, CFunctionCall, CStructField
 
 if TYPE_CHECKING:
@@ -107,21 +108,13 @@ class RenameNode(QDialog):
         self._status_label = status_label
 
         # buttons
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.setEnabled(False)
-        ok_button.clicked.connect(self._on_ok_clicked)
-        self._ok_button = ok_button
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -206,6 +199,3 @@ class RenameNode(QDialog):
 
                 self._code_view.codegen.am_event()
                 self.close()
-
-    def _on_cancel_clicked(self):
-        self.close()

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -10,6 +10,10 @@ if TYPE_CHECKING:
 
 
 class NodeNameBox(QLineEdit):
+    """
+    QLineEdit that validates node names.
+    """
+
     def __init__(self, textchanged_callback, parent=None):
         super().__init__(parent)
 
@@ -28,6 +32,10 @@ class NodeNameBox(QLineEdit):
 
 
 class RenameNode(QDialog):
+    """
+    Dialog for renaming a node.
+    """
+
     def __init__(self, code_view: Optional['CodeView']=None, node: Optional[CConstruct]=None, parent=None):
         super().__init__(parent)
 

--- a/angrmanagement/ui/dialogs/retype_node.py
+++ b/angrmanagement/ui/dialogs/retype_node.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDialogButtonBox, QLineEdit
 
 import pycparser
 
@@ -108,21 +108,13 @@ class RetypeNode(QDialog):
         self._status_label = status_label
 
         # buttons
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.setEnabled(False)
-        ok_button.clicked.connect(self._on_ok_clicked)
-        self._ok_button = ok_button
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self._on_cancel_clicked)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers

--- a/angrmanagement/ui/dialogs/set_comment.py
+++ b/angrmanagement/ui/dialogs/set_comment.py
@@ -1,10 +1,14 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox, QPlainTextEdit, QApplication
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QDialogButtonBox, QPlainTextEdit, QApplication
 from PySide2.QtCore import Qt
 
 
 class QCommentTextBox(QPlainTextEdit):
+    """
+    Multiline text box for comment entry.
+    """
+
     def __init__(self, textchanged_callback=None, textconfirmed_callback=None, parent=None):
-        super(QCommentTextBox, self).__init__(parent)
+        super().__init__(parent)
         if textchanged_callback is not None:
             self.textChanged.connect(textchanged_callback)
         self._textconfirmed_callback = textconfirmed_callback
@@ -25,8 +29,12 @@ class QCommentTextBox(QPlainTextEdit):
 
 
 class SetComment(QDialog):
+    """
+    Dialog for setting comment.
+    """
+
     def __init__(self, workspace, comment_addr, parent=None):
-        super(SetComment, self).__init__(parent)
+        super().__init__(parent)
 
         # initialization
         self._workspace = workspace

--- a/angrmanagement/ui/dialogs/set_comment.py
+++ b/angrmanagement/ui/dialogs/set_comment.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QPlainTextEdit, QApplication
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox, QPlainTextEdit, QApplication
 from PySide2.QtCore import Qt
 
 
@@ -62,19 +62,11 @@ class SetComment(QDialog):
         self.main_layout.addLayout(comment_layout)
 
         # buttons
-        ok_button = QPushButton(self)
-        ok_button.setText('OK')
-        ok_button.clicked.connect(self._on_ok_clicked)
-
-        cancel_button = QPushButton(self)
-        cancel_button.setText('Cancel')
-        cancel_button.clicked.connect(self._on_cancel_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(ok_button)
-        buttons_layout.addWidget(cancel_button)
-
-        self.main_layout.addLayout(buttons_layout)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self.main_layout.addWidget(buttons)
 
     #
     # Event handlers
@@ -83,7 +75,4 @@ class SetComment(QDialog):
     def _on_ok_clicked(self):
         comment_txt = self._comment_textbox.text
         self._workspace.set_comment(self._comment_addr, comment_txt)
-        self.close()
-
-    def _on_cancel_clicked(self):
         self.close()

--- a/angrmanagement/ui/dialogs/type_editor.py
+++ b/angrmanagement/ui/dialogs/type_editor.py
@@ -2,7 +2,7 @@ from typing import Optional
 from collections import OrderedDict
 
 from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialog, QLineEdit, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QDialogButtonBox
+from PySide2.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QDialogButtonBox
 
 import pycparser.plyparser
 from angr import sim_type

--- a/angrmanagement/ui/dialogs/type_editor.py
+++ b/angrmanagement/ui/dialogs/type_editor.py
@@ -2,7 +2,7 @@ from typing import Optional
 from collections import OrderedDict
 
 from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialog, QLineEdit, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox
+from PySide2.QtWidgets import QDialog, QLineEdit, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QDialogButtonBox
 
 import pycparser.plyparser
 from angr import sim_type
@@ -41,12 +41,11 @@ class CTypeEditor(QDialog):
         self.result = []
 
     def _init_widgets(self, base_text, multiline):
-        self._ok_button = QPushButton(self)
-        self._ok_button.setText("Ok")
-        self._ok_button.pressed.connect(self._on_ok_pressed)
-        cancel_button = QPushButton(self)
-        cancel_button.setText("Cancel")
-        cancel_button.pressed.connect(self._on_cancel_pressed)
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_pressed)
+        buttons.rejected.connect(self._on_cancel_pressed)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
 
         if multiline:
             editor = QCommentTextBox(parent=self,
@@ -69,14 +68,9 @@ class CTypeEditor(QDialog):
             editor.setFocus()
             editor.selectAll()
 
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(self._ok_button)
-        buttons_layout.addWidget(cancel_button)
-
         layout = QVBoxLayout()
         layout.addWidget(editor)
-        layout.addLayout(buttons_layout)
+        layout.addWidget(buttons)
 
         self.setLayout(layout)
 

--- a/angrmanagement/ui/dialogs/xref.py
+++ b/angrmanagement/ui/dialogs/xref.py
@@ -48,29 +48,11 @@ class XRef(QDialog):
             instance=self._instance, disassembly_view=self._disassembly_view, parent=self,
         )
 
-        # buttons
-        btn_ok = QPushButton('OK')
-
-        btn_close = QPushButton('Close')
-        btn_close.clicked.connect(self._on_close_clicked)
-
-        buttons_layout = QHBoxLayout()
-        buttons_layout.addWidget(btn_ok)
-        buttons_layout.addWidget(btn_close)
-
         layout = QVBoxLayout()
         layout.addWidget(xref_viewer)
-        layout.addLayout(buttons_layout)
 
         self.setLayout(layout)
 
     def jump_to(self, addr):
         self._disassembly_view.jump_to(addr, src_ins_addr=self._addr)
-        self.close()
-
-    #
-    # Event handlers
-    #
-
-    def _on_close_clicked(self):
         self.close()

--- a/angrmanagement/ui/dialogs/xref.py
+++ b/angrmanagement/ui/dialogs/xref.py
@@ -1,13 +1,17 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton
+from PySide2.QtWidgets import QDialog, QVBoxLayout
 from PySide2.QtCore import QSize, Qt
 
-from ..widgets.qxref_viewer import QXRefViewer, XRefMode
+from ..widgets.qxref_viewer import QXRefViewer
 
 
 class XRef(QDialog):
+    """
+    Dialog displaying cross-references.
+    """
+
     def __init__(self, addr=None, variable_manager=None, variable=None, xrefs_manager=None, dst_addr=None,
                  instance=None, parent=None):
-        super(XRef, self).__init__(parent)
+        super().__init__(parent)
 
         self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
 
@@ -20,7 +24,7 @@ class XRef(QDialog):
         self._disassembly_view = parent
 
         if variable is not None:
-            self.setWindowTitle('XRefs to variable %s(%s)' % (variable.name, variable.ident))
+            self.setWindowTitle(f'XRefs to variable {variable.name}({variable.ident})')
         elif dst_addr is not None:
             # is there a label for it?
             try:
@@ -28,15 +32,15 @@ class XRef(QDialog):
             except KeyError:
                 lbl = None
             if lbl is not None:
-                self.setWindowTitle('XRefs to %s' % lbl)
+                self.setWindowTitle(f'XRefs to {lbl}')
             else:
-                self.setWindowTitle('XRefs to address %#x' % dst_addr)
+                self.setWindowTitle(f'XRefs to address {dst_addr:#x}')
         else:
             raise ValueError("Either variable or dst_addr must be specified.")
 
         self._init_widgets()
 
-    def sizeHint(self, *args, **kwargs):
+    def sizeHint(self, *args, **kwargs):  # pylint: disable=unused-argument,no-self-use
         return QSize(600, 400)
 
     def _init_widgets(self):

--- a/angrmanagement/ui/views/console_view.py
+++ b/angrmanagement/ui/views/console_view.py
@@ -83,14 +83,14 @@ class ConsoleView(BaseView):
             return
 
         self._ipython_widget = ipython_widget
-        ipython_widget.executed.connect(self.commend_executed)
+        ipython_widget.executed.connect(self.command_executed)
 
         hlayout = QHBoxLayout()
         hlayout.addWidget(ipython_widget)
 
         self.setLayout(hlayout)
 
-    def commend_executed(self,msg):
+    def command_executed(self,msg):
         if msg["msg_type"] == "execute_reply" and msg["content"]["status"] == "ok":
             view = self.workspace.view_manager.first_view_in_category("disassembly")
             if view is not None:

--- a/angrmanagement/ui/widgets/qxref_viewer.py
+++ b/angrmanagement/ui/widgets/qxref_viewer.py
@@ -291,6 +291,10 @@ class QXRefViewer(QTableView):
         self.setSortingEnabled(True)
         self.setSelectionMode(QAbstractItemView.SingleSelection)
 
+        hheader = self.horizontalHeader()
+        hheader.setStretchLastSection(True)
+        hheader.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+
         self.doubleClicked.connect(self._on_item_doubleclicked)
 
     def _reload(self):


### PR DESCRIPTION
* Removes some unnecessary dialog buttons
* Converts most 'Ok/Cancel' button combos over to the standard `QDialogButtonBox` (Fixes #489)
* Fixes a typo and lint issues in touched files
* Fixes column header issues in XRefs view

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/8210/148344320-4a99dcf2-854e-47a2-9aaf-1980939a48ba.png)|![image](https://user-images.githubusercontent.com/8210/148344398-201bbba2-f68d-43fc-b505-b9c9f7c38703.png)|
|![image](https://user-images.githubusercontent.com/8210/148453217-02d2b949-597f-4cfc-8f98-c3a359b617c1.png)|![image](https://user-images.githubusercontent.com/8210/148453282-9865322a-f152-4b8b-bb88-5a369d1937f1.png)|


