### PR TITLE
Add integrated trace debugger and trace view

### DIFF
--- a/angrmanagement/data/breakpoint.py
+++ b/angrmanagement/data/breakpoint.py
@@ -1,0 +1,58 @@
+from enum import Enum
+from typing import Sequence
+
+from .object_container import ObjectContainer
+
+
+class BreakpointType(Enum):
+    """
+    Type of breakpoint.
+    """
+
+    Execute = 1
+    Read = 2
+    Write = 4
+
+
+class Breakpoint:
+    """
+    A breakpoint / watchpoint.
+    """
+
+    __slots__ = (
+        'type', 'addr', 'length', 'comment'
+    )
+
+    def __init__(self, type_: BreakpointType, addr: int, length: int = 1, comment: str = ''):
+        self.type: BreakpointType = type_
+        self.addr: int = addr
+        self.length: int = length
+        self.comment: str = comment
+
+
+class BreakpointManager:
+    """
+    Manager of breakpoins.
+    """
+
+    def __init__(self):
+        self.breakpoints: ObjectContainer = ObjectContainer([], 'List of breakpoints')
+
+    def clear(self):
+        self.breakpoints.clear()
+        self.breakpoints.am_event()
+
+    def add_breakpoint(self, bp: Breakpoint):
+        self.breakpoints.append(bp)
+        self.breakpoints.am_event(added=bp)
+
+    def remove_breakpoint(self, bp: Breakpoint):
+        self.breakpoints.remove(bp)
+        self.breakpoints.am_event(removed=bp)
+
+    def add_exec_breakpoint(self, addr):
+        self.add_breakpoint(Breakpoint(BreakpointType.Execute, addr))
+
+    def get_breakpoints_at(self, addr: int) -> Sequence[Breakpoint]:
+        return [bp for bp in self.breakpoints
+                     if bp.addr <= addr < (bp.addr + bp.length)]

--- a/angrmanagement/data/breakpoint.py
+++ b/angrmanagement/data/breakpoint.py
@@ -9,9 +9,9 @@ class BreakpointType(Enum):
     Type of breakpoint.
     """
 
-    Execute = 1
-    Read = 2
-    Write = 4
+    Execute = 0
+    Read = 1
+    Write = 2
 
 
 class Breakpoint:

--- a/angrmanagement/data/breakpoint.py
+++ b/angrmanagement/data/breakpoint.py
@@ -43,7 +43,7 @@ class Breakpoint:
 
 class BreakpointManager:
     """
-    Manager of breakpoins.
+    Manager of breakpoints.
     """
 
     def __init__(self):

--- a/angrmanagement/data/breakpoint.py
+++ b/angrmanagement/data/breakpoint.py
@@ -20,14 +20,25 @@ class Breakpoint:
     """
 
     __slots__ = (
-        'type', 'addr', 'length', 'comment'
+        'type', 'addr', '_size', 'comment'
     )
 
-    def __init__(self, type_: BreakpointType, addr: int, length: int = 1, comment: str = ''):
+    def __init__(self, type_: BreakpointType, addr: int, size: int = 1, comment: str = ''):
         self.type: BreakpointType = type_
         self.addr: int = addr
-        self.length: int = length
+        self._size: int = 1
+        self.size = size
         self.comment: str = comment
+
+    @property
+    def size(self):
+        if self.type == BreakpointType.Execute:
+            return 1
+        return self._size
+
+    @size.setter
+    def size(self, v: int):
+        self._size = v
 
 
 class BreakpointManager:
@@ -55,4 +66,4 @@ class BreakpointManager:
 
     def get_breakpoints_at(self, addr: int) -> Sequence[Breakpoint]:
         return [bp for bp in self.breakpoints
-                     if bp.addr <= addr < (bp.addr + bp.length)]
+                     if bp.addr <= addr < (bp.addr + bp.size)]

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -2,7 +2,7 @@ import time
 import logging
 from threading import Thread
 from queue import Queue
-from typing import List, Optional, Type, Union, Callable, TYPE_CHECKING
+from typing import List, Optional, Type, Union, Callable, TYPE_CHECKING, Set
 
 import angr
 from angr.block import Block
@@ -16,6 +16,7 @@ from ..logic import GlobalInfo
 from ..logic.threads import gui_thread_schedule_async
 from ..logic.debugger import DebuggerListManager, DebuggerManager
 from ..logic.debugger.simgr import SimulationDebugger
+from ..data.trace import Trace
 
 if TYPE_CHECKING:
     from ..ui.workspace import Workspace
@@ -63,6 +64,9 @@ class Instance:
                                 List[Type[ProtocolInteractor]],
                                 'Available interaction protocols')
         self.register_container('log', lambda: [], List[LogRecord], 'Saved log messages')
+        self.register_container('current_trace', lambda: None, Type[Trace], 'Currently selected trace')
+        self.register_container('traces', lambda: [], List[Trace], 'Global traces list')
+        self.register_container('breakpoints', lambda: set(), Set[int], 'Breakpoints')
 
         self.debugger_list_mgr = DebuggerListManager()
         self.debugger_mgr = DebuggerManager(self.debugger_list_mgr)

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -17,6 +17,7 @@ from ..logic.threads import gui_thread_schedule_async
 from ..logic.debugger import DebuggerListManager, DebuggerManager
 from ..logic.debugger.simgr import SimulationDebugger
 from ..data.trace import Trace
+from ..data.breakpoint import Breakpoint, BreakpointManager
 
 if TYPE_CHECKING:
     from ..ui.workspace import Workspace
@@ -66,8 +67,8 @@ class Instance:
         self.register_container('log', lambda: [], List[LogRecord], 'Saved log messages')
         self.register_container('current_trace', lambda: None, Type[Trace], 'Currently selected trace')
         self.register_container('traces', lambda: [], List[Trace], 'Global traces list')
-        self.register_container('breakpoints', lambda: set(), Set[int], 'Breakpoints')
 
+        self.breakpoint_mgr = BreakpointManager()
         self.debugger_list_mgr = DebuggerListManager()
         self.debugger_mgr = DebuggerManager(self.debugger_list_mgr)
 
@@ -312,6 +313,8 @@ class Instance:
 
         for dbg in list(self.debugger_list_mgr.debugger_list):
             self.debugger_list_mgr.remove_debugger(dbg)
+
+        self.breakpoint_mgr.clear()
 
     def _update_simgr_debuggers(self, **kwargs):  # pylint:disable=unused-argument
         sim_dbg = None

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -2,7 +2,7 @@ import time
 import logging
 from threading import Thread
 from queue import Queue
-from typing import List, Optional, Type, Union, Callable, TYPE_CHECKING, Set
+from typing import List, Optional, Type, Union, Callable, TYPE_CHECKING
 
 import angr
 from angr.block import Block
@@ -17,7 +17,7 @@ from ..logic.threads import gui_thread_schedule_async
 from ..logic.debugger import DebuggerListManager, DebuggerManager
 from ..logic.debugger.simgr import SimulationDebugger
 from ..data.trace import Trace
-from ..data.breakpoint import Breakpoint, BreakpointManager
+from ..data.breakpoint import BreakpointManager
 
 if TYPE_CHECKING:
     from ..ui.workspace import Workspace

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -310,6 +310,9 @@ class Instance:
             self.extra_containers[name].am_obj = self._container_defaults[name][0]()
             self.extra_containers[name].am_event(**kwargs)
 
+        for dbg in list(self.debugger_list_mgr.debugger_list):
+            self.debugger_list_mgr.remove_debugger(dbg)
+
     def _update_simgr_debuggers(self, **kwargs):  # pylint:disable=unused-argument
         sim_dbg = None
         for dbg in self.debugger_list_mgr.debugger_list:

--- a/angrmanagement/data/jobs/loading.py
+++ b/angrmanagement/data/jobs/loading.py
@@ -13,6 +13,10 @@ from ...ui.dialogs import LoadBinary
 
 
 class LoadTargetJob(Job):
+    """
+    Job to load archr target and angr project.
+    """
+
     def __init__(self, target, on_finish=None):
         super().__init__("Loading target", on_finish=on_finish)
         self.target = target
@@ -39,9 +43,13 @@ class LoadTargetJob(Job):
 
 
 class LoadBinaryJob(Job):
-    def __init__(self, fname, load_options={}, on_finish=None):
+    """
+    Job to display binary load dialog and create angr project.
+    """
+
+    def __init__(self, fname, load_options=None, on_finish=None):
         super().__init__("Loading file", on_finish=on_finish)
-        self.load_options = load_options
+        self.load_options = load_options or {}
         self.fname = fname
 
     def _run(self, inst):

--- a/angrmanagement/data/trace.py
+++ b/angrmanagement/data/trace.py
@@ -1,0 +1,49 @@
+try:
+    import bintrace
+    from bintrace.debugger_angr import get_angr_project_load_options_from_trace
+except ImportError:
+    bintrace = None
+
+
+class Trace:
+    """
+    Base class for different trace formats.
+    """
+
+    @property
+    def source(self) -> str:
+        raise NotImplementedError()
+
+    @classmethod
+    def trace_backend_enabled(cls) -> bool:
+        return False
+
+    def get_project_load_options(self):  # pylint:disable=no-self-use
+        return None
+
+
+class BintraceTrace(Trace):
+    """
+    Bintrace execution trace.
+    """
+
+    def __init__(self, trace: 'bintrace.Trace'):
+        assert BintraceTrace.trace_backend_enabled()
+        self.trace: 'bintrace.Trace' = trace
+
+    @property
+    def source(self) -> str:
+        return self.trace.path
+
+    @classmethod
+    def load_trace(cls, path: str) -> 'BintraceTrace':
+        trace = bintrace.Trace()
+        trace.load_trace(path)
+        return cls(trace)
+
+    @classmethod
+    def trace_backend_enabled(cls) -> bool:
+        return bintrace is not None
+
+    def get_project_load_options(self):
+        return get_angr_project_load_options_from_trace(self.trace)

