### PR TITLE
 Remove deprecated calls to close() on loader

### DIFF
--- a/angrmanagement/data/jobs/loading.py
+++ b/angrmanagement/data/jobs/loading.py
@@ -30,7 +30,6 @@ class LoadTargetJob(Job):
             partial_ld = apb.fire(return_loader=True, perform_relocations=False, load_debug_info=False)
             self._progress_callback(50)
             load_options, cfg_args, variable_recovery_args = gui_thread_schedule(LoadBinary.run, (partial_ld,))
-            partial_ld.close()
             if cfg_args is None:
                 return
 
@@ -77,7 +76,6 @@ class LoadBinaryJob(Job):
 
         self._progress_callback(50)
         new_load_options, cfg_args, variable_recovery_args = gui_thread_schedule(LoadBinary.run, (partial_ld, ))
-        partial_ld.close()
         if cfg_args is None:
             return
 


### PR DESCRIPTION
 Remove deprecated calls to `close()` on loader to silence the following log message from cle: ["You don't need to close the loader anymore :)"](https://github.com/angr/cle/blob/c5a36e6e5548aaf30df3005d529d8394190fde03/cle/loader.py#L144)

