### PR TITLE
[WIP] PySide6 Support

### DIFF
--- a/angrmanagement/__init__.py
+++ b/angrmanagement/__init__.py
@@ -1,11 +1,11 @@
 __version__ = "9.2.0.dev0"
 
 # Hack used to work around the slow-responsiveness issue with the GUI
-# PySide2 5.14.2 solves this problem but it introduces other bugs
+# PySide6 5.14.2 solves this problem but it introduces other bugs
 # See https://bugreports.qt.io/browse/PYSIDE-803
 try:
-    import PySide2
-    version = [int(k) for k in PySide2.__version__.split(".")[:4]]
+    import PySide6
+    version = [int(k) for k in PySide6.__version__.split(".")[:4]]
     while len(version) < 4:
         version.append(0)
     version = tuple(version)
@@ -17,7 +17,7 @@ except ImportError:
 
 
 try:
-    # make sure qtpy (which is used in PyQodeNG.core) is using PySide2
+    # make sure qtpy (which is used in PyQodeNG.core) is using PySide6
     import os
     os.environ['QT_API'] = 'pyside2'
     import qtpy

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -27,20 +27,20 @@ def check_dependencies_qt():
     missing_dep = False
 
     try:
-        import PySide2
+        import PySide6
     except ImportError:
-        PySide2 = None
-        sys.stderr.write("Cannot find the PySide2 package. You may install it via pip:\n" +
+        PySide6 = None
+        sys.stderr.write("Cannot find the PySide6 package. You may install it via pip:\n" +
                          "    pip install pyside2\n")
         missing_dep = True
 
     # version check
-    if PySide2 is not None and PySide2.__version__ in BUGGY_PYSIDE2_VERSIONS:
-        sys.stderr.write("Your installed version of PySide2 is known to have bugs that may lead to angr management "
+    if PySide6 is not None and PySide6.__version__ in BUGGY_PYSIDE2_VERSIONS:
+        sys.stderr.write("Your installed version of PySide6 is known to have bugs that may lead to angr management "
                          "crashing. Please switch to other versions.\n"
-                         "A known good version of PySide2 is 5.14.1. You may install it via pip:\n"
+                         "A known good version of PySide6 is 5.14.1. You may install it via pip:\n"
                          "    pip install -U pyside2==5.14.1\n")
-        sys.stderr.write("Bad PySide2 versions include: %s" % ", ".join(BUGGY_PYSIDE2_VERSIONS))
+        sys.stderr.write("Bad PySide6 versions include: %s" % ", ".join(BUGGY_PYSIDE2_VERSIONS))
         missing_dep = True
 
     try:
@@ -105,7 +105,7 @@ def set_windows_event_loop_policy():
 
 def macos_bigsur_wants_layer():
     # workaround for https://bugreports.qt.io/browse/QTBUG-87014
-    # this is because the latest PySide2 (5.15.2) does not include this fix
+    # this is because the latest PySide6 (5.15.2) does not include this fix
     v, _, _ = platform.mac_ver()
     vs = v.split(".")
     if len(vs) >= 2:
@@ -129,9 +129,9 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
     set_app_user_model_id()
     set_windows_event_loop_policy()
 
-    from PySide2.QtWidgets import QApplication, QSplashScreen, QMessageBox
-    from PySide2.QtGui import QFontDatabase, QPixmap, QIcon
-    from PySide2.QtCore import Qt, QCoreApplication
+    from PySide6.QtWidgets import QApplication, QSplashScreen, QMessageBox
+    from PySide6.QtGui import QFontDatabase, QPixmap, QIcon
+    from PySide6.QtCore import Qt, QCoreApplication
 
     from .config import FONT_LOCATION, IMG_LOCATION, Conf
 

--- a/angrmanagement/config/color_schemes.py
+++ b/angrmanagement/config/color_schemes.py
@@ -1,4 +1,4 @@
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 
 COLOR_SCHEMES = {

--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -4,8 +4,8 @@ import re
 from typing import Union
 
 import toml
-from PySide2.QtGui import QFont, QFontMetricsF, QColor
-from PySide2.QtWidgets import QApplication, QMessageBox
+from PySide6.QtGui import QFont, QFontMetricsF, QColor
+from PySide6.QtWidgets import QApplication, QMessageBox
 
 from ..utils.env import app_root
 from .config_entry import ConfigurationEntry as CE

--- a/angrmanagement/data/jobs/dependency_analysis.py
+++ b/angrmanagement/data/jobs/dependency_analysis.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Optional, Generator, List, Tuple, Set
 import logging
 
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 from angr import KnowledgeBase
 from angr.analyses.reaching_definitions.external_codeloc import ExternalCodeLocation

--- a/angrmanagement/logic/disassembly/info_dock.py
+++ b/angrmanagement/logic/disassembly/info_dock.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, Signal
 
 from ...data.object_container import ObjectContainer
 

--- a/angrmanagement/logic/threads.py
+++ b/angrmanagement/logic/threads.py
@@ -1,6 +1,6 @@
 import threading
 
-from PySide2.QtCore import QEvent, QCoreApplication
+from PySide6.QtCore import QEvent, QCoreApplication
 
 from . import GlobalInfo
 

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -4,7 +4,7 @@ import sys
 import subprocess
 import pathlib
 
-from PySide2.QtCore import QSettings
+from PySide6.QtCore import QSettings
 
 from ..utils.env import app_path
 

--- a/angrmanagement/plugins/ail2asm/asm_output.py
+++ b/angrmanagement/plugins/ail2asm/asm_output.py
@@ -1,5 +1,5 @@
-from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPlainTextEdit, QDialogButtonBox
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPlainTextEdit, QDialogButtonBox
 
 
 class AsmOutput(QDialog):

--- a/angrmanagement/plugins/base_plugin.py
+++ b/angrmanagement/plugins/base_plugin.py
@@ -1,9 +1,9 @@
 # pylint:disable=unused-private-member
 import logging
 from typing import Optional, Tuple, Callable, Iterator, Generator, List, Any, Union, TYPE_CHECKING
-from PySide2.QtGui import QColor, QPainter
-from PySide2.QtGui import QIcon
-from PySide2.QtWidgets import QGraphicsSceneMouseEvent
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QGraphicsSceneMouseEvent
 from angr.sim_manager import SimulationManager
 
 from ..ui.widgets.qblock import QBlock

--- a/angrmanagement/plugins/binsync/controller.py
+++ b/angrmanagement/plugins/binsync/controller.py
@@ -5,7 +5,7 @@ import datetime
 import time
 import os
 
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator
 from angr.knowledge_plugins.sync.sync_controller import SyncController

--- a/angrmanagement/plugins/binsync/ui/config_dialog.py
+++ b/angrmanagement/plugins/binsync/ui/config_dialog.py
@@ -1,9 +1,9 @@
 import traceback
 import os
 
-from PySide2.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox,
+from PySide6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QMessageBox,
                                QFileDialog, QCheckBox, QGridLayout)
-from PySide2.QtCore import QDir
+from PySide6.QtCore import QDir
 
 try:
     import binsync

--- a/angrmanagement/plugins/binsync/ui/info_panel.py
+++ b/angrmanagement/plugins/binsync/ui/info_panel.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QVBoxLayout, QHBoxLayout, QGroupBox, QLabel, QComboBox
+from PySide6.QtWidgets import QVBoxLayout, QHBoxLayout, QGroupBox, QLabel, QComboBox
 
 from angrmanagement.ui.views.view import BaseView
 from .info_tables import QFuncInfoTable

--- a/angrmanagement/plugins/binsync/ui/info_tables/func_info_table.py
+++ b/angrmanagement/plugins/binsync/ui/info_tables/func_info_table.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView
+from PySide6.QtCore import Qt
 
 from ...controller import BinsyncController
 

--- a/angrmanagement/plugins/binsync/ui/info_tables/struct_info_table.py
+++ b/angrmanagement/plugins/binsync/ui/info_tables/struct_info_table.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QHeaderView
+from PySide6.QtCore import Qt
 
 
 class QUserItem:

--- a/angrmanagement/plugins/binsync/ui/sync_menu.py
+++ b/angrmanagement/plugins/binsync/ui/sync_menu.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QLabel, QComboBox, QTableWidget, QTableWidgetItem, \
+from PySide6.QtWidgets import QDialog, QLabel, QComboBox, QTableWidget, QTableWidgetItem, \
     QDialogButtonBox, QGridLayout, QHeaderView, QAbstractItemView
 
 from ..controller import BinsyncController

--- a/angrmanagement/plugins/bughouse/ui/components_treeview.py
+++ b/angrmanagement/plugins/bughouse/ui/components_treeview.py
@@ -1,8 +1,8 @@
 from typing import List, Tuple, Optional
 
-import PySide2.QtCore
-from PySide2.QtCore import QSize, Qt
-from PySide2.QtWidgets import QTreeWidget, QTreeWidgetItem, QHBoxLayout, QVBoxLayout
+import PySide6.QtCore
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtWidgets import QTreeWidget, QTreeWidgetItem, QHBoxLayout, QVBoxLayout
 
 from angr.project import Project
 from angr.knowledge_plugins.functions import Function
@@ -68,7 +68,7 @@ class ComponentsView(BaseView):
 
         self.setLayout(layout)
 
-    def minimumSizeHint(self) -> PySide2.QtCore.QSize:
+    def minimumSizeHint(self) -> PySide6.QtCore.QSize:
         return QSize(100, 100)
 
     def load(self, tree: ComponentTree):

--- a/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
+++ b/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
@@ -3,7 +3,7 @@ import os
 import json
 import binascii
 
-from PySide2.QtWidgets import QDialog, QLineEdit, QLabel, QHBoxLayout, QVBoxLayout, QPushButton, QProgressBar,\
+from PySide6.QtWidgets import QDialog, QLineEdit, QLabel, QHBoxLayout, QVBoxLayout, QPushButton, QProgressBar,\
     QMessageBox, QSizePolicy, QFileDialog
 
 from ....utils.io import isurl, download_url

--- a/angrmanagement/plugins/chess_manager/backend_selector_dialog.py
+++ b/angrmanagement/plugins/chess_manager/backend_selector_dialog.py
@@ -3,8 +3,8 @@ from typing import Optional, TYPE_CHECKING
 import sqlalchemy
 import requests
 
-from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QLineEdit, QLabel, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QDialog, QLineEdit, QLabel, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox
 
 try:
     import slacrs

--- a/angrmanagement/plugins/chess_manager/chess_connector.py
+++ b/angrmanagement/plugins/chess_manager/chess_connector.py
@@ -4,8 +4,8 @@ import os
 import threading
 import time
 
-from PySide2.QtWidgets import QPushButton, QMessageBox
-from PySide2.QtGui import QPixmap, Qt, QIcon
+from PySide6.QtWidgets import QPushButton, QMessageBox
+from PySide6.QtGui import QPixmap, Qt, QIcon
 
 from angrmanagement.logic.threads import gui_thread_schedule_async
 from angrmanagement.config import Conf, save_config

--- a/angrmanagement/plugins/chess_manager/chess_url_handler.py
+++ b/angrmanagement/plugins/chess_manager/chess_url_handler.py
@@ -7,8 +7,8 @@ from typing import Tuple, Optional
 
 import toml
 from xdg import BaseDirectory
-from PySide2.QtWidgets import QApplication
-from PySide2.QtWidgets import QMessageBox, QFileDialog
+from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QMessageBox, QFileDialog
 
 from angrmanagement.plugins import BasePlugin
 from angrmanagement.daemon.url_handler import UrlActionBase, register_url_action

--- a/angrmanagement/plugins/chess_manager/multi_poi.py
+++ b/angrmanagement/plugins/chess_manager/multi_poi.py
@@ -1,7 +1,7 @@
 import math
 import logging
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 _l = logging.getLogger(__name__)
 # _l.setLevel('DEBUG')

--- a/angrmanagement/plugins/chess_manager/poi_plugin.py
+++ b/angrmanagement/plugins/chess_manager/poi_plugin.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 import os
 from typing import Optional, Union
 
-from PySide2.QtGui import QColor
-from PySide2.QtWidgets import QFileDialog, QMessageBox
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QFileDialog, QMessageBox
 
 from ...data.object_container import ObjectContainer
 from ..base_plugin import BasePlugin

--- a/angrmanagement/plugins/chess_manager/qpoi_viewer.py
+++ b/angrmanagement/plugins/chess_manager/qpoi_viewer.py
@@ -2,10 +2,10 @@ from uuid import uuid4
 from copy import deepcopy
 import logging
 
-from PySide2.QtWidgets import QWidget, QVBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItemGroup, QMessageBox, \
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItemGroup, QMessageBox, \
     QTabWidget, QAbstractItemView, QMenu, QTableWidget, QTableWidgetItem, QHeaderView
-from PySide2.QtGui import QPen, QBrush, QLinearGradient, QColor, QPainter, QImage, QFont, QContextMenuEvent
-from PySide2.QtCore import Qt, QPoint
+from PySide6.QtGui import QPen, QBrush, QLinearGradient, QColor, QPainter, QImage, QFont, QContextMenuEvent
+from PySide6.QtCore import Qt, QPoint
 
 from angrmanagement.ui.views.view import BaseView
 

--- a/angrmanagement/plugins/chess_manager/summary_view.py
+++ b/angrmanagement/plugins/chess_manager/summary_view.py
@@ -4,8 +4,8 @@ import threading
 import datetime
 from time import sleep
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QVBoxLayout, QHBoxLayout, QTableWidget, QHeaderView, \
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QVBoxLayout, QHBoxLayout, QTableWidget, QHeaderView, \
     QAbstractItemView, QTableWidgetItem, QWidget, QTabWidget, QLabel
 
 from angrmanagement.ui.views.view import BaseView

--- a/angrmanagement/plugins/chess_manager/target_selector.py
+++ b/angrmanagement/plugins/chess_manager/target_selector.py
@@ -6,10 +6,10 @@ import threading
 import asyncio
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
-import PySide2
-from PySide2.QtWidgets import QDialog, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QTableView, \
+import PySide6
+from PySide6.QtWidgets import QDialog, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QTableView, \
     QAbstractItemView, QHeaderView, QLabel
-from PySide2.QtCore import Qt, QAbstractTableModel
+from PySide6.QtCore import Qt, QAbstractTableModel
 
 try:
     import slacrs
@@ -57,13 +57,13 @@ class QTargetSelectorTableModel(QAbstractTableModel):
         self._targets = v
         self.endResetModel()
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self.targets)
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> typing.Any:
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> typing.Any:
         if role != Qt.DisplayRole:
             return None
 
@@ -71,7 +71,7 @@ class QTargetSelectorTableModel(QAbstractTableModel):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> typing.Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> typing.Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/plugins/chess_manager/trace_statistics.py
+++ b/angrmanagement/plugins/chess_manager/trace_statistics.py
@@ -2,7 +2,7 @@ import logging
 import random
 from collections import defaultdict
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 from angr.errors import SimEngineError
 
 l = logging.getLogger(name=__name__)

--- a/angrmanagement/plugins/dep_viewer/dep_plugin.py
+++ b/angrmanagement/plugins/dep_viewer/dep_plugin.py
@@ -1,7 +1,7 @@
 from typing import Set, Tuple, Optional, Dict
 from sortedcontainers import SortedDict
 
-from PySide2.QtGui import QColor, Qt
+from PySide6.QtGui import QColor, Qt
 
 from angr.sim_type import normalize_cpp_function_name
 

--- a/angrmanagement/plugins/execution_statistics_viewer/execution_statistics_viewer.py
+++ b/angrmanagement/plugins/execution_statistics_viewer/execution_statistics_viewer.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
-from PySide2.QtWidgets import QLabel
+from PySide6.QtWidgets import QLabel
 
 from angrmanagement.plugins.base_plugin import BasePlugin
 from angrmanagement.logic.threads import gui_thread_schedule

--- a/angrmanagement/plugins/interaction_console/interaction_console.py
+++ b/angrmanagement/plugins/interaction_console/interaction_console.py
@@ -1,8 +1,8 @@
 import threading
 
 import archr
-from PySide2.QtWidgets import QMainWindow, QMessageBox, QVBoxLayout, QHBoxLayout, QPushButton
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QMainWindow, QMessageBox, QVBoxLayout, QHBoxLayout, QPushButton
+from PySide6.QtCore import Qt
 from qtterm import TerminalWidget
 
 from angrmanagement.plugins import BasePlugin

--- a/angrmanagement/plugins/log_fatigue/log_fatigue_plugin.py
+++ b/angrmanagement/plugins/log_fatigue/log_fatigue_plugin.py
@@ -6,8 +6,8 @@ from time import sleep
 from typing import Optional
 
 
-from PySide2.QtCore import QEvent, QObject
-from PySide2.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QVBoxLayout
+from PySide6.QtCore import QEvent, QObject
+from PySide6.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QVBoxLayout
 
 try:
     from slacrs import Slacrs

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Type, Union, TYPE_CHECKING
 import logging
 import os
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 from ..config import config_path
 from ..config.config_manager import ENTRIES

--- a/angrmanagement/plugins/seed_table/seed_table_plugin.py
+++ b/angrmanagement/plugins/seed_table/seed_table_plugin.py
@@ -1,8 +1,8 @@
 import time
 
-from PySide2.QtCore import Qt, QAbstractTableModel, QModelIndex, QEvent, Signal, QObject
-from PySide2.QtGui import QCursor
-from PySide2.QtWidgets import (
+from PySide6.QtCore import Qt, QAbstractTableModel, QModelIndex, QEvent, Signal, QObject
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import (
     QVBoxLayout,
     QMainWindow,
     QTableView,
@@ -174,7 +174,7 @@ class SeedTableWidget(QTableView):
         self.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
         self.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
 
-    def contextMenuEvent(self, event:'PySide2.QtGui.QContextMenuEvent') -> None:
+    def contextMenuEvent(self, event:'PySide6.QtGui.QContextMenuEvent') -> None:
         rows = self.selectionModel().selectedIndexes()
         contextMenu = QMenu(self)
         saveSeed = contextMenu.addAction("&Save Seed")

--- a/angrmanagement/plugins/source_viewer/source_viewer_plugin.py
+++ b/angrmanagement/plugins/source_viewer/source_viewer_plugin.py
@@ -2,9 +2,9 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 from sortedcontainers import SortedDict
 
-from PySide2.QtGui import QCursor
-from PySide2.QtWidgets import QInputDialog, QLineEdit, QMenu, QPlainTextEdit, QStyle, QVBoxLayout
-from PySide2.QtCore import QEvent, Qt
+from PySide6.QtGui import QCursor
+from PySide6.QtWidgets import QInputDialog, QLineEdit, QMenu, QPlainTextEdit, QStyle, QVBoxLayout
+from PySide6.QtCore import QEvent, Qt
 
 from pyqodeng.core.api import CodeEdit
 from pyqodeng.core.panels import LineNumberPanel, MarkerPanel, Marker

--- a/angrmanagement/plugins/trace_viewer/afl_qemu_bitmap.py
+++ b/angrmanagement/plugins/trace_viewer/afl_qemu_bitmap.py
@@ -5,7 +5,7 @@ import networkx as nx
 
 from angr.knowledge_plugins.functions import Function
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 _l = logging.getLogger(name=__name__)
 

--- a/angrmanagement/plugins/trace_viewer/chess_trace_list.py
+++ b/angrmanagement/plugins/trace_viewer/chess_trace_list.py
@@ -6,10 +6,10 @@ import threading
 import asyncio
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
-import PySide2
-from PySide2.QtWidgets import QDialog, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QTableView, \
+import PySide6
+from PySide6.QtWidgets import QDialog, QPushButton, QHBoxLayout, QVBoxLayout, QMessageBox, QTableView, \
     QAbstractItemView, QHeaderView, QLabel
-from PySide2.QtCore import Qt, QAbstractTableModel
+from PySide6.QtCore import Qt, QAbstractTableModel
 
 try:
     import slacrs
@@ -59,13 +59,13 @@ class QTraceTableModel(QAbstractTableModel):
         self._traces = v
         self.endResetModel()
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self.traces)
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> typing.Any:
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> typing.Any:
         if role != Qt.DisplayRole:
             return None
 
@@ -73,7 +73,7 @@ class QTraceTableModel(QAbstractTableModel):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> typing.Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> typing.Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/plugins/trace_viewer/multi_trace.py
+++ b/angrmanagement/plugins/trace_viewer/multi_trace.py
@@ -1,6 +1,6 @@
 import math
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 from .trace_statistics import TraceStatistics
 

--- a/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
+++ b/angrmanagement/plugins/trace_viewer/qtrace_viewer.py
@@ -1,10 +1,10 @@
 import logging
 
-from PySide2.QtWidgets import QWidget, QVBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItemGroup
-from PySide2.QtWidgets import QTabWidget, QPushButton, QAbstractItemView
-from PySide2.QtWidgets import  QMessageBox, QTableWidget, QTableWidgetItem
-from PySide2.QtGui import QPen, QBrush, QLinearGradient, QColor, QPainter, QImage, QFont
-from PySide2.QtCore import Qt, QPoint, QEvent
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItemGroup
+from PySide6.QtWidgets import QTabWidget, QPushButton, QAbstractItemView
+from PySide6.QtWidgets import  QMessageBox, QTableWidget, QTableWidgetItem
+from PySide6.QtGui import QPen, QBrush, QLinearGradient, QColor, QPainter, QImage, QFont
+from PySide6.QtCore import Qt, QPoint, QEvent
 
 
 l = logging.getLogger(name=__name__)

--- a/angrmanagement/plugins/trace_viewer/trace_plugin.py
+++ b/angrmanagement/plugins/trace_viewer/trace_plugin.py
@@ -2,9 +2,9 @@ import json
 import os
 from typing import Optional, Union, List, Tuple
 
-from PySide2.QtCore import Qt
-from PySide2.QtGui import QColor
-from PySide2.QtWidgets import QApplication, QFileDialog, QInputDialog, QLineEdit, QMessageBox
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication, QFileDialog, QInputDialog, QLineEdit, QMessageBox
 
 import requests
 

--- a/angrmanagement/plugins/trace_viewer/trace_statistics.py
+++ b/angrmanagement/plugins/trace_viewer/trace_statistics.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from bisect import bisect_left
 from typing import Dict, Any, List, Set, Optional
 
-from PySide2.QtGui import QColor
+from PySide6.QtGui import QColor
 
 from angr.errors import SimEngineError
 

--- a/angrmanagement/plugins/varec/varec.py
+++ b/angrmanagement/plugins/varec/varec.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 import requests
 from sortedcontainers import SortedDict
 
-from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QMessageBox
 
 from angrmanagement.config import Conf
 from ..base_plugin import BasePlugin

--- a/angrmanagement/ui/css/__init__.py
+++ b/angrmanagement/ui/css/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
-from PySide2.QtWidgets import QApplication
-from PySide2.QtGui import QPalette
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPalette
 
 from ..widgets.qccode_highlighter import reset_formats
 from ...data.object_container import ObjectContainer

--- a/angrmanagement/ui/dialogs/about.py
+++ b/angrmanagement/ui/dialogs/about.py
@@ -1,8 +1,8 @@
 import os
 
-from PySide2.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout
-from PySide2.QtGui import QIcon, QPixmap, QFont
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout, QHBoxLayout
+from PySide6.QtGui import QIcon, QPixmap, QFont
+from PySide6.QtCore import Qt
 import angr
 
 from ...config import IMG_LOCATION

--- a/angrmanagement/ui/dialogs/breakpoint.py
+++ b/angrmanagement/ui/dialogs/breakpoint.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox, QGridLayout, \
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox, QGridLayout, \
     QRadioButton, QButtonGroup
 
 from ...data.breakpoint import Breakpoint, BreakpointType

--- a/angrmanagement/ui/dialogs/data_dep_graph_search.py
+++ b/angrmanagement/ui/dialogs/data_dep_graph_search.py
@@ -1,5 +1,5 @@
 from typing import Optional, List, TYPE_CHECKING
-from PySide2 import QtWidgets
+from PySide6 import QtWidgets
 
 if TYPE_CHECKING:
     from angr.analyses.data_dep import BaseDepNode

--- a/angrmanagement/ui/dialogs/dependson.py
+++ b/angrmanagement/ui/dialogs/dependson.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from PySide2.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QGroupBox, QRadioButton, QHBoxLayout, \
+from PySide6.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QGroupBox, QRadioButton, QHBoxLayout, \
     QVBoxLayout, QCheckBox, QMessageBox, QWidget
 
 from angr.knowledge_plugins import Function

--- a/angrmanagement/ui/dialogs/fs_mount.py
+++ b/angrmanagement/ui/dialogs/fs_mount.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout
+from PySide6.QtCore import Qt
 from ..widgets.filesystem_table import QFileSystemTable
 
 class FilesystemMount(QDialog):

--- a/angrmanagement/ui/dialogs/func_doc.py
+++ b/angrmanagement/ui/dialogs/func_doc.py
@@ -1,5 +1,5 @@
-from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QTextEdit
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QTextEdit
 
 from ...config import Conf
 from ...data.instance import Instance

--- a/angrmanagement/ui/dialogs/hook.py
+++ b/angrmanagement/ui/dialogs/hook.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QRadioButton, QGroupBox, QScrollArea, \
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QGridLayout, QRadioButton, QGroupBox, QScrollArea, \
     QWidget, QDialogButtonBox
-from PySide2.QtGui import QTextOption
+from PySide6.QtGui import QTextOption
 from pyqodeng.core.api import CodeEdit
 from pyqodeng.core.modes import CaretLineHighlighterMode, PygmentsSyntaxHighlighter, AutoIndentMode
 from ...data.instance import Instance

--- a/angrmanagement/ui/dialogs/input_prompt.py
+++ b/angrmanagement/ui/dialogs/input_prompt.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QDialogButtonBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QDialogButtonBox
 
 
 class InputPromptDialog(QDialog):

--- a/angrmanagement/ui/dialogs/jumpto.py
+++ b/angrmanagement/ui/dialogs/jumpto.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QDialogButtonBox
 
 from ..widgets import QAddressInput
 

--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -5,9 +5,9 @@ import logging
 import archinfo
 from cle import Blob
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWidget, QCheckBox, QFrame, QGroupBox, \
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QTabWidget, QCheckBox, QFrame, QGroupBox, \
     QListWidgetItem, QListWidget, QMessageBox, QLineEdit, QGridLayout, QComboBox, QSizePolicy, QDialogButtonBox
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 
 
 l = logging.getLogger('dialogs.load_binary')

--- a/angrmanagement/ui/dialogs/load_docker_prompt.py
+++ b/angrmanagement/ui/dialogs/load_docker_prompt.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
 
-from PySide2.QtWidgets import QInputDialog, QMessageBox
+from PySide6.QtWidgets import QInputDialog, QMessageBox
 
 
 _l = logging.getLogger(__name__)

--- a/angrmanagement/ui/dialogs/load_plugins.py
+++ b/angrmanagement/ui/dialogs/load_plugins.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Type, List
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QPushButton, QFrame, QGroupBox, QListWidgetItem, \
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QPushButton, QFrame, QGroupBox, QListWidgetItem, \
     QListWidget, QFileDialog, QMessageBox, QDialogButtonBox
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 
 from angrmanagement.plugins import load_plugins_from_file
 

--- a/angrmanagement/ui/dialogs/new_state.py
+++ b/angrmanagement/ui/dialogs/new_state.py
@@ -1,9 +1,9 @@
 import os
 from typing import List
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QDialogButtonBox, QGridLayout, QComboBox, \
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, QDialogButtonBox, QGridLayout, QComboBox, \
     QLineEdit, QTextEdit, QTreeWidget, QTreeWidgetItem
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 import angr
 
 from ..widgets import QStateComboBox

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -1,8 +1,8 @@
-from PySide2.QtGui import QColor
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
     QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, \
     QSizePolicy, QDialogButtonBox
-from PySide2.QtCore import QSize
+from PySide6.QtCore import QSize
 
 from ..widgets.qcolor_option import QColorOption
 from ...config.config_manager import ENTRIES

--- a/angrmanagement/ui/dialogs/rename.py
+++ b/angrmanagement/ui/dialogs/rename.py
@@ -1,6 +1,6 @@
 from typing import Optional, TYPE_CHECKING
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
 
 if TYPE_CHECKING:
     from angrmanagement.ui.views.code_view import CodeView

--- a/angrmanagement/ui/dialogs/rename_label.py
+++ b/angrmanagement/ui/dialogs/rename_label.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QDialogButtonBox
 
 
 class LabelNameBox(QLineEdit):

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 from collections import OrderedDict
 
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QListWidget, \
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QLineEdit, QListWidget, \
     QDialogButtonBox
 from angr.analyses.decompiler.structured_codegen.c import CVariable, CFunction, CConstruct, CFunctionCall, CStructField
 

--- a/angrmanagement/ui/dialogs/retype_node.py
+++ b/angrmanagement/ui/dialogs/retype_node.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
-from PySide2.QtGui import Qt
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDialogButtonBox, QLineEdit
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QDialogButtonBox, QLineEdit
 
 import pycparser
 

--- a/angrmanagement/ui/dialogs/set_comment.py
+++ b/angrmanagement/ui/dialogs/set_comment.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QLabel, QDialogButtonBox, QPlainTextEdit, QApplication
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QDialogButtonBox, QPlainTextEdit, QApplication
+from PySide6.QtCore import Qt
 
 
 class QCommentTextBox(QPlainTextEdit):

--- a/angrmanagement/ui/dialogs/type_editor.py
+++ b/angrmanagement/ui/dialogs/type_editor.py
@@ -1,8 +1,8 @@
 from typing import Optional
 from collections import OrderedDict
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QDialogButtonBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QLineEdit, QPushButton, QVBoxLayout, QMessageBox, QDialogButtonBox
 
 import pycparser.plyparser
 from angr import sim_type

--- a/angrmanagement/ui/dialogs/xref.py
+++ b/angrmanagement/ui/dialogs/xref.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QDialog, QVBoxLayout
-from PySide2.QtCore import QSize, Qt
+from PySide6.QtWidgets import QDialog, QVBoxLayout
+from PySide6.QtCore import QSize, Qt
 
 from ..widgets.qxref_viewer import QXRefViewer
 

--- a/angrmanagement/ui/documents/qcodedocument.py
+++ b/angrmanagement/ui/documents/qcodedocument.py
@@ -1,5 +1,5 @@
-from PySide2.QtGui import QTextDocument
-from PySide2.QtWidgets import QPlainTextDocumentLayout
+from PySide6.QtGui import QTextDocument
+from PySide6.QtWidgets import QPlainTextDocumentLayout
 
 from angr.analyses.decompiler.structured_codegen.c import CConstant, CVariable, CFunctionCall, \
     CStructField, CClosingObject, CFunction

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -6,10 +6,10 @@ import sys
 import time
 from typing import Optional, TYPE_CHECKING
 
-from PySide2.QtWidgets import QMainWindow, QTabWidget, QFileDialog, QProgressBar, QProgressDialog
-from PySide2.QtWidgets import QMessageBox, QShortcut, QTabBar
-from PySide2.QtGui import QResizeEvent, QIcon, QDesktopServices, QKeySequence
-from PySide2.QtCore import Qt, QSize, QEvent, QTimer, QUrl
+from PySide6.QtWidgets import QMainWindow, QTabWidget, QFileDialog, QProgressBar, QProgressDialog
+from PySide6.QtWidgets import QMessageBox, QTabBar
+from PySide6.QtGui import QResizeEvent, QIcon, QDesktopServices, QKeySequence, QShortcut
+from PySide6.QtCore import Qt, QSize, QEvent, QTimer, QUrl
 
 import angr
 import angr.flirt
@@ -52,7 +52,7 @@ from .toolbars import FileToolbar, DebugToolbar
 from .toolbar_manager import ToolbarManager
 
 if TYPE_CHECKING:
-    from PySide2.QtWidgets import QApplication
+    from PySide6.QtWidgets import QApplication
 
 _l = logging.getLogger(name=__name__)
 

--- a/angrmanagement/ui/menus/analyze_menu.py
+++ b/angrmanagement/ui/menus/analyze_menu.py
@@ -1,6 +1,6 @@
 
-from PySide2.QtGui import QKeySequence
-from PySide2.QtCore import Qt
+from PySide6.QtGui import QKeySequence
+from PySide6.QtCore import Qt
 
 from .menu import Menu, MenuEntry, MenuSeparator
 

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -1,7 +1,7 @@
 import os.path
 
-from PySide2.QtGui import QKeySequence
-from PySide2.QtCore import Qt
+from PySide6.QtGui import QKeySequence
+from PySide6.QtCore import Qt
 
 from .menu import Menu, MenuEntry, MenuSeparator
 from ...logic import GlobalInfo

--- a/angrmanagement/ui/menus/help_menu.py
+++ b/angrmanagement/ui/menus/help_menu.py
@@ -1,6 +1,6 @@
 
-from PySide2.QtGui import QKeySequence
-from PySide2.QtCore import Qt
+from PySide6.QtGui import QKeySequence
+from PySide6.QtCore import Qt
 
 from .menu import Menu, MenuEntry, MenuSeparator
 

--- a/angrmanagement/ui/menus/log_menu.py
+++ b/angrmanagement/ui/menus/log_menu.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from PySide2.QtGui import QKeySequence, Qt
+from PySide6.QtGui import QKeySequence, Qt
 
 from .menu import Menu, MenuEntry, MenuSeparator
 

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -1,4 +1,5 @@
-from PySide2.QtWidgets import QMenu, QAction
+from PySide6.QtWidgets import QMenu
+from PySide6.QtGui import QAction
 
 
 class MenuEntry:

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from PySide2.QtGui import QKeySequence
+from PySide6.QtGui import QKeySequence
 from angrmanagement.ui.toolbars.toolbar import Toolbar
 
 from .menu import Menu, MenuEntry, MenuSeparator

--- a/angrmanagement/ui/toolbar_manager.py
+++ b/angrmanagement/ui/toolbar_manager.py
@@ -1,6 +1,6 @@
 from typing import Type, Mapping
 
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 from angrmanagement.ui.toolbars import FileToolbar, DebugToolbar
 from angrmanagement.ui.toolbars.toolbar import Toolbar
 

--- a/angrmanagement/ui/toolbars/debug_toolbar.py
+++ b/angrmanagement/ui/toolbars/debug_toolbar.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
 import qtawesome as qta
-from PySide2.QtCore import QAbstractItemModel, Qt, QModelIndex
-from PySide2.QtWidgets import QLabel, QComboBox, QAction, QMenu
+from PySide6.QtCore import QAbstractItemModel, Qt, QModelIndex
+from PySide6.QtWidgets import QLabel, QComboBox, QMenu
+from PySide6.QtGui import QAction
 
 from ...logic.debugger import DebuggerWatcher
 from ...config import Conf

--- a/angrmanagement/ui/toolbars/file_toolbar.py
+++ b/angrmanagement/ui/toolbars/file_toolbar.py
@@ -1,7 +1,7 @@
 
 import os
 
-from PySide2.QtGui import QIcon
+from PySide6.QtGui import QIcon
 
 from ...config import IMG_LOCATION
 from .toolbar import Toolbar, ToolbarAction

--- a/angrmanagement/ui/toolbars/function_table_toolbar.py
+++ b/angrmanagement/ui/toolbars/function_table_toolbar.py
@@ -1,7 +1,7 @@
 
 import os
 
-from PySide2.QtGui import QIcon
+from PySide6.QtGui import QIcon
 
 from ...config import IMG_LOCATION
 from .toolbar import Toolbar, ToolbarAction

--- a/angrmanagement/ui/toolbars/nav_toolbar.py
+++ b/angrmanagement/ui/toolbars/nav_toolbar.py
@@ -1,9 +1,9 @@
 import os
 from typing import Callable, Any
 
-from PySide2.QtCore import Signal, QSize
-from PySide2.QtGui import QMouseEvent, QIcon
-from PySide2.QtWidgets import QMenu, QAction, QToolButton, QToolBar, QStyle
+from PySide6.QtCore import Signal, QSize
+from PySide6.QtGui import QMouseEvent, QIcon, QAction
+from PySide6.QtWidgets import QMenu, QToolButton, QToolBar, QStyle
 
 from .toolbar import Toolbar
 from ...logic.disassembly import JumpHistory

--- a/angrmanagement/ui/toolbars/toolbar.py
+++ b/angrmanagement/ui/toolbars/toolbar.py
@@ -1,5 +1,6 @@
-from PySide2.QtWidgets import QToolBar, QAction
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QToolBar
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QAction
 
 
 class ToolbarAction:

--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Sequence
 import logging
 import functools
 
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 
 from angrmanagement.ui.views.view import BaseView
 

--- a/angrmanagement/ui/views/breakpoints_view.py
+++ b/angrmanagement/ui/views/breakpoints_view.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any, Optional, Sequence
 
-import PySide2
-from PySide2.QtCore import QAbstractTableModel, Qt, QSize
-from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
+import PySide6
+from PySide6.QtCore import QAbstractTableModel, Qt, QSize
+from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
 
 from ...data.breakpoint import Breakpoint, BreakpointType, BreakpointManager
 from ..dialogs import BreakpointDialog
@@ -33,20 +33,20 @@ class QBreakpointTableModel(QAbstractTableModel):
         self.beginResetModel()
         self.endResetModel()
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.breakpoint_mgr.breakpoints)
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
         if role != Qt.DisplayRole:
             return None
         if section < len(self.Headers):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -1,9 +1,9 @@
 from typing import Set, Union, Optional
 import logging
 
-from PySide2.QtWidgets import QHBoxLayout, QTextEdit, QMainWindow, QDockWidget, QVBoxLayout, QWidget, QFrame, QComboBox
-from PySide2.QtGui import QTextCursor
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QHBoxLayout, QTextEdit, QMainWindow, QDockWidget, QVBoxLayout, QWidget, QFrame, QComboBox
+from PySide6.QtGui import QTextCursor
+from PySide6.QtCore import Qt
 
 from angr.analyses.decompiler.structured_codegen.c import CFunctionCall, CConstant, CStructuredCodeGenerator
 from angr.analyses.decompiler.structured_codegen import DummyStructuredCodeGenerator

--- a/angrmanagement/ui/views/console_view.py
+++ b/angrmanagement/ui/views/console_view.py
@@ -1,7 +1,7 @@
 
 import logging
-from PySide2.QtWidgets import QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtCore import QSize
 from traitlets.config.configurable import MultipleInstanceError
 
 from .view import BaseView

--- a/angrmanagement/ui/views/data_dep_view.py
+++ b/angrmanagement/ui/views/data_dep_view.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Dict, List, TYPE_CHECKING, Set
 
 # noinspection PyPackageRequirements
-from PySide2 import QtCore, QtWidgets, QtGui
+from PySide6 import QtCore, QtWidgets, QtGui
 # noinspection PyPackageRequirements
 from networkx import DiGraph
 

--- a/angrmanagement/ui/views/dep_view.py
+++ b/angrmanagement/ui/views/dep_view.py
@@ -2,8 +2,8 @@ from typing import Dict, Any, Optional
 
 import networkx
 
-from PySide2.QtWidgets import QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtCore import QSize
 
 from angr.knowledge_plugins.key_definitions.definition import Definition
 from angr.knowledge_plugins.key_definitions.atoms import Atom

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 import logging
 from typing import Union, Optional, TYPE_CHECKING
 
-import PySide2
-from PySide2.QtWidgets import QHBoxLayout, QVBoxLayout, QApplication, QMessageBox, QMenu, QAction
-from PySide2.QtCore import Qt, Signal
-from PySide2.QtGui import QCursor
+import PySide6
+from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QApplication, QMessageBox, QMenu
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QCursor, QAction
 from angr.block import Block
 from angr.knowledge_plugins.cfg import MemoryData
 
@@ -294,7 +294,7 @@ class DisassemblyView(SynchronizedView):
         menu.addSeparator()
         menu.addMenu(self.get_synchronize_with_submenu())
 
-    def contextMenuEvent(self, event: PySide2.QtGui.QContextMenuEvent):  # pylint: disable=unused-argument
+    def contextMenuEvent(self, event: PySide6.QtGui.QContextMenuEvent):  # pylint: disable=unused-argument
         """
         Display view context menu.
         """

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QVBoxLayout, QLabel
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QVBoxLayout, QLabel
+from PySide6.QtCore import QSize
 
 from .view import BaseView
 from ..widgets.qfunction_table import QFunctionTable

--- a/angrmanagement/ui/views/hex_view.py
+++ b/angrmanagement/ui/views/hex_view.py
@@ -1,12 +1,12 @@
 from typing import Sequence, Union, Optional, Tuple, Callable
 import logging
 
-import PySide2
-from PySide2.QtWidgets import QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QFrame, QGraphicsView, \
+import PySide6
+from PySide6.QtWidgets import QApplication, QHBoxLayout, QMainWindow, QVBoxLayout, QFrame, QGraphicsView, \
     QGraphicsScene, QGraphicsItem, QGraphicsObject, QGraphicsSimpleTextItem, \
-    QGraphicsSceneMouseEvent, QLabel, QMenu, QPushButton, QAction, QMessageBox
-from PySide2.QtGui import QPainterPath, QPen, QFont, QColor, QWheelEvent, QCursor
-from PySide2.QtCore import Qt, QRectF, QPointF, QSizeF, Signal, QEvent, QMarginsF, QTimer
+    QGraphicsSceneMouseEvent, QLabel, QMenu, QPushButton, QMessageBox
+from PySide6.QtGui import QPainterPath, QPen, QFont, QColor, QWheelEvent, QCursor, QAction
+from PySide6.QtCore import Qt, QRectF, QPointF, QSizeF, Signal, QEvent, QMarginsF, QTimer
 
 from angr import Block
 from angr.knowledge_plugins.cfg import MemoryData
@@ -194,7 +194,7 @@ class HexGraphicsObject(QGraphicsObject):
 
         self._update_layout()
 
-    def focusInEvent(self, event: PySide2.QtGui.QFocusEvent):  # pylint: disable=unused-argument
+    def focusInEvent(self, event: PySide6.QtGui.QFocusEvent):  # pylint: disable=unused-argument
         """
         Item receives focus.
         """
@@ -202,7 +202,7 @@ class HexGraphicsObject(QGraphicsObject):
         self.restart_cursor_blink_timer()
         self.update()
 
-    def focusOutEvent(self, event: PySide2.QtGui.QFocusEvent):  # pylint: disable=unused-argument
+    def focusOutEvent(self, event: PySide6.QtGui.QFocusEvent):  # pylint: disable=unused-argument
         """
         Item lost focus.
         """
@@ -491,7 +491,7 @@ class HexGraphicsObject(QGraphicsObject):
         next_nibble = 1 - nibble
         self.set_cursor(self.cursor + next_nibble, nibble=next_nibble)
 
-    def keyPressEvent(self, event: PySide2.QtGui.QKeyEvent):
+    def keyPressEvent(self, event: PySide6.QtGui.QKeyEvent):
         """
         Handle key press events (e.g. moving cursor around).
         """
@@ -709,7 +709,7 @@ class HexGraphicsObject(QGraphicsObject):
             color = color.darker(150)
 
         r = path.boundingRect()
-        bg = PySide2.QtGui.QLinearGradient(r.topLeft(), r.bottomLeft())
+        bg = PySide6.QtGui.QLinearGradient(r.topLeft(), r.bottomLeft())
         top_color = QColor(color)
         top_color.setAlpha(50)
         bg.setColorAt(0, top_color)
@@ -853,7 +853,7 @@ class HexGraphicsObject(QGraphicsObject):
             tl.setY(tl.y() + self.row_height - cursor_height)
             painter.drawRect(QRectF(tl, QSizeF(self.ascii_width, cursor_height)))
 
-    def boundingRect(self) -> PySide2.QtCore.QRectF:
+    def boundingRect(self) -> PySide6.QtCore.QRectF:
         return QRectF(0, 0, self.max_x, self.max_y)
 
 
@@ -950,7 +950,7 @@ class HexGraphicsView(QGraphicsView):
             self.setBackgroundBrush(Conf.palette_base)
             self.update()
 
-    def keyPressEvent(self, event: PySide2.QtGui.QKeyEvent):
+    def keyPressEvent(self, event: PySide6.QtGui.QKeyEvent):
         """
         Handle key events.
         """
@@ -1212,7 +1212,7 @@ class HexView(SynchronizedView):
         if self._clipboard is not None:
             self.project_memory_write_bytearray(self.inner_widget.hex.cursor, self._clipboard)
 
-    def contextMenuEvent(self, event: PySide2.QtGui.QContextMenuEvent):  # pylint: disable=unused-argument
+    def contextMenuEvent(self, event: PySide6.QtGui.QContextMenuEvent):  # pylint: disable=unused-argument
         """
         Display view context menu.
         """
@@ -1295,7 +1295,7 @@ class HexView(SynchronizedView):
             s = f'Address: [{minaddr:08x}, {maxaddr:08x}], {bytes_selected} byte{plural} selected'
         self._status_lbl.setText(s)
 
-    def keyPressEvent(self, event: PySide2.QtGui.QKeyEvent):
+    def keyPressEvent(self, event: PySide6.QtGui.QKeyEvent):
         """
         Handle key events.
         """

--- a/angrmanagement/ui/views/interaction_view.py
+++ b/angrmanagement/ui/views/interaction_view.py
@@ -2,8 +2,8 @@ import enum
 import logging
 from typing import Optional
 from threading import Thread
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtWidgets import QMessageBox, QInputDialog, QLineEdit
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import QMessageBox, QInputDialog, QLineEdit
 
 from .view import BaseView
 

--- a/angrmanagement/ui/views/log_view.py
+++ b/angrmanagement/ui/views/log_view.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2.QtWidgets import QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtCore import QSize
 
 from ..widgets.qlog_widget import QLogWidget
 from .view import BaseView

--- a/angrmanagement/ui/views/patches_view.py
+++ b/angrmanagement/ui/views/patches_view.py
@@ -1,5 +1,5 @@
 
-from PySide2.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog
+from PySide6.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog
 
 from .view import BaseView
 from ..widgets.qpatch_table import QPatchTable

--- a/angrmanagement/ui/views/proximity_view.py
+++ b/angrmanagement/ui/views/proximity_view.py
@@ -2,8 +2,8 @@ from typing import Dict, Optional, Set, TYPE_CHECKING
 
 import networkx
 
-from PySide2.QtWidgets import QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtCore import QSize
 
 from angrmanagement.ui.views.view import BaseView
 from angrmanagement.ui.widgets.qproximity_graph import QProximityGraph

--- a/angrmanagement/ui/views/registers_view.py
+++ b/angrmanagement/ui/views/registers_view.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Optional
 
-import PySide2
-from PySide2.QtGui import QFont, QBrush
-from PySide2.QtCore import QAbstractTableModel, Qt, QSize
-from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout
+import PySide6
+from PySide6.QtGui import QFont, QBrush
+from PySide6.QtCore import QAbstractTableModel, Qt, QSize
+from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout
 import angr
 from archinfo import Register
 
@@ -34,20 +34,20 @@ class QRegisterTableModel(QAbstractTableModel):
     def _filtered_register_list(self):
         return [reg for reg in self.state.arch.register_list if reg.general_purpose]
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return 0 if self.state is None else len(self._filtered_register_list())
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
         if role != Qt.DisplayRole:
             return None
         if section < len(self.Headers):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/ui/views/stack_view.py
+++ b/angrmanagement/ui/views/stack_view.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Any, Optional
 
-import PySide2
-from PySide2.QtGui import QFont
-from PySide2.QtCore import QAbstractTableModel, Qt, QSize
-from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout
+import PySide6
+from PySide6.QtGui import QFont
+from PySide6.QtCore import QAbstractTableModel, Qt, QSize
+from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout
 
 import angr
 
@@ -30,20 +30,20 @@ class QStackTableModel(QAbstractTableModel):
         self._log_widget = log_widget
         self.state: angr.SimState = None
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return 0 if self.state is None else 15
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
         if role != Qt.DisplayRole:
             return None
         if section < len(self.Headers):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/ui/views/states_view.py
+++ b/angrmanagement/ui/views/states_view.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QHBoxLayout
+from PySide6.QtCore import QSize
 
 from .view import BaseView
 from ..widgets.qstate_table import QStateTable

--- a/angrmanagement/ui/views/strings_view.py
+++ b/angrmanagement/ui/views/strings_view.py
@@ -1,6 +1,6 @@
 import re
-from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QLineEdit, QVBoxLayout, QLabel
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QCheckBox, QHBoxLayout, QLineEdit, QVBoxLayout, QLabel
+from PySide6.QtCore import QSize
 
 from angr.knowledge_plugins import Function
 from angr.knowledge_plugins.cfg.memory_data import MemoryData

--- a/angrmanagement/ui/views/symexec_view.py
+++ b/angrmanagement/ui/views/symexec_view.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QMainWindow, QHBoxLayout, QDockWidget
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QMainWindow, QHBoxLayout, QDockWidget
+from PySide6.QtCore import Qt
 
 from ...data.instance import ObjectContainer
 from ..widgets.state_inspector import StateInspector

--- a/angrmanagement/ui/views/trace_map_view.py
+++ b/angrmanagement/ui/views/trace_map_view.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from PySide2.QtWidgets import QVBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QVBoxLayout
+from PySide6.QtCore import QSize
 
 from ..views import BaseView
 from ..widgets import QTraceMap

--- a/angrmanagement/ui/views/traces_view.py
+++ b/angrmanagement/ui/views/traces_view.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any, Optional
 
-import PySide2
-from PySide2.QtCore import QAbstractTableModel, Qt, QSize
-from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
+import PySide6
+from PySide6.QtCore import QAbstractTableModel, Qt, QSize
+from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QMenu
 
 from .view import BaseView
 
@@ -33,20 +33,20 @@ class QTraceTableModel(QAbstractTableModel):
         self.beginResetModel()
         self.endResetModel()
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.instance.traces)
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:  # pylint:disable=unused-argument
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> Any:  # pylint:disable=unused-argument
         if role != Qt.DisplayRole:
             return None
         if section < len(self.Headers):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> Any:
         if not index.isValid():
             return None
         row = index.row()