--- a/angrmanagement/logic/debugger/bintrace.py
+++ b/angrmanagement/logic/debugger/bintrace.py
@@ -52,7 +52,7 @@ class BintraceDebugger(Debugger):
             BreakpointType.Write: bintrace.debugger.BreakpointType.Write,
         }
         self._trace_dbg.breakpoints = {
-            bintrace.debugger.Breakpoint(bp_type_map[bp.type], addr=bp.addr, length=bp.length)
+            bintrace.debugger.Breakpoint(bp_type_map[bp.type], bp.addr, bp.size)
             for bp in self.workspace.instance.breakpoint_mgr.breakpoints
         }
 

--- a/angrmanagement/logic/debugger/bintrace.py
+++ b/angrmanagement/logic/debugger/bintrace.py
@@ -10,6 +10,7 @@ except ImportError as e:
     bintrace = None
 
 from ...data.trace import BintraceTrace
+from ...data.breakpoint import BreakpointType
 from .debugger import Debugger
 
 
@@ -45,7 +46,15 @@ class BintraceDebugger(Debugger):
         """
         Synchronize breakpoints set in Workspace with trace debugger.
         """
-        self._trace_dbg.breakpoints = self.workspace.instance.breakpoints
+        bp_type_map = {
+            BreakpointType.Execute: bintrace.debugger.BreakpointType.Execute,
+            BreakpointType.Read: bintrace.debugger.BreakpointType.Read,
+            BreakpointType.Write: bintrace.debugger.BreakpointType.Write,
+        }
+        self._trace_dbg.breakpoints = {
+            bintrace.debugger.Breakpoint(bp_type_map[bp.type], addr=bp.addr, length=bp.length)
+            for bp in self.workspace.instance.breakpoint_mgr.breakpoints
+        }
 
     @property
     def simstate(self) -> SimState:

--- a/angrmanagement/logic/debugger/bintrace.py
+++ b/angrmanagement/logic/debugger/bintrace.py
@@ -1,0 +1,135 @@
+import os
+import logging
+
+from angr import SimState
+
+try:
+    import bintrace
+    from bintrace.debugger_angr import AngrTraceDebugger
+except ImportError as e:
+    bintrace = None
+
+from ...data.trace import BintraceTrace
+from .debugger import Debugger
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class BintraceDebugger(Debugger):
+    """
+    Trace playback debugger.
+    """
+
+    def __init__(self, trace: BintraceTrace, workspace: 'Workspace'):
+        super().__init__(workspace)
+        assert bintrace is not None
+        assert isinstance(trace, BintraceTrace)
+        self._trace: 'bintrace.Trace' = trace
+        self._trace_dbg: AngrTraceDebugger = AngrTraceDebugger(self._trace.trace,
+                                                               self.workspace.instance.project.am_obj)
+        self._cached_simstate = None
+
+    def __str__(self):
+        pc = self.simstate.solver.eval(self.simstate.regs.pc)
+        return f'{os.path.basename(self._trace.trace.path)} @ {pc:x}'
+
+    def _on_state_change(self):
+        """
+        Common handler for state changes.
+        """
+        self._cached_simstate = None
+        self.state_changed.am_event()
+
+    def _sync_breakpoints(self):
+        """
+        Synchronize breakpoints set in Workspace with trace debugger.
+        """
+        self._trace_dbg.breakpoints = self.workspace.instance.breakpoints
+
+    @property
+    def simstate(self) -> SimState:
+        if self._cached_simstate is None:
+            self._cached_simstate = self._trace_dbg.simstate
+        return self._cached_simstate
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+    @property
+    def can_step_backward(self) -> bool:
+        return self._trace_dbg.can_step_backward
+
+    def step_backward(self):
+        if self.can_step_backward:
+            self._trace_dbg.step_backward()
+            self._on_state_change()
+
+    @property
+    def can_step_forward(self) -> bool:
+        return self._trace_dbg.can_step_forward
+
+    def step_forward(self):
+        if self.can_step_forward:
+            self._trace_dbg.step_forward()
+            self._on_state_change()
+
+    @property
+    def can_continue_backward(self) -> bool:
+        return self._trace_dbg.can_continue_backward
+
+    def continue_backward(self):
+        if self.can_continue_backward:
+            self._sync_breakpoints()
+            self._trace_dbg.continue_backward()
+            self._on_state_change()
+
+    @property
+    def can_continue_forward(self) -> bool:
+        return self._trace_dbg.can_continue_forward
+
+    def continue_forward(self):
+        if self.can_continue_forward:
+            self._sync_breakpoints()
+            self._trace_dbg.continue_forward()
+            self._on_state_change()
+
+    @property
+    def can_halt(self) -> bool:
+        return False  # XXX: Trace playback is "instantaneous", always is halted state.
+
+    @property
+    def is_halted(self) -> bool:
+        return True
+
+    @property
+    def can_stop(self) -> bool:
+        return True
+
+    def stop(self):
+        pass
+
+    @property
+    def is_exited(self) -> bool:
+        return False
+
+    def replay_to_nth_event(self, n: int):
+        """
+        Replay to the Nth event, skipping over stop events and ending on the nearest execution event.
+        """
+        t = self._trace.trace
+        assert 0 <= n < t.get_num_events()
+
+        until = t.get_nth_event(n)
+        if until is None:
+            _l.error('Could not seek to event %d', n)
+            return
+
+        until = t.get_prev_exec_event(until)
+        if until is None:
+            _l.error('No execution event prior to event %d', n)
+            return
+
+        self._trace_dbg.state = t.replay(self._trace_dbg.state, until)
+        self._on_state_change()

--- a/angrmanagement/ui/dialogs/__init__.py
+++ b/angrmanagement/ui/dialogs/__init__.py
@@ -2,3 +2,4 @@ from .load_binary import LoadBinary
 from .load_plugins import LoadPlugins
 from .load_docker_prompt import LoadDockerPrompt
 from .preferences import Preferences
+from .breakpoint import BreakpointDialog

--- a/angrmanagement/ui/dialogs/breakpoint.py
+++ b/angrmanagement/ui/dialogs/breakpoint.py
@@ -21,7 +21,7 @@ class BreakpointDialog(QDialog):
         self.main_layout: QVBoxLayout = QVBoxLayout()
         self._type_radio_group: Optional[QButtonGroup] = None
         self._address_box: Optional[QAddressInput] = None
-        self._length_box: Optional[QLineEdit] = None
+        self._size_box: Optional[QLineEdit] = None
         self._comment_box: Optional[QLineEdit] = None
         self._status_label: Optional[QLabel] = None
         self._ok_button: Optional[QPushButton] = None
@@ -56,11 +56,11 @@ class BreakpointDialog(QDialog):
         layout.addWidget(self._address_box, row, 1)
         row += 1
 
-        layout.addWidget(QLabel('Length:', self), row, 0, Qt.AlignRight)
-        self._length_box = QLineEdit(self)
-        self._length_box.setText(f'{self.breakpoint.length:#x}')
-        self._length_box.textChanged.connect(self._on_length_changed)
-        layout.addWidget(self._length_box, row, 1)
+        layout.addWidget(QLabel('size:', self), row, 0, Qt.AlignRight)
+        self._size_box = QLineEdit(self)
+        self._size_box.setText(f'{self.breakpoint.size:#x}')
+        self._size_box.textChanged.connect(self._on_size_changed)
+        layout.addWidget(self._size_box, row, 1)
         row += 1
 
         layout.addWidget(QLabel('Comment:', self), row, 0, Qt.AlignRight)
@@ -91,9 +91,9 @@ class BreakpointDialog(QDialog):
         self._status_label.style().unpolish(self._status_label)
         self._status_label.style().polish(self._status_label)
 
-    def _get_length(self):
+    def _get_size(self):
         try:
-            return int(self._length_box.text(), 0)
+            return int(self._size_box.text(), 0)
         except ValueError:
             pass
         return None
@@ -104,18 +104,18 @@ class BreakpointDialog(QDialog):
 
 
     def _validate(self):
-        self._set_valid(bool(self._address_box.target is not None and self._get_length()))
+        self._set_valid(bool(self._address_box.target is not None and self._get_size()))
 
     def _on_address_changed(self, new_text):  # pylint: disable=unused-argument
         self._validate()
 
-    def _on_length_changed(self, new_text):  # pylint: disable=unused-argument
+    def _on_size_changed(self, new_text):  # pylint: disable=unused-argument
         self._validate()
 
     def _on_ok_clicked(self):
         self.breakpoint.type = BreakpointType(self._type_radio_group.checkedId())
         self.breakpoint.addr = self._address_box.target
-        self.breakpoint.length = self._get_length()
+        self.breakpoint.size = self._get_size()
         self.breakpoint.comment = self._comment_box.text()
         self.workspace.instance.breakpoint_mgr.breakpoints.am_event()
         self.accept()

