### PR TITLE
Add progress dialog for blocking tasks

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -276,7 +276,8 @@ class Instance:
             gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0))
 
             if any(job.blocking for job in self.jobs):
-                self.workspace.main_window._progress_dialog.show()
+                if self.workspace.main_window.isVisible():
+                    self.workspace.main_window._progress_dialog.show()
 
             try:
                 self.current_job = job

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -4,8 +4,6 @@ from threading import Thread
 from queue import Queue
 from typing import List, Optional, Type, Union, Callable, TYPE_CHECKING
 
-from PySide2.QtWidgets import QProgressDialog
-
 import angr
 from angr.block import Block
 from angr.knowledge_base import KnowledgeBase
@@ -37,7 +35,8 @@ class Instance:
     def __init__(self):
         # pylint:disable=import-outside-toplevel)
         # delayed import
-        from ..ui.views.interaction_view import PlainTextProtocol, BackslashTextProtocol, ProtocolInteractor, SavedInteraction
+        from ..ui.views.interaction_view import PlainTextProtocol, BackslashTextProtocol, ProtocolInteractor,\
+            SavedInteraction
 
         self._live = False
         self.workspace: Optional['Workspace'] = None

--- a/angrmanagement/data/jobs/decompile_function.py
+++ b/angrmanagement/data/jobs/decompile_function.py
@@ -4,10 +4,10 @@ from .job import Job
 
 
 class DecompileFunctionJob(Job):
-    def __init__(self, function, on_finish=None, **kwargs):
+    def __init__(self, function, on_finish=None, blocking=False, **kwargs):
         self.kwargs = kwargs
         self.function = function
-        super().__init__(name="Decompiling", on_finish=on_finish)
+        super().__init__(name="Decompiling", on_finish=on_finish, blocking=blocking)
 
     def _run(self, inst):
         decompiler = inst.project.analyses.Decompiler(

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -18,12 +18,13 @@ except ImportError:
 l = logging.getLogger(__name__)
 
 class Job:
-    def __init__(self, name, on_finish=None):
+    def __init__(self, name, on_finish=None, blocking=False):
         self.name = name
         self.progress_percentage = 0.
         self.last_text: Optional[str] = None
         self.start_at: float = 0.
         self.last_gui_updated_at: float = 0.
+        self.blocking = blocking
 
         # callbacks
         self._on_finish = on_finish
@@ -54,7 +55,7 @@ class Job:
             gui_thread_schedule_async(self._on_finish)
 
     def keyboard_interrupt(self):
-        """Called from the GUI thread when the user presses Ctrl+C"""
+        """Called from the GUI thread when the user presses Ctrl+C or presses a cancel button"""
         return
 
     def _progress_callback(self, percentage, text=None):
@@ -67,10 +68,10 @@ class Job:
 
     def _set_progress(self, text=None):
         if text:
-            GlobalInfo.main_window.status = f"Working... {self.name}: {text} - {self.time_elapsed}"
+            status = f"{self.name}: {text} - {self.time_elapsed}"
         else:
-            GlobalInfo.main_window.status = f"Working... {self.name} - {self.time_elapsed}"
-        GlobalInfo.main_window.progress = self.progress_percentage
+            status = f"{self.name} - {self.time_elapsed}"
+        GlobalInfo.main_window.progress(status, self.progress_percentage)
 
     def _finish_progress(self):
-        GlobalInfo.main_window.progress_done()
+        pass

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -193,7 +193,7 @@ class MainWindow(QMainWindow):
         self._progress_dialog.setAutoClose(False)
         self._progress_dialog.setModal(True)
         self._progress_dialog.setMinimumDuration(2**31 - 1)
-        def on_cancel(*args, **kwargs):
+        def on_cancel():
             if self.workspace is None:
                 return
             for job in self.workspace.instance.jobs:
@@ -672,7 +672,6 @@ class MainWindow(QMainWindow):
 
 
     def progress_done(self):
-        self._progress = None
         self._progressbar.hide()
         self.statusBar().showMessage("Ready.")
         self._progress_dialog.hide()

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -137,6 +137,7 @@ class CodeView(BaseView):
             peephole_optimizations=self._options.selected_peephole_opts,
             vars_must_struct=self.vars_must_struct,
             on_finish=decomp_ready,
+            blocking=True,
         )
 
         self.workspace.instance.add_job(job)


### PR DESCRIPTION
- Adds a `blocking` parameter to job creation
- When a blocking job is in the queue, a dialog duplicating the information in the status bar will pop up
- The dialog's cancel button will attempt to cancel the current task