--- a/angrmanagement/ui/views/types_view.py
+++ b/angrmanagement/ui/views/types_view.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from PySide2.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QFrame, QHBoxLayout, QPushButton, QMessageBox, QLabel
+from PySide6.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QFrame, QHBoxLayout, QPushButton, QMessageBox, QLabel
 
 from angr.sim_type import TypeRef, ALL_TYPES, SimStruct, SimUnion
 

--- a/angrmanagement/ui/views/view.py
+++ b/angrmanagement/ui/views/view.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING, Optional, Mapping, Sequence
 
-import PySide2.QtGui
-from PySide2.QtWidgets import QFrame, QMenu, QAction
-from PySide2.QtCore import QSize
+import PySide6.QtGui
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QFrame, QMenu
+from PySide6.QtCore import QSize
 
 from ...data.highlight_region import SynchronizedHighlightRegion
 
@@ -61,7 +62,7 @@ class BaseView(QFrame):
     def is_shown(self):
         return self.visibleRegion().isEmpty() is False
 
-    def closeEvent(self, event: PySide2.QtGui.QCloseEvent):
+    def closeEvent(self, event: PySide6.QtGui.QCloseEvent):
         self.workspace.view_manager.remove_view(self)
         event.accept()
 
@@ -188,7 +189,7 @@ class SynchronizedView(BaseView):
         Handle view being added to or removed from the view synchronization group.
         """
 
-    def closeEvent(self, event: PySide2.QtGui.QCloseEvent):
+    def closeEvent(self, event: PySide6.QtGui.QCloseEvent):
         """
         View close event handler.
         """

--- a/angrmanagement/ui/widgets/filesystem_table.py
+++ b/angrmanagement/ui/widgets/filesystem_table.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu, QFileDialog, QHeaderView
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu, QFileDialog, QHeaderView
 
 
 class QFileSystemTable(QTableWidget):

--- a/angrmanagement/ui/widgets/qaddress_input.py
+++ b/angrmanagement/ui/widgets/qaddress_input.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, TYPE_CHECKING
 
-from PySide2.QtWidgets import QLineEdit
+from PySide6.QtWidgets import QLineEdit
 
 if TYPE_CHECKING:
     from angrmanagement.ui.workspace import Workspace

--- a/angrmanagement/ui/widgets/qast_viewer.py
+++ b/angrmanagement/ui/widgets/qast_viewer.py
@@ -1,6 +1,6 @@
-from PySide2.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy
-from PySide2.QtGui import QPainter
-from PySide2.QtCore import QSize, Qt
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy
+from PySide6.QtGui import QPainter
+from PySide6.QtCore import QSize, Qt
 
 import claripy
 

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2.QtGui import QPen, QPainterPath
-from PySide2.QtCore import QRectF, QMarginsF
+from PySide6.QtGui import QPen, QPainterPath
+from PySide6.QtCore import QRectF, QMarginsF
 
 from angr.analyses.disassembly import Instruction, IROp
 from angr.analyses.decompiler.clinic import Clinic

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -1,8 +1,8 @@
 from typing import Any, Sequence, Optional, Tuple
 
-from PySide2.QtGui import QPainter, QTextDocument, QTextCursor, QTextCharFormat, QFont, QMouseEvent
-from PySide2.QtCore import Qt, QPointF, QRectF, QObject
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtGui import QPainter, QTextDocument, QTextCursor, QTextCharFormat, QFont, QMouseEvent
+from PySide6.QtCore import Qt, QPointF, QRectF, QObject
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
 
 import ailment
 import pyvex

--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -1,7 +1,7 @@
 
-from PySide2.QtGui import QPainter
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
-from PySide2.QtCore import Qt, QRectF
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtCore import Qt, QRectF
 
 from ...config import Conf
 from .qgraph_object import QCachedGraphicsItem

--- a/angrmanagement/ui/widgets/qccode_edit.py
+++ b/angrmanagement/ui/widgets/qccode_edit.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
-from PySide2.QtCore import Qt, QEvent
-from PySide2.QtGui import QTextCharFormat
-from PySide2.QtWidgets import QMenu, QAction, QInputDialog, QLineEdit, QApplication
+from PySide6.QtCore import Qt, QEvent
+from PySide6.QtGui import QTextCharFormat, QAction
+from PySide6.QtWidgets import QMenu, QInputDialog, QLineEdit, QApplication
 
 from pyqodeng.core import api
 from pyqodeng.core import modes
@@ -21,7 +21,7 @@ from ..widgets.qccode_highlighter import QCCodeHighlighter
 from ..menus.menu import Menu
 
 if TYPE_CHECKING:
-    from PySide2.QtGui import QTextDocument
+    from PySide6.QtGui import QTextDocument
     from ..views.code_view import CodeView
 
 

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -2,7 +2,7 @@
 import re
 
 from pyqodeng.core.api import SyntaxHighlighter
-from PySide2.QtGui import QTextCharFormat, QFont, QBrush
+from PySide6.QtGui import QTextCharFormat, QFont, QBrush
 
 from ..documents import QCodeDocument
 from ...config import Conf

--- a/angrmanagement/ui/widgets/qcolor_option.py
+++ b/angrmanagement/ui/widgets/qcolor_option.py
@@ -1,5 +1,5 @@
-from PySide2.QtGui import QColor
-from PySide2.QtWidgets import QWidget, QHBoxLayout, QFrame, QLabel, QColorDialog
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QFrame, QLabel, QColorDialog
 
 from ...data.object_container import ObjectContainer
 

--- a/angrmanagement/ui/widgets/qconstraint_viewer.py
+++ b/angrmanagement/ui/widgets/qconstraint_viewer.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QFrame, QHeaderView, QSizePolicy, QVBoxLayout,QTableWidget, QTableWidgetItem
+from PySide6.QtWidgets import QFrame, QHeaderView, QSizePolicy, QVBoxLayout,QTableWidget, QTableWidgetItem
 
 
 class QConstraintViewer(QFrame):

--- a/angrmanagement/ui/widgets/qdatadep_graph.py
+++ b/angrmanagement/ui/widgets/qdatadep_graph.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from typing import Optional, Any, List, Dict, TYPE_CHECKING, Set
 
-from PySide2 import QtWidgets, QtCore, QtGui
+from PySide6 import QtWidgets, QtCore, QtGui
 
 from .qgraph import QZoomableDraggableGraphicsView
 from .qgraph_arrow import QDataDepGraphArrow, QDataDepGraphAncestorLine

--- a/angrmanagement/ui/widgets/qdatadepgraph_block.py
+++ b/angrmanagement/ui/widgets/qdatadepgraph_block.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from PySide2 import QtWidgets, QtCore, QtGui
+from PySide6 import QtWidgets, QtCore, QtGui
 
 
 from angr.analyses.data_dep import ConstantDepNode, TmpDepNode

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QTreeWidget, QTreeWidgetItem, QPushButton
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QTreeWidget, QTreeWidgetItem, QPushButton
 
 from angr.analyses.decompiler.decompilation_options import options as dec_options
 from angr.analyses.decompiler.optimization_passes import get_optimization_passes, get_default_optimization_passes

--- a/angrmanagement/ui/widgets/qdep_graph.py
+++ b/angrmanagement/ui/widgets/qdep_graph.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, List, Dict, Any
 import logging
 
-from PySide2.QtCore import Qt, QPointF
+from PySide6.QtCore import Qt, QPointF
 
 from ...utils.edge import Edge
 from ...utils.tree_graph_layouter import TreeGraphLayouter

--- a/angrmanagement/ui/widgets/qdepgraph_block.py
+++ b/angrmanagement/ui/widgets/qdepgraph_block.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, Optional
 import logging
 
-import PySide2.QtWidgets
-from PySide2.QtGui import QColor, QPen
-from PySide2.QtCore import Qt, QRectF
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
+import PySide6.QtWidgets
+from PySide6.QtGui import QColor, QPen
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
 
 from angr.knowledge_plugins.key_definitions.atoms import Atom, Register, MemoryLocation, SpOffset
 
@@ -167,10 +167,10 @@ class QDepGraphBlock(QCachedGraphicsItem):
 
         super().mouseDoubleClickEvent(event)
 
-    def hoverEnterEvent(self, event: PySide2.QtWidgets.QGraphicsSceneHoverEvent):
+    def hoverEnterEvent(self, event: PySide6.QtWidgets.QGraphicsSceneHoverEvent):
         self._dep_view.hover_enter_block(self)
 
-    def hoverLeaveEvent(self, event: PySide2.QtWidgets.QGraphicsSceneHoverEvent):
+    def hoverLeaveEvent(self, event: PySide6.QtWidgets.QGraphicsSceneHoverEvent):
         self._dep_view.hover_leave_block(self)
 
     def paint(self, painter, option, widget): #pylint: disable=unused-argument

--- a/angrmanagement/ui/widgets/qdisasm_base_control.py
+++ b/angrmanagement/ui/widgets/qdisasm_base_control.py
@@ -1,5 +1,5 @@
 from typing import Optional, Tuple, TYPE_CHECKING
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 from enum import Enum
 
 if TYPE_CHECKING:

--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -1,7 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 import logging
 
-from PySide2.QtCore import QRect, QPointF, Qt, QSize, QEvent, QRectF, QTimeLine
+from PySide6.QtCore import QRect, QPointF, Qt, QSize, QEvent, QRectF, QTimeLine
 
 from angr.analyses.decompiler.utils import to_ail_supergraph
 

--- a/angrmanagement/ui/widgets/qdisasm_statusbar.py
+++ b/angrmanagement/ui/widgets/qdisasm_statusbar.py
@@ -2,7 +2,7 @@ import os
 import logging
 from typing import Optional
 
-from PySide2.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QFileDialog, QComboBox
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QFileDialog, QComboBox
 
 from ..menus.disasm_options_menu import DisasmOptionsMenu
 from ..toolbars import NavToolbar

--- a/angrmanagement/ui/widgets/qfeature_map.py
+++ b/angrmanagement/ui/widgets/qfeature_map.py
@@ -2,10 +2,10 @@ from typing import Optional, Sequence, Mapping
 import logging
 from sortedcontainers import SortedDict
 
-from PySide2.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItem, QGraphicsRectItem, \
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItem, QGraphicsRectItem, \
     QGraphicsPolygonItem, QGraphicsLineItem
-from PySide2.QtGui import QBrush, QPen, QPolygonF
-from PySide2.QtCore import Qt, QRectF, QSize, QPointF, QPoint, QEvent, QMarginsF
+from PySide6.QtGui import QBrush, QPen, QPolygonF
+from PySide6.QtCore import Qt, QRectF, QSize, QPointF, QPoint, QEvent, QMarginsF
 
 import cle
 from angr.block import Block

--- a/angrmanagement/ui/widgets/qfiledesc_viewer.py
+++ b/angrmanagement/ui/widgets/qfiledesc_viewer.py
@@ -1,6 +1,6 @@
 import os
 import typing
-from PySide2.QtWidgets import QFileDialog, QFrame, QComboBox, QMessageBox, QPushButton, QVBoxLayout, QTextEdit
+from PySide6.QtWidgets import QFileDialog, QFrame, QComboBox, QMessageBox, QPushButton, QVBoxLayout, QTextEdit
 from angr.storage.file import SimFileDescriptor
 
 

--- a/angrmanagement/ui/widgets/qfunction_combobox.py
+++ b/angrmanagement/ui/widgets/qfunction_combobox.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QComboBox, QHBoxLayout
+from PySide6.QtWidgets import QComboBox, QHBoxLayout
 
 from angr.knowledge_plugins import FunctionManager
 

--- a/angrmanagement/ui/widgets/qfunction_header.py
+++ b/angrmanagement/ui/widgets/qfunction_header.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from PySide2.QtGui import QPainter, QCursor
-from PySide2.QtCore import Qt, QRectF
-from PySide2.QtWidgets import QApplication, QGraphicsSimpleTextItem
+from PySide6.QtGui import QPainter, QCursor
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QApplication, QGraphicsSimpleTextItem
 
 from angr.sim_type import SimTypeFunction
 from angr.calling_conventions import SimRegArg

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -4,9 +4,9 @@ from typing import List, Set, Tuple, Optional, TYPE_CHECKING
 
 from angr.analyses.code_tagging import CodeTags
 
-from PySide2.QtWidgets import QWidget, QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QLineEdit
-from PySide2.QtGui import QBrush, QColor, QCursor
-from PySide2.QtCore import Qt, QAbstractTableModel, SIGNAL, QEvent
+from PySide6.QtWidgets import QWidget, QTableView, QAbstractItemView, QHeaderView, QVBoxLayout, QLineEdit
+from PySide6.QtGui import QBrush, QColor, QCursor
+from PySide6.QtCore import Qt, QAbstractTableModel, SIGNAL, QEvent
 
 from ..menus.function_context_menu import FunctionContextMenu
 from ...data.instance import ObjectContainer
@@ -14,7 +14,7 @@ from ...config import Conf
 from ..toolbars import FunctionTableToolbar
 
 if TYPE_CHECKING:
-    import PySide2
+    import PySide6
     from ..views.functions_view import FunctionsView
     from angr.knowledge_plugins.functions import Function, FunctionManager
 
@@ -317,7 +317,7 @@ class QFunctionTableView(QTableView):
         self._function_table.show_filter_box(prefix=text)
         return True
 
-    def contextMenuEvent(self, event:'PySide2.QtGui.QContextMenuEvent') -> None: # pylint:disable=unused-argument
+    def contextMenuEvent(self, event:'PySide6.QtGui.QContextMenuEvent') -> None: # pylint:disable=unused-argument
         rows = self.selectionModel().selectedRows()
         funcs = [self.workspace.instance.kb.functions[r.data()] for r in rows]
         self._context_menu.set(funcs).qmenu().popup(QCursor.pos())

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -1,9 +1,9 @@
 import logging
 
-from PySide2.QtWidgets import QGraphicsScene, QGraphicsView, QStyleOptionGraphicsItem, QApplication,\
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsView, QStyleOptionGraphicsItem, QApplication,\
     QGraphicsSceneMouseEvent
-from PySide2.QtGui import QPainter, QMouseEvent, QImage, QVector2D
-from PySide2.QtCore import Qt, QSize, QEvent, QMarginsF, Signal, QRectF
+from PySide6.QtGui import QPainter, QMouseEvent, QImage, QVector2D
+from PySide6.QtCore import Qt, QSize, QEvent, QMarginsF, Signal, QRectF
 
 _l = logging.getLogger(__name__)
 

--- a/angrmanagement/ui/widgets/qgraph_arrow.py
+++ b/angrmanagement/ui/widgets/qgraph_arrow.py
@@ -1,9 +1,9 @@
 import math
 from typing import TYPE_CHECKING, List
 
-from PySide2.QtWidgets import QGraphicsItem, QApplication, QToolTip
-from PySide2.QtGui import QPen, QBrush, QColor, QPainterPath, QPainterPathStroker, QKeyEvent
-from PySide2.QtCore import QPointF, Qt
+from PySide6.QtWidgets import QGraphicsItem, QApplication, QToolTip
+from PySide6.QtGui import QPen, QBrush, QColor, QPainterPath, QPainterPathStroker, QKeyEvent
+from PySide6.QtCore import QPointF, Qt
 
 from ...utils.edge import EdgeSort
 from ...config import Conf

--- a/angrmanagement/ui/widgets/qgraph_object.py
+++ b/angrmanagement/ui/widgets/qgraph_object.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QGraphicsItem
+from PySide6.QtWidgets import QGraphicsItem
 
 
 class QCachedGraphicsItem(QGraphicsItem):

--- a/angrmanagement/ui/widgets/qinst_annotation.py
+++ b/angrmanagement/ui/widgets/qinst_annotation.py
@@ -1,7 +1,7 @@
 from typing import List, TYPE_CHECKING, Dict
-from PySide2.QtGui import QColor, QPainterPath, QBrush, QCursor
-from PySide2.QtCore import QMarginsF
-from PySide2.QtWidgets import QGraphicsItem, QGraphicsSimpleTextItem, QGraphicsSceneMouseEvent, QMenu, \
+from PySide6.QtGui import QColor, QPainterPath, QBrush, QCursor
+from PySide6.QtCore import QMarginsF
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsSimpleTextItem, QGraphicsSceneMouseEvent, QMenu, \
     QInputDialog, QLineEdit
 
 from .qsimulation_managers import QSimulationManagers

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
 import logging
 
-import PySide2
-from PySide2.QtGui import QPainter, QCursor, QBrush
-from PySide2.QtCore import Qt, QRectF
-from PySide2.QtWidgets import QApplication, QGraphicsSceneMouseEvent, QGraphicsSimpleTextItem
+import PySide6
+from PySide6.QtGui import QPainter, QCursor, QBrush
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QApplication, QGraphicsSceneMouseEvent, QGraphicsSimpleTextItem
 
 from angr.analyses.disassembly import Value
 from .qgraph_object import QCachedGraphicsItem
@@ -57,7 +57,7 @@ class QInstruction(QCachedGraphicsItem):
 
         self._init_widgets()
 
-    def contextMenuEvent(self, event:PySide2.QtWidgets.QGraphicsSceneContextMenuEvent) -> None:
+    def contextMenuEvent(self, event:PySide6.QtWidgets.QGraphicsSceneContextMenuEvent) -> None:
         pass
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -2,9 +2,9 @@ from typing import Optional, TYPE_CHECKING, Union
 import logging
 from sortedcontainers import SortedDict
 
-from PySide2.QtWidgets import QGraphicsScene, QAbstractSlider, QHBoxLayout, QAbstractScrollArea
-from PySide2.QtGui import QPainter
-from PySide2.QtCore import Qt, QRectF, QRect, QEvent
+from PySide6.QtWidgets import QGraphicsScene, QAbstractSlider, QHBoxLayout, QAbstractScrollArea
+from PySide6.QtGui import QPainter
+from PySide6.QtCore import Qt, QRectF, QRect, QEvent
 
 from angr.block import Block
 from angr.knowledge_plugins.cfg.memory_data import MemoryData

--- a/angrmanagement/ui/widgets/qlog_widget.py
+++ b/angrmanagement/ui/widgets/qlog_widget.py
@@ -3,10 +3,10 @@ import os
 import logging
 from typing import List, Any, Optional
 
-import PySide2
-from PySide2.QtWidgets import QTableView, QAbstractItemView, QHeaderView
-from PySide2.QtCore import QAbstractTableModel, Qt
-from PySide2.QtGui import QIcon, QCursor, QGuiApplication, QClipboard, QKeySequence
+import PySide6
+from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView
+from PySide6.QtCore import QAbstractTableModel, Qt
+from PySide6.QtGui import QIcon, QCursor, QGuiApplication, QClipboard, QKeySequence
 
 from ...config import IMG_LOCATION
 from ...logic.threads import gui_thread_schedule_async
@@ -62,20 +62,20 @@ class QLogTableModel(QAbstractTableModel):
     def log(self) -> List[LogRecord]:
         return self._log
 
-    def rowCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def rowCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self._log)
 
-    def columnCount(self, parent:PySide2.QtCore.QModelIndex=...) -> int:
+    def columnCount(self, parent:PySide6.QtCore.QModelIndex=...) -> int:
         return len(self.Headers)
 
-    def headerData(self, section:int, orientation:PySide2.QtCore.Qt.Orientation, role:int=...) -> Any:
+    def headerData(self, section:int, orientation:PySide6.QtCore.Qt.Orientation, role:int=...) -> Any:
         if role != Qt.DisplayRole:
             return None
         if section < len(self.Headers):
             return self.Headers[section]
         return None
 
-    def data(self, index:PySide2.QtCore.QModelIndex, role:int=...) -> Any:
+    def data(self, index:PySide6.QtCore.QModelIndex, role:int=...) -> Any:
         if not index.isValid():
             return None
         row = index.row()
@@ -209,7 +209,7 @@ class QLogWidget(QTableView):
         self.log_view.workspace.instance.log.am_unsubscribe(self._on_new_logrecord)
         super().closeEvent(event)
 
-    def contextMenuEvent(self, arg__1: PySide2.QtGui.QContextMenuEvent):
+    def contextMenuEvent(self, arg__1: PySide6.QtGui.QContextMenuEvent):
         self._context_menu.popup(QCursor.pos())
 
     def _on_new_logrecord(self, log_record: LogRecord = None):
@@ -239,7 +239,7 @@ class QLogWidget(QTableView):
         if self._auto_scroll:
             self.scrollToBottom()
 
-    def keyPressEvent(self, event:PySide2.QtGui.QKeyEvent):
+    def keyPressEvent(self, event:PySide6.QtGui.QKeyEvent):
         if event.matches(QKeySequence.Copy):
             self.copy_selected_messages()
         else:

--- a/angrmanagement/ui/widgets/qmemory_data_block.py
+++ b/angrmanagement/ui/widgets/qmemory_data_block.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Tuple
 import math
 
-from PySide2.QtCore import Qt, QRectF
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
 
 from angr.knowledge_plugins.cfg.memory_data import MemoryDataSort, MemoryData
 

--- a/angrmanagement/ui/widgets/qmemory_viewer.py
+++ b/angrmanagement/ui/widgets/qmemory_viewer.py
@@ -1,9 +1,9 @@
 import logging
 
-from PySide2.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QLineEdit,\
+from PySide6.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QLineEdit,\
     QWidget
-from PySide2.QtGui import QPainter, QBrush, QPen
-from PySide2.QtCore import Qt, QSize
+from PySide6.QtGui import QPainter, QBrush, QPen
+from PySide6.QtCore import Qt, QSize
 
 from ...config import Conf
 from .qast_viewer import QASTViewer

--- a/angrmanagement/ui/widgets/qminimap.py
+++ b/angrmanagement/ui/widgets/qminimap.py
@@ -1,6 +1,6 @@
-from PySide2.QtCore import QPoint, QPointF, Qt, QRectF, QMarginsF, QEvent
-from PySide2.QtGui import QPainter, QPainterPath, QPen, QMouseEvent, QWheelEvent, QImage
-from PySide2.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsItem, QFrame
+from PySide6.QtCore import QPoint, QPointF, Qt, QRectF, QMarginsF, QEvent
+from PySide6.QtGui import QPainter, QPainterPath, QPen, QMouseEvent, QWheelEvent, QImage
+from PySide6.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsItem, QFrame
 
 from ...config import Conf
 from .qgraph import QBaseGraphicsView

--- a/angrmanagement/ui/widgets/qoperand.py
+++ b/angrmanagement/ui/widgets/qoperand.py
@@ -1,8 +1,8 @@
 from typing import Optional
 import logging
 
-from PySide2.QtWidgets import QApplication, QGraphicsSimpleTextItem
-from PySide2.QtCore import Qt, QRectF, QPointF
+from PySide6.QtWidgets import QApplication, QGraphicsSimpleTextItem
+from PySide6.QtCore import Qt, QRectF, QPointF
 
 from angr.analyses.disassembly import ConstantOperand, RegisterOperand, MemoryOperand, Value
 

--- a/angrmanagement/ui/widgets/qpatch_table.py
+++ b/angrmanagement/ui/widgets/qpatch_table.py
@@ -1,9 +1,9 @@
 import binascii
 from typing import Set
 
-from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu, QAction, QMessageBox
-from PySide2.QtCore import Qt
-from PySide2.QtGui import QContextMenuEvent, QCursor
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu, QMessageBox
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QContextMenuEvent, QCursor, QAction
 
 from angr.knowledge_plugins.patches import Patch
 

--- a/angrmanagement/ui/widgets/qpathtree.py
+++ b/angrmanagement/ui/widgets/qpathtree.py
@@ -2,8 +2,8 @@ import weakref
 import logging
 
 import networkx
-from PySide2.QtWidgets import QFrame, QHBoxLayout
-from PySide2.QtCore import QSize
+from PySide6.QtWidgets import QFrame, QHBoxLayout
+from PySide6.QtCore import QSize
 
 from .qsymexec_graph import QSymExecGraph
 from .qstate_block import QStateBlock

--- a/angrmanagement/ui/widgets/qphivariable.py
+++ b/angrmanagement/ui/widgets/qphivariable.py
@@ -1,6 +1,6 @@
 
-from PySide2.QtGui import QColor
-from PySide2.QtCore import Qt, QRectF
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt, QRectF
 
 from ...utils.block_objects import PhiVariable
 from .qgraph_object import QCachedGraphicsItem

--- a/angrmanagement/ui/widgets/qproximity_graph.py
+++ b/angrmanagement/ui/widgets/qproximity_graph.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, List, Dict, Any
 import logging
 
-from PySide2.QtCore import Qt, QPointF
+from PySide6.QtCore import Qt, QPointF
 
 from ...utils.edge import Edge
 from ...utils.tree_graph_layouter import TreeGraphLayouter

--- a/angrmanagement/ui/widgets/qproximitygraph_block.py
+++ b/angrmanagement/ui/widgets/qproximitygraph_block.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING, List, Tuple, Type
 import logging
 
-import PySide2.QtWidgets
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
-from PySide2.QtGui import QPen
-from PySide2.QtCore import Qt, QRectF
+import PySide6.QtWidgets
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtGui import QPen
+from PySide6.QtCore import Qt, QRectF
 
 from angr.analyses.proximity_graph import FunctionProxiNode, CallProxiNode, StringProxiNode, \
     IntegerProxiNode, UnknownProxiNode, VariableProxiNode
@@ -85,10 +85,10 @@ class QProximityGraphBlock(QCachedGraphicsItem):
 
         super().mouseDoubleClickEvent(event)
 
-    def hoverEnterEvent(self, event: PySide2.QtWidgets.QGraphicsSceneHoverEvent):  # pylint:disable=unused-argument
+    def hoverEnterEvent(self, event: PySide6.QtWidgets.QGraphicsSceneHoverEvent):  # pylint:disable=unused-argument
         self._proximity_view.hover_enter_block(self)
 
-    def hoverLeaveEvent(self, event: PySide2.QtWidgets.QGraphicsSceneHoverEvent):  # pylint:disable=unused-argument
+    def hoverLeaveEvent(self, event: PySide6.QtWidgets.QGraphicsSceneHoverEvent):  # pylint:disable=unused-argument
         self._proximity_view.hover_leave_block(self)
 
     def _paint_boundary(self, painter):

--- a/angrmanagement/ui/widgets/qregister_viewer.py
+++ b/angrmanagement/ui/widgets/qregister_viewer.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QSizePolicy
-from PySide2.QtCore import Qt, QSize
+from PySide6.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QSizePolicy
+from PySide6.QtCore import Qt, QSize
 
 from .qast_viewer import QASTViewer
 

--- a/angrmanagement/ui/widgets/qsimulation_manager_viewer.py
+++ b/angrmanagement/ui/widgets/qsimulation_manager_viewer.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
 from typing import List
 
-from PySide2.QtGui import QCursor, QContextMenuEvent
-from PySide2.QtWidgets import QTreeWidget, QTreeWidgetItem, QMenu, QMessageBox, QInputDialog, QAbstractItemView
-from PySide2.QtCore import Qt
+from PySide6.QtGui import QCursor, QContextMenuEvent
+from PySide6.QtWidgets import QTreeWidget, QTreeWidgetItem, QMenu, QMessageBox, QInputDialog, QAbstractItemView
+from PySide6.QtCore import Qt
 
 from angr import SimState
 from inspect import isfunction

--- a/angrmanagement/ui/widgets/qsimulation_managers.py
+++ b/angrmanagement/ui/widgets/qsimulation_managers.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING
 
-from PySide2.QtWidgets import QFrame, QInputDialog, QLabel, QComboBox, QHBoxLayout, QVBoxLayout, QPushButton, \
+from PySide6.QtWidgets import QFrame, QInputDialog, QLabel, QComboBox, QHBoxLayout, QVBoxLayout, QPushButton, \
     QCheckBox, QTabWidget, QTreeWidget, QTreeWidgetItem
-from PySide2.QtCore import Qt
+from PySide6.QtCore import Qt
 
 from ...data.jobs import SimgrStepJob, SimgrExploreJob
 from ..widgets.qsimulation_manager_viewer import QSimulationManagerViewer

--- a/angrmanagement/ui/widgets/qsmart_dockwidget.py
+++ b/angrmanagement/ui/widgets/qsmart_dockwidget.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QDockWidget
+from PySide6.QtWidgets import QDockWidget
 
 
 class QSmartDockWidget(QDockWidget):

--- a/angrmanagement/ui/widgets/qstate_block.py
+++ b/angrmanagement/ui/widgets/qstate_block.py
@@ -1,8 +1,8 @@
 import logging
 
-from PySide2.QtWidgets import QGraphicsItem
-from PySide2.QtGui import QColor, QPen
-from PySide2.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QGraphicsItem
+from PySide6.QtGui import QColor, QPen
+from PySide6.QtCore import Qt, QRectF
 
 from ...config import Conf
 from ...utils import locate_function

--- a/angrmanagement/ui/widgets/qstate_combobox.py
+++ b/angrmanagement/ui/widgets/qstate_combobox.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QComboBox
+from PySide6.QtWidgets import QComboBox
 
 
 class QStateComboBox(QComboBox):

--- a/angrmanagement/ui/widgets/qstate_table.py
+++ b/angrmanagement/ui/widgets/qstate_table.py
@@ -1,9 +1,9 @@
 
 import re
 
-from PySide2.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu
-from PySide2.QtGui import QColor
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt
 
 import angr
 

--- a/angrmanagement/ui/widgets/qstring_table.py
+++ b/angrmanagement/ui/widgets/qstring_table.py
@@ -1,7 +1,7 @@
 from typing import Any
 import re
-from PySide2.QtWidgets import QHeaderView, QTableView, QAbstractItemView
-from PySide2.QtCore import QSortFilterProxyModel, Qt, QAbstractTableModel
+from PySide6.QtWidgets import QHeaderView, QTableView, QAbstractItemView
+from PySide6.QtCore import QSortFilterProxyModel, Qt, QAbstractTableModel
 
 from angr.analyses.cfg.cfg_fast import MemoryData
 

--- a/angrmanagement/ui/widgets/qsymexec_graph.py
+++ b/angrmanagement/ui/widgets/qsymexec_graph.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2.QtGui import QColor, QPen, QBrush
-from PySide2.QtCore import Qt, QPointF
+from PySide6.QtGui import QColor, QPen, QBrush
+from PySide6.QtCore import Qt, QPointF
 
 from ...utils.graph_layouter import GraphLayouter
 from .qgraph import QZoomableDraggableGraphicsView

--- a/angrmanagement/ui/widgets/qtrace_map.py
+++ b/angrmanagement/ui/widgets/qtrace_map.py
@@ -1,10 +1,10 @@
 from typing import Optional, Sequence
 import logging
 
-from PySide2.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItem, QGraphicsRectItem, \
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QGraphicsScene, QGraphicsView, QGraphicsItem, QGraphicsRectItem, \
     QGraphicsPolygonItem, QGraphicsLineItem
-from PySide2.QtGui import QBrush, QPen, QPolygonF, QLinearGradient, QColor
-from PySide2.QtCore import Qt, QRectF, QSize, QPointF, QPoint, QEvent
+from PySide6.QtGui import QBrush, QPen, QPolygonF, QLinearGradient, QColor
+from PySide6.QtCore import Qt, QRectF, QSize, QPointF, QPoint, QEvent
 
 from ...config import Conf
 from ...logic.debugger import DebuggerWatcher

--- a/angrmanagement/ui/widgets/qtypedef.py
+++ b/angrmanagement/ui/widgets/qtypedef.py
@@ -1,6 +1,6 @@
-from PySide2.QtGui import QPainter, QBrush, QColor
-from PySide2.QtWidgets import QWidget, QSizePolicy, QMessageBox
-from PySide2.QtCore import Qt, QSize
+from PySide6.QtGui import QPainter, QBrush, QColor
+from PySide6.QtWidgets import QWidget, QSizePolicy, QMessageBox
+from PySide6.QtCore import Qt, QSize
 
 from angr.sim_type import TypeRef, SimUnion, SimStruct, SimTypeBottom
 from angr.knowledge_plugins.types import TypesStore

--- a/angrmanagement/ui/widgets/qunknown_block.py
+++ b/angrmanagement/ui/widgets/qunknown_block.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
-from PySide2.QtCore import QRectF
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtCore import QRectF
 
 from ...config import Conf
 from .qgraph_object import QCachedGraphicsItem

--- a/angrmanagement/ui/widgets/qvariable.py
+++ b/angrmanagement/ui/widgets/qvariable.py
@@ -1,5 +1,5 @@
-from PySide2.QtWidgets import QGraphicsSimpleTextItem
-from PySide2.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
+from PySide6.QtCore import Qt, QRectF
 
 from .qgraph_object import QCachedGraphicsItem
 

--- a/angrmanagement/ui/widgets/qvextemps_viewer.py
+++ b/angrmanagement/ui/widgets/qvextemps_viewer.py
@@ -1,7 +1,7 @@
 import logging
 
-from PySide2.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QSizePolicy
-from PySide2.QtCore import Qt, QSize
+from PySide6.QtWidgets import QFrame, QLabel, QVBoxLayout, QHBoxLayout, QScrollArea, QSizePolicy
+from PySide6.QtCore import Qt, QSize
 
 from .qast_viewer import QASTViewer
 

--- a/angrmanagement/ui/widgets/qxref_viewer.py
+++ b/angrmanagement/ui/widgets/qxref_viewer.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from PySide2.QtWidgets import QAbstractItemView, QHeaderView, QTableView
-from PySide2.QtCore import Qt, QAbstractTableModel
+from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QTableView
+from PySide6.QtCore import Qt, QAbstractTableModel
 
 from angr.knowledge_plugins.variables.variable_access import VariableAccess
 from angr.knowledge_plugins.xrefs.xref import XRef, XRefType

--- a/angrmanagement/ui/widgets/state_inspector.py
+++ b/angrmanagement/ui/widgets/state_inspector.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QTabWidget
+from PySide6.QtWidgets import QTabWidget
 
 from .qmemory_viewer import QMemoryViewer
 from .qregister_viewer import QRegisterViewer

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Callable, Optional, List, Union
 import logging
 import traceback
 
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 from angr.knowledge_plugins.functions.function import Function
 from angr import StateHierarchy
 from angr.misc.testing import is_testing

--- a/angrmanagement/utils/io.py
+++ b/angrmanagement/utils/io.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import requests
 
-from PySide2.QtWidgets import QFileDialog
+from PySide6.QtWidgets import QFileDialog
 
 from ..config import Conf
 from ..errors import InvalidURLError, UnexpectedStatusCodeError

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,6 +1,6 @@
 import os
 
-from PySide2.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication
 
 from angrmanagement.config import Conf
 

--- a/tests/disabled_test_binsync_plugin.py
+++ b/tests/disabled_test_binsync_plugin.py
@@ -4,8 +4,8 @@ import tempfile
 import time
 import unittest
 
-from PySide2.QtTest import QTest
-from PySide2.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtCore import Qt
 
 import angr
 import common

--- a/tests/manual_human_activities.py
+++ b/tests/manual_human_activities.py
@@ -6,9 +6,9 @@ import string
 import unittest
 from time import sleep
 
-from PySide2.QtTest import QTest
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QGraphicsScene, QGraphicsView
+from PySide6.QtTest import QTest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsView
 
 import angr
 from angrmanagement.ui.main_window import MainWindow

--- a/tests/test_qaddress_input.py
+++ b/tests/test_qaddress_input.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 
-from PySide2.QtTest import QTest
+from PySide6.QtTest import QTest
 
 from angrmanagement.ui.main_window import MainWindow
 import angr

--- a/tests/test_rename_functions.py
+++ b/tests/test_rename_functions.py
@@ -2,8 +2,8 @@ import os
 import sys
 import unittest
 
-from PySide2.QtTest import QTest
-from PySide2.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtCore import Qt
 
 import angr
 from angrmanagement.ui.main_window import MainWindow


### PR DESCRIPTION
## Background
The current and hardest problems for this port has to do with a fork of pyqode that we use:
https://github.com/ltfish/pyqodeng.core

This repo depends on `qtpy`, which we "use" for Qt version agnostic imports. QtPy currently does not support many imports that we still use in PySide6. An example is the `QUndoCommand` which was moved from Qt.Widgets to Qt.Gui in PySide6. However, `qtpy`, does not fix this case: 
https://github.com/spyder-ide/qtpy/blob/6199be5ad3d4ed16d69ee1ac48f45e59cdc8436b/qtpy/QtWidgets.py#L39

There are **many** such cases of this that I have tracked. The real problem is that we are even still trying to use an agnostic platform like this. 

## Proposal 
To address these issues I propose we do three things:
1. Remove use of `qtpy` from the entirety of angr-management
2. Support only PySide6 in angr-management 
3. Do a full refactor of our fork of pyqodeng to no longer use `qtpy` and only use PySide6

Currently, I have started by fixing some imports that have been deprecated or moved for PySide6, but now this PR waits on changes to pyqode fork for PySide6 use only. 