--- a/angrmanagement/ui/dialogs/breakpoint.py
+++ b/angrmanagement/ui/dialogs/breakpoint.py
@@ -1,0 +1,121 @@
+from typing import Optional
+
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox, QGridLayout, \
+    QRadioButton, QButtonGroup
+
+from ...data.breakpoint import Breakpoint, BreakpointType
+from ..widgets import QAddressInput
+
+
+class BreakpointDialog(QDialog):
+    """
+    Dialog to edit breakpoints.
+    """
+
+    def __init__(self, breakpoint_: Breakpoint, workspace: 'Workspace', parent=None):
+        super().__init__(parent)
+        self.breakpoint = breakpoint_
+        self.workspace = workspace
+        self.setWindowTitle('Edit Breakpoint')
+        self.main_layout: QVBoxLayout = QVBoxLayout()
+        self._type_radio_group: Optional[QButtonGroup] = None
+        self._address_box: Optional[QAddressInput] = None
+        self._length_box: Optional[QLineEdit] = None
+        self._comment_box: Optional[QLineEdit] = None
+        self._status_label: Optional[QLabel] = None
+        self._ok_button: Optional[QPushButton] = None
+        self._init_widgets()
+        self.setLayout(self.main_layout)
+        self._validate()
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        layout = QGridLayout()
+        self.main_layout.addLayout(layout)
+        self._status_label = QLabel(self)
+
+        row = 0
+        layout.addWidget(QLabel('Break on:', self), row, 0, Qt.AlignRight)
+        self._type_radio_group = QButtonGroup(self)
+        self._type_radio_group.addButton(QRadioButton('Execute', self), BreakpointType.Execute.value)
+        self._type_radio_group.addButton(QRadioButton('Write', self), BreakpointType.Write.value)
+        self._type_radio_group.addButton(QRadioButton('Read', self), BreakpointType.Read.value)
+        for b in self._type_radio_group.buttons():
+            layout.addWidget(b, row, 1)
+            row += 1
+
+        self._type_radio_group.button(self.breakpoint.type.value).setChecked(True)
+
+        layout.addWidget(QLabel('Address:', self), row, 0, Qt.AlignRight)
+        self._address_box = QAddressInput(self._on_address_changed, self.workspace, parent=self,
+                                          default=f'{self.breakpoint.addr:#x}')
+        layout.addWidget(self._address_box, row, 1)
+        row += 1
+
+        layout.addWidget(QLabel('Length:', self), row, 0, Qt.AlignRight)
+        self._length_box = QLineEdit(self)
+        self._length_box.setText(f'{self.breakpoint.length:#x}')
+        self._length_box.textChanged.connect(self._on_length_changed)
+        layout.addWidget(self._length_box, row, 1)
+        row += 1
+
+        layout.addWidget(QLabel('Comment:', self), row, 0, Qt.AlignRight)
+        self._comment_box = QLineEdit(self)
+        self._comment_box.setText(self.breakpoint.comment)
+        layout.addWidget(self._comment_box, row, 1)
+        row += 1
+
+        self.main_layout.addWidget(self._status_label)
+
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
+
+    def _set_valid(self, valid: bool):
+        if not valid:
+            self._status_label.setText('Invalid')
+            self._status_label.setProperty('class', 'status_invalid')
+        else:
+            self._status_label.setText('Valid')
+            self._status_label.setProperty('class', 'status_valid')
+
+        self._ok_button.setEnabled(valid)
+        self._status_label.style().unpolish(self._status_label)
+        self._status_label.style().polish(self._status_label)
+
+    def _get_length(self):
+        try:
+            return int(self._length_box.text(), 0)
+        except ValueError:
+            pass
+        return None
+
+    #
+    # Event handlers
+    #
+
+
+    def _validate(self):
+        self._set_valid(bool(self._address_box.target is not None and self._get_length()))
+
+    def _on_address_changed(self, new_text):  # pylint: disable=unused-argument
+        self._validate()
+
+    def _on_length_changed(self, new_text):  # pylint: disable=unused-argument
+        self._validate()
+
+    def _on_ok_clicked(self):
+        self.breakpoint.type = BreakpointType(self._type_radio_group.checkedId())
+        self.breakpoint.addr = self._address_box.target
+        self.breakpoint.length = self._get_length()
+        self.breakpoint.comment = self._comment_box.text()
+        self.workspace.instance.breakpoint_mgr.breakpoints.am_event()
+        self.accept()

--- a/angrmanagement/ui/dialogs/breakpoint.py
+++ b/angrmanagement/ui/dialogs/breakpoint.py
@@ -56,7 +56,7 @@ class BreakpointDialog(QDialog):
         layout.addWidget(self._address_box, row, 1)
         row += 1
 
-        layout.addWidget(QLabel('size:', self), row, 0, Qt.AlignRight)
+        layout.addWidget(QLabel('Size:', self), row, 0, Qt.AlignRight)
         self._size_box = QLineEdit(self)
         self._size_box.setText(f'{self.breakpoint.size:#x}')
         self._size_box.textChanged.connect(self._on_size_changed)

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -154,7 +154,7 @@ class MainWindow(QMainWindow):
     # Dialogs
     #
 
-    def _open_mainfile_dialog(self):
+    def open_mainfile_dialog(self):
         # pylint: disable=assigning-non-slot
         # https://github.com/PyCQA/pylint/issues/3793
         file_path, _ = QFileDialog.getOpenFileName(self, "Open a binary", Conf.last_used_directory,
@@ -462,7 +462,7 @@ class MainWindow(QMainWindow):
         self.workspace.reload()
 
     def open_file_button(self):
-        file_path = self._open_mainfile_dialog()
+        file_path = self.open_mainfile_dialog()
         if not file_path:
             return
         self.load_file(file_path)
@@ -492,6 +492,10 @@ class MainWindow(QMainWindow):
         if not isurl(file_path):
             # file
             if os.path.isfile(file_path):
+                if file_path.endswith(".trace"):
+                    self.workspace.load_trace_from_path(file_path)
+                    return
+
                 self.workspace.instance.binary_path = file_path
                 self.workspace.instance.original_binary_path = file_path
                 if file_path.endswith(".adb"):
@@ -573,6 +577,12 @@ class MainWindow(QMainWindow):
             file_path = file_path + ".adb"
 
         return self._save_database(file_path)
+
+    def load_trace(self):
+        file_path, _ = QFileDialog.getOpenFileName(self, "Load trace", ".", "bintrace (*.trace)")
+        if not file_path:
+            return
+        self.workspace.load_trace_from_path(file_path)
 
     def preferences(self):
 

--- a/angrmanagement/ui/menus/disasm_insn_context_menu.py
+++ b/angrmanagement/ui/menus/disasm_insn_context_menu.py
@@ -36,7 +36,8 @@ class DisasmInsnContextMenu(Menu):
             MenuEntry('&Avoid in execution...', self._avoid_in_execution),
             MenuEntry('&Find in execution...', self._find_in_execution),
             MenuEntry('Add &hook...', self._add_hook),
-            MenuEntry('View function &documentation...', self._view_docs)
+            MenuEntry('View function &documentation...', self._view_docs),
+            MenuEntry('Add &breakpoint...', self._add_breakpoint)
         ])
 
     @property
@@ -58,6 +59,10 @@ class DisasmInsnContextMenu(Menu):
 
     def _find_in_execution(self):
         self._disasm_view.find_addr_in_exec(self.insn_addr)
+        self._disasm_view.refresh()
+
+    def _add_breakpoint(self):
+        self._disasm_view.add_breakpoint(self.insn_addr)
         self._disasm_view.refresh()
 
     def _add_hook(self):

--- a/angrmanagement/ui/menus/disasm_insn_context_menu.py
+++ b/angrmanagement/ui/menus/disasm_insn_context_menu.py
@@ -33,11 +33,11 @@ class DisasmInsnContextMenu(Menu):
             ])
         self.entries.extend([
             MenuEntry('E&xecute symbolically...', self._popup_newstate_dialog),
-            MenuEntry('&Avoid in execution...', self._avoid_in_execution),
-            MenuEntry('&Find in execution...', self._find_in_execution),
+            MenuEntry('&Avoid in execution', self._avoid_in_execution),
+            MenuEntry('&Find in execution', self._find_in_execution),
             MenuEntry('Add &hook...', self._add_hook),
             MenuEntry('View function &documentation...', self._view_docs),
-            MenuEntry('Add &breakpoint...', self._add_breakpoint)
+            MenuEntry('Add &breakpoint', self._add_breakpoint)
         ])
 
     @property
@@ -62,7 +62,7 @@ class DisasmInsnContextMenu(Menu):
         self._disasm_view.refresh()
 
     def _add_breakpoint(self):
-        self._disasm_view.add_breakpoint(self.insn_addr)
+        self._disasm_view.workspace.instance.breakpoint_mgr.add_exec_breakpoint(self.insn_addr)
         self._disasm_view.refresh()
 
     def _add_hook(self):

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -17,6 +17,8 @@ class FileMenu(Menu):
             MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL + Qt.Key_S)),
             MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
             MenuSeparator(),
+            MenuEntry('Load a new &trace...', main_window.load_trace),
+            MenuSeparator(),
             MenuEntry('&Preferences...', main_window.preferences, shortcut=QKeySequence(Qt.CTRL + Qt.Key_P)),
             MenuSeparator(),
             MenuEntry('E&xit', main_window.quit),

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -92,6 +92,7 @@ class ViewMenu(Menu):
             MenuEntry('&Types', main_window.workspace.show_types_view),
             MenuEntry('&Functions', main_window.workspace.show_functions_view),
             MenuEntry('&Traces', main_window.workspace.show_traces_view),
+            MenuEntry('&Trace Map', main_window.workspace.show_trace_map_view),
             MenuSeparator(),
             MenuEntry('Symbolic &Execution', main_window.workspace.show_symexec_view),
             MenuEntry('S&ymbolic States', main_window.workspace.show_states_view),

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -98,6 +98,7 @@ class ViewMenu(Menu):
             MenuEntry('&Interaction', main_window.workspace.show_interaction_view),
             MenuEntry('&Registers', main_window.workspace.show_registers_view),
             MenuEntry('&Stack', main_window.workspace.show_stack_view),
+            MenuEntry('&Breakpoints', main_window.workspace.show_breakpoints_view),
             MenuSeparator(),
             MenuEntry('&Console', main_window.workspace.show_console_view),
             MenuEntry('&Log', main_window.workspace.show_log_view),

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -91,6 +91,7 @@ class ViewMenu(Menu):
             MenuEntry('&Patches', main_window.workspace.show_patches_view),
             MenuEntry('&Types', main_window.workspace.show_types_view),
             MenuEntry('&Functions', main_window.workspace.show_functions_view),
+            MenuEntry('&Traces', main_window.workspace.show_traces_view),
             MenuSeparator(),
             MenuEntry('Symbolic &Execution', main_window.workspace.show_symexec_view),
             MenuEntry('S&ymbolic States', main_window.workspace.show_states_view),

--- a/angrmanagement/ui/toolbars/debug_toolbar.py
+++ b/angrmanagement/ui/toolbars/debug_toolbar.py
@@ -90,6 +90,10 @@ class DebugToolbar(Toolbar):
         self._new_dbg_sim.triggered.connect(self.workspace.main_window.open_newstate_dialog)
         self._new_dbg_menu.addAction(self._new_dbg_sim)
 
+        self._new_dbg_trace = QAction("New trace debugger", self._new_dbg_menu)
+        self._new_dbg_trace.triggered.connect(self.workspace.create_trace_debugger)
+        self._new_dbg_menu.addAction(self._new_dbg_trace)
+
         self._new_dbg_menu.aboutToShow.connect(self._update_new_dbg_list)
         self._cached_actions[self._start_act].setMenu(self._new_dbg_menu)
         self._update_new_dbg_list()
@@ -131,6 +135,7 @@ class DebugToolbar(Toolbar):
 
     def _update_new_dbg_list(self):
         self._new_dbg_sim.setDisabled(self.instance.project.am_none)
+        self._new_dbg_trace.setDisabled(self.instance.current_trace.am_none)
 
     def _update_dbg_list_combo(self, *args, **kwargs):   # pylint:disable=unused-argument
         dl = self.instance.debugger_list_mgr.debugger_list

--- a/angrmanagement/ui/views/__init__.py
+++ b/angrmanagement/ui/views/__init__.py
@@ -16,4 +16,5 @@ from .log_view import LogView
 from .registers_view import RegistersView
 from .stack_view import StackView
 from .traces_view import TracesView
+from .trace_map_view import TraceMapView
 from .breakpoints_view import BreakpointsView

--- a/angrmanagement/ui/views/__init__.py
+++ b/angrmanagement/ui/views/__init__.py
@@ -15,3 +15,4 @@ from .hex_view import HexView
 from .log_view import LogView
 from .registers_view import RegistersView
 from .stack_view import StackView
+from .traces_view import TracesView

--- a/angrmanagement/ui/views/__init__.py
+++ b/angrmanagement/ui/views/__init__.py
@@ -16,3 +16,4 @@ from .log_view import LogView
 from .registers_view import RegistersView
 from .stack_view import StackView
 from .traces_view import TracesView
+from .breakpoints_view import BreakpointsView

--- a/angrmanagement/ui/views/breakpoints_view.py
+++ b/angrmanagement/ui/views/breakpoints_view.py
@@ -1,0 +1,166 @@
+import logging
+from typing import Any, Optional, Sequence
+
+import PySide2
+from PySide2.QtCore import QAbstractTableModel, Qt, QSize
+from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
+
+from ...data.breakpoint import Breakpoint, BreakpointType, BreakpointManager
+from ..dialogs import BreakpointDialog
+from .view import BaseView
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class QBreakpointTableModel(QAbstractTableModel):
+    """
+    Breakpoint table model.
+    """
+
+    Headers = ['Type', 'Address', 'Length', 'Comment']
+    COL_TYPE = 0
+    COL_ADDR = 1
+    COL_LENGTH = 2
+    COL_COMMENT = 3
+
+    def __init__(self, breakpoint_mgr: BreakpointManager):
+        super().__init__()
+        self.breakpoint_mgr = breakpoint_mgr
+        self.breakpoint_mgr.breakpoints.am_subscribe(self._on_breakpoints_updated)
+
+    def _on_breakpoints_updated(self, **kwargs):  # pylint:disable=unused-argument
+        self.beginResetModel()
+        self.endResetModel()
+
+    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+        return len(self.breakpoint_mgr.breakpoints)
+
+    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+        return len(self.Headers)
+
+    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+        if role != Qt.DisplayRole:
+            return None
+        if section < len(self.Headers):
+            return self.Headers[section]
+        return None
+
+    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+        if not index.isValid():
+            return None
+        row = index.row()
+        if row >= len(self.breakpoint_mgr.breakpoints):
+            return None
+        col = index.column()
+        if role == Qt.DisplayRole:
+            return self._get_column_text(self.breakpoint_mgr.breakpoints[row], col)
+        else:
+            return None
+
+    def _get_column_text(self, bp: 'Breakpoint', column: int) -> str:
+        if column == self.COL_TYPE:
+            return {
+                BreakpointType.Execute: 'Execute',
+                BreakpointType.Read: 'Read',
+                BreakpointType.Write: 'Write'
+            }.get(bp.type)
+        elif column == self.COL_ADDR:
+            return f'{bp.addr:#08x}'
+        elif column == self.COL_LENGTH:
+            return f'{bp.length:#x}'
+        elif column == self.COL_COMMENT:
+            return bp.comment
+        else:
+            assert False
+
+
+class QBreakpointTableWidget(QTableView):
+    """
+    Breakpoint table widget.
+    """
+
+    def __init__(self, breakpoint_mgr: BreakpointManager, workspace: 'Workspace', *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.workspace = workspace
+        self.breakpoint_mgr = breakpoint_mgr
+
+        hheader = self.horizontalHeader()
+        hheader.setVisible(True)
+
+        vheader = self.verticalHeader()
+        vheader.setVisible(False)
+        vheader.setDefaultSectionSize(20)
+
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setHorizontalScrollMode(self.ScrollPerPixel)
+
+        self.model: QBreakpointTableModel = QBreakpointTableModel(self.breakpoint_mgr)
+        self.setModel(self.model)
+
+        for col in range(len(QBreakpointTableModel.Headers)):
+            hheader.setSectionResizeMode(col, QHeaderView.ResizeToContents)
+        hheader.setStretchLastSection(True)
+        self.doubleClicked.connect(self._on_cell_double_click)
+
+    #
+    # Events
+    #
+
+    def closeEvent(self, event):
+        self.model.shutdown()
+        super().closeEvent(event)
+
+    def contextMenuEvent(self, event):
+        selected_rows = {i.row() for i in self.selectedIndexes()}
+        breakpoints = [self.breakpoint_mgr.breakpoints[r] for r in selected_rows]
+        menu = QMenu("", self)
+        if len(breakpoints):
+            if len(breakpoints) == 1:
+                menu.addAction('Edit breakpoint', lambda: self.edit_breakpoint(breakpoints[0]))
+            menu.addAction('Remove breakpoint' + ('s' if len(breakpoints) > 1 else ''),
+                           lambda: self.remove_breakpoints(breakpoints))
+            menu.addSeparator()
+        menu.addAction('New breakpoint', self.new_breakpoint)
+        menu.exec_(event.globalPos())
+
+    def _on_cell_double_click(self, index):
+        self.edit_breakpoint(self.breakpoint_mgr.breakpoints[index.row()])
+
+    def new_breakpoint(self):
+        bp = Breakpoint(BreakpointType.Execute, 0)
+        if BreakpointDialog(bp, self.workspace, self).exec_():
+            self.breakpoint_mgr.add_breakpoint(bp)
+
+    def edit_breakpoint(self, breakpoint_: Breakpoint):
+        BreakpointDialog(breakpoint_, self.workspace, self).exec_()
+
+    def remove_breakpoints(self, breakpoints: Sequence[Breakpoint]):
+        for b in breakpoints:
+            self.breakpoint_mgr.remove_breakpoint(b)
+
+
+class BreakpointsView(BaseView):
+    """
+    Breakpoints table view.
+    """
+
+    def __init__(self, workspace, default_docking_position, *args, **kwargs):
+        super().__init__('breakpoints', workspace, default_docking_position, *args, **kwargs)
+        self.base_caption = 'Breakpoints'
+        self._tbl_widget: Optional[QBreakpointTableWidget] = None
+        self._init_widgets()
+        self.reload()
+
+    def reload(self):
+        pass
+
+    @staticmethod
+    def minimumSizeHint(*args, **kwargs):  # pylint:disable=unused-argument
+        return QSize(200, 200)
+
+    def _init_widgets(self):
+        vlayout = QVBoxLayout()
+        self._tbl_widget = QBreakpointTableWidget(self.workspace.instance.breakpoint_mgr, self.workspace)
+        vlayout.addWidget(self._tbl_widget)
+        self.setLayout(vlayout)

--- a/angrmanagement/ui/views/breakpoints_view.py
+++ b/angrmanagement/ui/views/breakpoints_view.py
@@ -18,10 +18,10 @@ class QBreakpointTableModel(QAbstractTableModel):
     Breakpoint table model.
     """
 
-    Headers = ['Type', 'Address', 'Length', 'Comment']
+    Headers = ['Type', 'Address', 'Size', 'Comment']
     COL_TYPE = 0
     COL_ADDR = 1
-    COL_LENGTH = 2
+    COL_SIZE = 2
     COL_COMMENT = 3
 
     def __init__(self, breakpoint_mgr: BreakpointManager):
@@ -67,8 +67,8 @@ class QBreakpointTableModel(QAbstractTableModel):
             }.get(bp.type)
         elif column == self.COL_ADDR:
             return f'{bp.addr:#08x}'
-        elif column == self.COL_LENGTH:
-            return f'{bp.length:#x}'
+        elif column == self.COL_SIZE:
+            return f'{bp.size:#x}'
         elif column == self.COL_COMMENT:
             return bp.comment
         else:

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -32,7 +32,7 @@ from ..menus.disasm_label_context_menu import DisasmLabelContextMenu
 from .view import SynchronizedView
 from ..widgets import QFindAddrAnnotation, QAvoidAddrAnnotation, QBlockAnnotations
 from ..widgets.qblock_code import QVariableObj
-from ...ui.widgets.qinst_annotation import QHookAnnotation
+from ...ui.widgets.qinst_annotation import QHookAnnotation, QBreakAnnotation
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins import VariableManager
@@ -682,6 +682,9 @@ class DisassemblyView(SynchronizedView):
     def find_addr_in_exec(self, addr):
         self.workspace._get_or_create_symexec_view().find_addr_in_exec(addr)
 
+    def add_breakpoint(self, addr):
+        self.workspace.instance.breakpoints.add(addr)
+
     def run_induction_variable_analysis(self):
         if self._flow_graph.induction_variable_analysis:
             self._flow_graph.induction_variable_analysis = None
@@ -706,6 +709,9 @@ class DisassemblyView(SynchronizedView):
                     addr_to_annotations[addr].append(QFindAddrAnnotation(addr, qsimgrs))
                 if addr in qsimgrs.avoid_addrs:
                     addr_to_annotations[addr].append(QAvoidAddrAnnotation(addr, qsimgrs))
+                if addr in self.workspace.instance.breakpoints:
+                    addr_to_annotations[addr].append(QBreakAnnotation(addr))
+
         return QBlockAnnotations(addr_to_annotations, parent=qblock, disasm_view=self)
 
     def update_highlight_regions_for_synchronized_views(self, **kwargs):  # pylint: disable=unused-argument

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -15,7 +15,6 @@ from ...data.instance import ObjectContainer
 from ...utils import locate_function
 from ...data.function_graph import FunctionGraph
 from ...data.highlight_region import SynchronizedHighlightRegion
-from ...data.breakpoint import Breakpoint, BreakpointType
 from ...logic.disassembly import JumpHistory, InfoDock
 from ..widgets import QDisassemblyGraph, QDisasmStatusBar, QLinearDisassembly, QFeatureMap,\
     QLinearDisassemblyView, DisassemblyLevel

--- a/angrmanagement/ui/views/trace_map_view.py
+++ b/angrmanagement/ui/views/trace_map_view.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+from PySide2.QtWidgets import QVBoxLayout
+from PySide2.QtCore import QSize
+
+from ..views import BaseView
+from ..widgets import QTraceMap
+
+
+class TraceMapView(BaseView):
+    """
+    View container for QTraceMap.
+    """
+
+    def __init__(self, workspace: 'Workspace', default_docking_position, *args, **kwargs):
+        super().__init__('tracemap', workspace, default_docking_position, *args, **kwargs)
+        self.base_caption: str = 'Trace Map'
+        self.inner_widget: Optional[QTraceMap] = None
+        self._init_widgets()
+
+    @staticmethod
+    def minimumSizeHint(*args, **kwargs):  # pylint:disable=unused-argument
+        return QSize(25, 25)
+
+    @staticmethod
+    def sizeHint():
+        return QSize(25, 25)
+
+    def _init_widgets(self):
+        """
+        Initialize widgets for this view.
+        """
+        self.inner_widget = QTraceMap(self.workspace, parent=self)
+        lyt = QVBoxLayout()
+        lyt.addWidget(self.inner_widget)
+        self.setLayout(lyt)

--- a/angrmanagement/ui/views/traces_view.py
+++ b/angrmanagement/ui/views/traces_view.py
@@ -1,0 +1,141 @@
+import logging
+from typing import Any, Optional
+
+import PySide2
+from PySide2.QtCore import QAbstractTableModel, Qt, QSize
+from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
+
+from .view import BaseView
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class QTraceTableModel(QAbstractTableModel):
+    """
+    Trace table model.
+    """
+
+    Headers = ['Source']
+    COL_SOURCE = 0
+
+    def __init__(self, instance):
+        super().__init__()
+        self.instance = instance
+        self.instance.current_trace.am_subscribe(self._on_traces_updated)
+        self.instance.traces.am_subscribe(self._on_traces_updated)
+
+    def shutdown(self):
+        self.instance.current_trace.am_unsubscribe(self._on_traces_updated)
+        self.instance.traces.am_unsubscribe(self._on_traces_updated)
+
+    def _on_traces_updated(self, **kwargs):  # pylint:disable=unused-argument
+        self.beginResetModel()
+        self.endResetModel()
+
+    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+        return len(self.instance.traces)
+
+    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+        return len(self.Headers)
+
+    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+        if role != Qt.DisplayRole:
+            return None
+        if section < len(self.Headers):
+            return self.Headers[section]
+        return None
+
+    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+        if not index.isValid():
+            return None
+        row = index.row()
+        if row >= len(self.instance.traces):
+            return None
+        col = index.column()
+        if role == Qt.DisplayRole:
+            return self._get_column_text(self.instance.traces[row], col)
+        else:
+            return None
+
+    def _get_column_text(self, trace: 'Trace', col: int) -> Any:
+        if col == QTraceTableModel.COL_SOURCE:
+            return trace.source + (' (Current)' if self.instance.current_trace.am_obj is trace else '')
+        else:
+            return None
+
+
+class QTraceTableWidget(QTableView):
+    """
+    Trace table widget.
+    """
+
+    def __init__(self, instance, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.instance = instance
+
+        hheader = self.horizontalHeader()
+        hheader.setVisible(True)
+        hheader.setStretchLastSection(True)
+
+        vheader = self.verticalHeader()
+        vheader.setVisible(False)
+        vheader.setDefaultSectionSize(20)
+
+        self.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.setHorizontalScrollMode(self.ScrollPerPixel)
+
+        self.model: QTraceTableModel = QTraceTableModel(instance)
+        self.setModel(self.model)
+
+        hheader.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+
+    #
+    # Events
+    #
+
+    def closeEvent(self, event):
+        self.model.shutdown()
+        super().closeEvent(event)
+
+    def contextMenuEvent(self, event):
+        selected_rows = {i.row() for i in self.selectedIndexes()}
+        traces = [self.instance.traces[r] for r in selected_rows]
+        if len(traces):
+            menu = QMenu("", self)
+            if len(traces) == 1:
+                if not self.instance.workspace.is_current_trace(traces[0]):
+                    menu.addAction('Use as current trace', lambda: self.instance.workspace.set_current_trace(traces[0]))
+
+            def remove_selected_traces():
+                for t in traces:
+                    self.instance.workspace.remove_trace(t)
+            menu.addAction('Remove trace' + ('s' if len(traces) > 1 else ''), remove_selected_traces)
+            menu.exec_(event.globalPos())
+
+
+class TracesView(BaseView):
+    """
+    Traces table view.
+    """
+
+    def __init__(self, workspace, default_docking_position, *args, **kwargs):
+        super().__init__('traces', workspace, default_docking_position, *args, **kwargs)
+
+        self.base_caption = 'Traces'
+        self._tbl_widget: Optional[QTraceTableWidget] = None
+        self._init_widgets()
+        self.reload()
+
+    def reload(self):
+        pass
+
+    @staticmethod
+    def minimumSizeHint(*args, **kwargs):  # pylint:disable=unused-argument
+        return QSize(200, 200)
+
+    def _init_widgets(self):
+        vlayout = QVBoxLayout()
+        self._tbl_widget = QTraceTableWidget(self.workspace.instance, self)
+        vlayout.addWidget(self._tbl_widget)
+        self.setLayout(vlayout)

--- a/angrmanagement/ui/widgets/__init__.py
+++ b/angrmanagement/ui/widgets/__init__.py
@@ -13,3 +13,4 @@ from .qlinear_viewer import QLinearDisassembly, QLinearDisassemblyView
 # other widgets
 from .qfeature_map import QFeatureMap
 from .qinst_annotation import QFindAddrAnnotation, QAvoidAddrAnnotation, QHookAnnotation, QBlockAnnotations
+from .qtrace_map import QTraceMap

--- a/angrmanagement/ui/widgets/qinst_annotation.py
+++ b/angrmanagement/ui/widgets/qinst_annotation.py
@@ -203,8 +203,9 @@ class QBreakAnnotation(QInstructionAnnotation):
     foreground_color = QColor(220, 220, 220)
     text = "break"
 
-    def __init__(self, addr, *args, **kwargs):
-        super().__init__(addr, self.text, *args, **kwargs)
+    def __init__(self, bp, *args, **kwargs):
+        super().__init__(bp.addr, self.text, *args, **kwargs)
+        self.bp = bp
 
     def contextMenuEvent(self, event): #pylint: disable=unused-argument
         menu = QMenu()
@@ -212,8 +213,7 @@ class QBreakAnnotation(QInstructionAnnotation):
         menu.exec_(QCursor.pos())
 
     def delete(self):
-        self.disasm_view.workspace.instance.breakpoints.remove(self.addr)
-        self.disasm_view.refresh()
+        self.disasm_view.workspace.instance.breakpoint_mgr.remove_breakpoint(self.bp)
 
 
 class QAvoidAddrAnnotation(QExploreAnnotation):

--- a/angrmanagement/ui/widgets/qinst_annotation.py
+++ b/angrmanagement/ui/widgets/qinst_annotation.py
@@ -194,6 +194,28 @@ class QFindAddrAnnotation(QExploreAnnotation):
         self.disasm_view.refresh()
 
 
+class QBreakAnnotation(QInstructionAnnotation):
+    """
+    An instruction annotation for address breakpoint.
+    It is added to the annotation list by fetch_qblock_annotations
+    """
+    background_color = QColor(200, 10, 10)
+    foreground_color = QColor(220, 220, 220)
+    text = "break"
+
+    def __init__(self, addr, *args, **kwargs):
+        super().__init__(addr, self.text, *args, **kwargs)
+
+    def contextMenuEvent(self, event): #pylint: disable=unused-argument
+        menu = QMenu()
+        menu.addAction("Delete", self.delete)
+        menu.exec_(QCursor.pos())
+
+    def delete(self):
+        self.disasm_view.workspace.instance.breakpoints.remove(self.addr)
+        self.disasm_view.refresh()
+
+
 class QAvoidAddrAnnotation(QExploreAnnotation):
     """
     An instruction annotation for explore avoid address.

--- a/angrmanagement/ui/widgets/qtrace_map.py
+++ b/angrmanagement/ui/widgets/qtrace_map.py
@@ -27,7 +27,6 @@ class TraceMapItem(QGraphicsItem):
         self.workspace = workspace
         self.instance = self.workspace.instance
 
-        self.scale: float = 1.0
         self._width: int = 1
         self._height: int = 1
 
@@ -149,7 +148,7 @@ class TraceMapItem(QGraphicsItem):
         pos_x = int(pos_x - tri_width / 2)  # Center drawing
         center = pos_x + int(tri_width / 2)
         pos_y = 0
-        frontier_width = 200 * self.scale
+        frontier_width = int(0.15 * max(self.width, self.height))
 
         if show_frontier:
             # Draw frontier gradients
@@ -428,7 +427,6 @@ class QTraceMapView(QGraphicsView):
             # Only resize to map to viewport width if scale is at base level to not disturb preferred size
             self._base_width = w
 
-        self.fm.scale = self._scale
         self.fm.set_width(int(self._base_width * self._scale))
         self.fm.set_height(h)
         self.fm.refresh()

--- a/angrmanagement/ui/widgets/qtrace_map.py
+++ b/angrmanagement/ui/widgets/qtrace_map.py
@@ -1,0 +1,474 @@
+from typing import Optional, Sequence
+import logging
+
+from PySide2.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItem, QGraphicsRectItem, \
+    QGraphicsPolygonItem, QGraphicsLineItem
+from PySide2.QtGui import QBrush, QPen, QPolygonF, QLinearGradient, QColor
+from PySide2.QtCore import Qt, QRectF, QSize, QPointF, QPoint, QEvent
+
+from ...config import Conf
+from ...logic.debugger import DebuggerWatcher
+from ...logic.debugger.bintrace import BintraceDebugger
+
+
+l = logging.getLogger(name=__name__)
+
+
+class TraceMapItem(QGraphicsItem):
+    """
+    Trace map item to be rendered in graphics scene.
+    """
+    ZVALUE_CHECKPOINT = 1
+    ZVALUE_ADDR = 2
+    ZVALUE_HOVER = 3
+
+    def __init__(self, workspace, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.workspace = workspace
+        self.instance = self.workspace.instance
+
+        self.scale: float = 1.0
+        self._width: int = 1
+        self._height: int = 1
+
+        self._addr: int = 0
+        self._indicator_items: Sequence[QGraphicsItem] = []
+
+        self._hover_addr: Optional[int] = None
+        self._hover_items: Sequence[QGraphicsItem] = []
+
+        self._checkpoints = []
+        self._checkpoint_items: Sequence[QGraphicsItem] = []
+
+        self._total_size: int = 0
+        self._pressed: bool = False
+
+        self.setAcceptHoverEvents(True)
+        self._register_events()
+
+    def refresh(self):
+        self._gen_current_indicator()
+        self._gen_checkpoint_indicators()
+        self._gen_hover_indicator()
+
+    def _register_events(self):
+        self._dbg_watcher = DebuggerWatcher(self.on_debugger_state_updated, self.instance.debugger_mgr.debugger)
+        self.on_debugger_state_updated()
+
+    def on_debugger_state_updated(self):
+        self._addr = 0
+        self._total_size = 0
+        self._checkpoints = []
+
+        if isinstance(self._dbg_watcher.debugger.am_obj, BintraceDebugger):
+            # FIXME: Expose trace info as TraceDebugger abstraction between Debugger<>BintraceDebugger
+            dbg = self._dbg_watcher.debugger.am_obj
+            t = dbg._trace.trace
+            s = dbg._trace_dbg.state
+            if s and s.event_count >= 0:
+                self._addr = s.event_count
+                self._total_size = t.get_num_events()
+                self._checkpoints = [s.event_count for s in t.checkpoints]
+
+        self.refresh()
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    def set_width(self, width: int):
+        """
+        Set the desired width of the trace map in scene units.
+        """
+        self.prepareGeometryChange()
+        self._width = width
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    def set_height(self, height: int):
+        """
+        Set the desired height of the trace map in scene units.
+        """
+        self.prepareGeometryChange()
+        self._height = height
+
+    def paint(self, painter, option, widget):
+        """
+        Paint the trace map.
+        """
+        # Drawn by child items
+
+    def boundingRect(self) -> QRectF:
+        """
+        Return the bounding dimensions of this item.
+        """
+        return QRectF(0, 0, self._width, self._height)
+
+    def _get_pos_from_addr(self, addr: int) -> Optional[int]:
+        """
+        Get scene X coordinate from address, or None if it could not be mapped.
+        """
+        if self._total_size == 0 or addr > self._total_size:
+            return None
+        return int(addr / self._total_size * self._width)
+
+    def _get_addr_from_pos(self, pos: int) -> Optional[int]:
+        """
+        Get address from scene X coordinate, or None if it could not be mapped.
+        """
+        offset = int(pos * self._total_size // self._width)
+        return offset
+
+    def _get_offset_size_rect(self, offset: int, size: int) -> QRectF:
+        """
+        Given a byte offset `offset` and number of bytes `size`, get a rect to draw.
+        """
+        if self._total_size == 0:
+            return None
+        x = offset / self._total_size * self._width
+        width = size / self._total_size * self._width
+        return QRectF(x, 0, width, self._height)
+
+    def _create_line_indicator(self, addr, item_map, color=Qt.yellow, show_frontier=False, z=None, z_frontier=None):
+        """
+        Generate a cursor at a given address.
+        """
+        pos_x = self._get_pos_from_addr(addr)
+        if pos_x is None:
+            return
+
+        pen = QPen(color)
+        brush = QBrush(color)
+        height = self.height
+
+        tri_width = 7
+        tri_height = 4
+
+        pos_x = int(pos_x - tri_width / 2)  # Center drawing
+        center = pos_x + int(tri_width / 2)
+        pos_y = 0
+        frontier_width = 200 * self.scale
+
+        if show_frontier:
+            # Draw frontier gradients
+            r = QRectF(center - frontier_width, pos_y, frontier_width, height)
+            bg = QLinearGradient(r.topLeft(), r.topRight())
+            color = Qt.red
+            top_color = QColor(color)
+            top_color.setAlpha(0)
+            bg.setColorAt(0, top_color)
+            bottom_color = QColor(color)
+            bottom_color.setAlpha(180)
+            bg.setColorAt(1, bottom_color)
+
+            i = QGraphicsRectItem(r, parent=self)
+            i.setPen(Qt.NoPen)
+            i.setBrush(bg)
+            if z_frontier is not None:
+                i.setZValue(z_frontier)
+            item_map.append(i)
+
+            r = QRectF(center, pos_y, frontier_width, height)
+            bg = QLinearGradient(r.topLeft(), r.topRight())
+            color = Qt.blue
+            top_color = QColor(color)
+            bg.setColorAt(0, top_color)
+            bottom_color = QColor(color)
+            bottom_color.setAlpha(0)
+            bg.setColorAt(1, bottom_color)
+
+            i = QGraphicsRectItem(r, parent=self)
+            i.setPen(Qt.NoPen)
+            i.setBrush(bg)
+            if z_frontier is not None:
+                i.setZValue(z_frontier)
+            item_map.append(i)
+
+        # Draw line
+        i = QGraphicsLineItem(center, 0, center, height, parent=self)
+        i.setPen(pen)
+        if z is not None:
+            i.setZValue(z)
+        item_map.append(i)
+
+        # Draw top and bottom triangles
+        t = QPolygonF()
+        t.append(QPointF(pos_x, pos_y))
+        t.append(QPointF(pos_x + tri_width - 1, pos_y))
+        t.append(QPointF(center, pos_y + tri_height - 1))
+        t.append(QPointF(pos_x, pos_y))
+
+        pos_y += height - 1
+        b = QPolygonF()
+        b.append(QPointF(pos_x, pos_y))
+        b.append(QPointF(center, pos_y - tri_height + 1))
+        b.append(QPointF(pos_x + tri_width - 1, pos_y))
+        b.append(QPointF(pos_x, pos_y))
+
+        for i in [QGraphicsPolygonItem(t, parent=self),
+                  QGraphicsPolygonItem(b, parent=self)]:
+            i.setPen(pen)
+            i.setBrush(brush)
+            if z is not None:
+                i.setZValue(z)
+            item_map.append(i)
+
+    def _gen_checkpoint_indicators(self):
+        """
+        Create checkpoint indicators.
+        """
+        scene = self.scene()
+        for item in self._checkpoint_items:
+            scene.removeItem(item)
+        self._checkpoint_items.clear()
+
+        color = QColor(Qt.green)
+
+        for checkpoint_addr in self._checkpoints:
+            self._create_line_indicator(checkpoint_addr, self._checkpoint_items, color=color,
+                                        z=self.ZVALUE_CHECKPOINT)
+
+    def _gen_current_indicator(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Create current address indicator.
+        """
+        scene = self.scene()
+        for item in self._indicator_items:
+            scene.removeItem(item)
+        self._indicator_items.clear()
+
+        self._create_line_indicator(self._addr, self._indicator_items, show_frontier=True, z=self.ZVALUE_ADDR)
+
+    def _gen_hover_indicator(self):
+        """
+        Create the hovered address indicator.
+        """
+        scene = self.scene()
+        for item in self._hover_items:
+            scene.removeItem(item)
+        self._hover_items.clear()
+
+        if self._hover_addr is not None:
+            self._create_line_indicator(self._hover_addr, self._hover_items, color=Qt.gray, z=self.ZVALUE_HOVER)
+
+    def _remove_hover_indicators(self):
+        """
+        Remove active hover items, if set.
+        """
+        if self._hover_addr is not None:
+            self._hover_addr = None
+            self._gen_hover_indicator()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            pos = event.pos()
+            offset = pos.x()
+            self.select_offset(offset)
+            self._pressed = True
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._pressed = False
+
+    def mouseMoveEvent(self, event):
+        if self._pressed:
+            pos = event.pos()
+            offset = pos.x()
+            self.select_offset(offset)
+        else:
+            super().mouseMoveEvent(event)
+
+    def on_mouse_move_event_from_view(self, point: QPointF):
+        """
+        Add hover items.
+        """
+        self._remove_hover_indicators()
+        self._hover_addr = self._get_addr_from_pos(point.x())
+        self._gen_hover_indicator()
+
+    def hoverLeaveEvent(self, event):  # pylint: disable=unused-argument
+        self._remove_hover_indicators()
+
+    def select_offset(self, offset):
+        """
+        Update listeners with new desired location.
+        """
+        if not isinstance(self._dbg_watcher.debugger.am_obj, BintraceDebugger):
+            return
+
+        addr = self._get_addr_from_pos(offset)
+        if addr is None:
+            return
+
+        dbg = self._dbg_watcher.debugger.am_obj
+        dbg.replay_to_nth_event(addr)
+
+
+class QTraceMapView(QGraphicsView):
+    """
+    Graphics view for trace map scene. The scene will rotate based on dimensions of the viewport to support horizontal
+    and vertical orientations.
+    """
+
+    def __init__(self, workspace, parent=None):
+        super().__init__(parent)
+        self.workspace = workspace
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setMouseTracking(True)
+        self._scene = QGraphicsScene(parent=self)
+        self.setScene(self._scene)
+        self.fm: TraceMapItem = TraceMapItem(self.workspace)
+        self._scale: float = 1.0
+        self._scene.addItem(self.fm)
+        self._orientation: str = 'horizontal'
+        self._base_width: int = 0
+
+        self.setBackgroundBrush(Conf.palette_base)
+        self.setResizeAnchor(QGraphicsView.NoAnchor)
+        self.setTransformationAnchor(QGraphicsView.NoAnchor)
+        self.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        self.update_size()
+
+    def mouseMoveEvent(self, event):
+        """
+        Handle mouse move events.
+
+        Mouse move events whilst not holding a mouse button will not be propagated down to QGraphicsItems, so we catch
+        the movement events here in the view and forward them to the trace map item.
+        """
+        scene_pt = self.mapToScene(event.pos().x(), event.pos().y())
+        item_pt = self.fm.mapFromScene(scene_pt)
+        self.fm.on_mouse_move_event_from_view(item_pt)
+        super().mouseMoveEvent(event)
+
+    def wheelEvent(self, event):
+        """
+        Handle wheel events to scale and translate the trace map.
+        """
+        if event.modifiers() & Qt.ControlModifier == Qt.ControlModifier:
+            self.adjust_viewport_scale(1.25 if event.delta() > 0 else 1/1.25,
+                                       QPoint(event.pos().x(), event.pos().y()))
+        else:
+            self.translate(100 * (-1 if event.delta() < 0 else 1), 0)
+            super().wheelEvent(event)
+
+    def resizeEvent(self, event):  # pylint: disable=unused-argument
+        """
+        Handle view resize events, updating the trace map size accordingly.
+        """
+        self.update_size()
+
+    def adjust_viewport_scale(self, scale: Optional[float] = None, point: Optional[QPoint] = None):
+        """
+        Adjust viewport scale factor.
+        """
+        if point is None:
+            point = QPoint(0, 0)
+        point_rel = self.mapToScene(point).x() / self.fm.width
+
+        if scale is None:
+            self._scale = 1.0
+        else:
+            self._scale = max(self._scale * scale, 1.0)
+
+        self.update_size()
+        self.translate(int(self.mapToScene(point).x() - point_rel * self.fm.width), 0)
+
+    def keyPressEvent(self, event):
+        """
+        Handle key events.
+        """
+        if event.modifiers() & Qt.ControlModifier == Qt.ControlModifier:
+            if event.key() == Qt.Key_0:
+                self.adjust_viewport_scale()
+                event.accept()
+                return
+            elif event.key() == Qt.Key_Equal:
+                self.adjust_viewport_scale(1.25)
+                event.accept()
+                return
+            elif event.key() == Qt.Key_Minus:
+                self.adjust_viewport_scale(1/1.25)
+                event.accept()
+                return
+        super().keyPressEvent(event)
+
+    def changeEvent(self, event: QEvent):
+        """
+        Redraw on color scheme update.
+        """
+        if event.type() == QEvent.StyleChange:
+            self.setBackgroundBrush(Conf.palette_base)
+            self.fm.refresh()
+
+    def update_size(self):
+        """
+        Resize map.
+        """
+        rotation = 0
+        vg = self.viewport().geometry()
+        if vg.width() > vg.height():
+            if self._orientation != 'horizontal':
+                rotation = -90
+            self._orientation = 'horizontal'
+            w, h = vg.width(), vg.height()
+        else:
+            if self._orientation != 'vertical':
+                rotation = 90
+            self._orientation = 'vertical'
+            w, h = vg.height(), vg.width()
+
+        if rotation:
+            self._scale = 1.0
+
+        if self._scale <= 1.0:
+            # Only resize to map to viewport width if scale is at base level to not disturb preferred size
+            self._base_width = w
+
+        self.fm.scale = self._scale
+        self.fm.set_width(int(self._base_width * self._scale))
+        self.fm.set_height(h)
+        self.fm.refresh()
+        self.setSceneRect(QRectF(0, 0, self.fm.width, self.fm.height))
+        if rotation:
+            self.rotate(rotation)
+
+
+class QTraceMap(QWidget):
+    """
+    Map of the current trace, with debugger playback position and checkpoint indicators.
+    """
+
+    def __init__(self, workspace, parent=None):
+        super().__init__(parent)
+        self.workspace = workspace
+        self.view: QTraceMapView = None
+        self._init_widgets()
+
+    def sizeHint(self):  # pylint:disable=no-self-use
+        return QSize(25, 25)
+
+    def minimumSizeHint(self):  # pylint:disable=no-self-use
+        return QSize(25, 25)
+
+    #
+    # Public methods
+    #
+
+    def refresh(self):
+        if self.view is not None:
+            self.view.fm.refresh()
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        self.view = QTraceMapView(self.workspace, self)
+        layout = QHBoxLayout()
+        layout.addWidget(self.view)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -6,6 +6,7 @@ import traceback
 from PySide2.QtWidgets import QMessageBox
 from angr.knowledge_plugins.functions.function import Function
 from angr import StateHierarchy
+from cle import SymbolType
 
 from ..logic.debugger import DebuggerWatcher
 from ..logic.debugger.bintrace import BintraceDebugger
@@ -304,7 +305,7 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
-    def add_breakpoint(self, obj: Union[str, int], type_: str = 'execute', size: Optional[int] = None):
+    def add_breakpoint(self, obj: Union[str, int], type_: Optional[str] = None, size: Optional[int] = None):
         """
         Convenience function to add a breakpoint.
         """
@@ -318,8 +319,15 @@ class Workspace:
             addr = sym.rebased_addr
             if not size:
                 size = sym.size
+            if not type_:
+                if sym.type == SymbolType.TYPE_FUNCTION:
+                    type_ = 'execute'
+                else:
+                    type_ = 'write'
         elif type(obj) is Function:
             addr = obj.addr
+            if not type_:
+                type_ = 'execute'
         else:
             _l.error('Unexpected target object type. Expected int | str | Function')
             return
@@ -328,6 +336,7 @@ class Workspace:
             size = 1
 
         bp_type_map = {
+            None: BreakpointType.Execute,
             'execute': BreakpointType.Execute,
             'write': BreakpointType.Write,
             'read': BreakpointType.Read,

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -490,6 +490,7 @@ class Workspace:
                 QMessageBox.warning(None, "Unable to find target binary!",
                                           f"Unable to find the traced binary at: \n\n{thing}\n\n"
                                           "Please select target binary.")
+                thing = None
 
         if not thing:
             thing = self.main_window.open_mainfile_dialog()

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -17,7 +17,7 @@ from ..data.jobs.loading import LoadBinaryJob
 from ..data.jobs import CodeTaggingJob, PrototypeFindingJob, VariableRecoveryJob, FlirtSignatureRecognitionJob
 from .views import (FunctionsView, DisassemblyView, SymexecView, StatesView, StringsView, ConsoleView, CodeView,
                     InteractionView, PatchesView, DependencyView, ProximityView, TypesView, HexView, LogView,
-                    RegistersView, StackView, TracesView)
+                    RegistersView, StackView, TracesView, BreakpointsView)
 from .view_manager import ViewManager
 from .menus.disasm_insn_context_menu import DisasmInsnContextMenu
 
@@ -569,6 +569,11 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
+    def show_breakpoints_view(self):
+        view = self._get_or_create_breakpoints_view()
+        self.raise_view(view)
+        view.setFocus()
+
     def show_console_view(self):
         view = self._get_or_create_console_view()
         self.raise_view(view)
@@ -751,6 +756,16 @@ class Workspace:
 
         if view is None:
             view = TracesView(self, 'center')
+            self.add_view(view)
+
+        return view
+
+    def _get_or_create_breakpoints_view(self) -> BreakpointsView:
+        # Take the first breakpoints view
+        view = self.view_manager.first_view_in_category("breakpoints")
+
+        if view is None:
+            view = BreakpointsView(self, 'center')
             self.add_view(view)
 
         return view

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -17,7 +17,7 @@ from ..data.jobs.loading import LoadBinaryJob
 from ..data.jobs import CodeTaggingJob, PrototypeFindingJob, VariableRecoveryJob, FlirtSignatureRecognitionJob
 from .views import (FunctionsView, DisassemblyView, SymexecView, StatesView, StringsView, ConsoleView, CodeView,
                     InteractionView, PatchesView, DependencyView, ProximityView, TypesView, HexView, LogView,
-                    RegistersView, StackView, TracesView, BreakpointsView)
+                    RegistersView, StackView, TracesView, TraceMapView, BreakpointsView)
 from .view_manager import ViewManager
 from .menus.disasm_insn_context_menu import DisasmInsnContextMenu
 
@@ -559,6 +559,11 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
+    def show_trace_map_view(self):
+        view = self._get_or_create_trace_map_view()
+        self.raise_view(view)
+        view.setFocus()
+
     def show_registers_view(self):
         view = self._get_or_create_registers_view()
         self.raise_view(view)
@@ -756,6 +761,16 @@ class Workspace:
 
         if view is None:
             view = TracesView(self, 'center')
+            self.add_view(view)
+
+        return view
+
+    def _get_or_create_trace_map_view(self) -> TraceMapView:
+        # Take the first tracemap view
+        view = self.view_manager.first_view_in_category("tracemap")
+
+        if view is None:
+            view = TraceMapView(self, 'top')
             self.add_view(view)
 
         return view

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -304,7 +304,7 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
-    def add_breakpoint(self, obj: Union[str, int], type_: str = 'execute', length: Optional[int] = None):
+    def add_breakpoint(self, obj: Union[str, int], type_: str = 'execute', size: Optional[int] = None):
         """
         Convenience function to add a breakpoint.
         """
@@ -316,16 +316,16 @@ class Workspace:
                 _l.error("Couldn't resolve '%s'", obj)
                 return
             addr = sym.rebased_addr
-            if not length:
-                length = sym.size
+            if not size:
+                size = sym.size
         elif type(obj) is Function:
             addr = obj.addr
         else:
             _l.error('Unexpected target object type. Expected int | str | Function')
             return
 
-        if not length:
-            length = 1
+        if not size:
+            size = 1
 
         bp_type_map = {
             'execute': BreakpointType.Execute,
@@ -337,7 +337,7 @@ class Workspace:
                      type_, ' | '.join(bp_type_map.keys()))
             return
 
-        bp = Breakpoint(bp_type_map[type_], addr, length)
+        bp = Breakpoint(bp_type_map[type_], addr, size)
         self.instance.breakpoint_mgr.add_breakpoint(bp)
 
     def set_comment(self, addr, comment_text):

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -308,6 +308,12 @@ class Workspace:
     def add_breakpoint(self, obj: Union[str, int], type_: Optional[str] = None, size: Optional[int] = None):
         """
         Convenience function to add a breakpoint.
+
+        Examples:
+        - `workspace.add_breakpoint(0x1234)` sets an execution breakpoint on address 0x1234
+        - `workspace.add_breakpoint('main')` sets an execution breakpoint on `main` function
+        - `workspace.add_breakpoint('global_value')` sets a write breakpoint on `global_value`
+        - `workspace.add_breakpoint('global_value', 'read', 1)` sets a 1-byte read breakpoint on `global_value`
         """
         if type(obj) is int:
             addr = obj

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'qtterm',
         'getmac',
         'QtAwesome',
-
     ],
     extras_require={
         'bintrace': ['bintrace']

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,9 @@ setup(
         'qtterm',
         'getmac',
         'QtAwesome',
-    ]
+
+    ],
+    extras_require={
+        'bintrace': ['bintrace']
+    }
 )


### PR DESCRIPTION
This PR:
* Is distinctly separate from and currently co-exists with existing trace plugin.
* Adds support for loading program execution traces collected with [bintrace](https://github.com/mborgerson/bintrace), a trace collection tool (based on QEMU) + analysis library.
  * Not a hard dependency. If bintrace isn't installed, angr-management will still run.
  * Traces can be loaded from <kbd>File</kbd>&rarr;<kbd>Load a new trace...</kbd> or by launching angr-management with the trace path as an argument.
  * If a project doesn't exist, an attempt will be made to create a project for the traced binary.
  * Adds a **Traces** view to manage traces. Currently 'managing' means setting one as current to create debuggers from it, or removing a loaded trace from the trace list.
* Adds a debugger backend to step through traces with typical debugging control.
  * bintrace is the only supported trace debugger backend. It is possible to add support for other trace debuggers.
  * You can have multiple traces loaded at once, and you can have multiple debugger instances loaded.
* Adds breakpoint/watchpoint features.
  * Adds a **Breakpoints** view to manage breakpoints.
  * Adds a context menu item in disassembly view to set a breakpoint on an instruction.
  * Adds an **Edit Breakpoint** dialog to create or update breakpoints.
    ![image](https://user-images.githubusercontent.com/8210/151928953-30f5223a-0a4a-4d8c-974d-e408d79b4898.png)
  * Adds a workspace helper function to quickly set breakpoints on points of interest. Symbol names can be resolved through the loader, and the type of breakpoint you want is guessed. Examples:
    * `workspace.add_breakpoint(0x1234)` sets an execution breakpoint on address 0x1234.
    * `workspace.add_breakpoint('main')` sets an execution breakpoint on `main` function .
    * `workspace.add_breakpoint('global_value')` sets a write breakpoint on `global_value`.
    * `workspace.add_breakpoint('global_value', 'read', 1)` sets a 1-byte read breakpoint on `global_value`.
* Adds an interactive **Trace Map** view to visualize the current debugger's position in associated trace file.
  * Yellow line is current point in trace. Blue is trace future, red is trace past.
  * Green lines indicate 'checkpoints' in a cache for faster playback.
  * You can click to jump to nearest execution event in trace.
  * You can drag the viewer around and it will orient itself to fit best into the docked position.

Demo:
* Creating a project from a trace
* Opening Registers/Stack views
* Creating a trace debugger
* Setting a breakpoint via disassembly view
* Continuing execution until hitting breakpoint, examining program state at various points
* Opening Trace Map viewer
* Creating additional debugger for trace comparison

https://user-images.githubusercontent.com/8210/151935470-5810d436-f796-45ed-981b-8c78a5b530e1.mp4


There are many things left to improve on trace support, but this PR is already large so I've left them for follow-up. Some items on my wish/todo list:
* Improving performance.
* Improving bintrace to support other platforms and tracing methods.
* fd analysis via syscall replay.
* Supporting watchpoint conditions / advanced query.
* Improving menu items for some things
  * Creating Breakpoint from main menu, right now it's either console or Breakpoints view
  * Improving watchpoint creation (e.g. being able to click on a symbol in disassembly/decomp and create a watchpoint for it)
* Adding better trace analysis interface (e.g. dialog to show all values for a particular global variable, how many times through a loop, etc)
* Showing execution frontier on disassembly views.
* Customization of trace map viewer colors.
* Adding real-time debugging support, with tracing.
* Allowing hex viewer to display memory contents of current debugger state instead of just loader state.
* Overlay trace analysis features on top of current feature map view (hot blocks/pages, etc).
* Possibly pushing some of this logic into angr.
* Visualizing trace call stack, enumerating all called functions, showing stats in Function table, etc.
* Improving debugger to support stepping over calls, stepping out, etc.