### PR TITLE
Fix minor crashes in QFileDescriptorViewer

### DIFF
--- a/angrmanagement/ui/widgets/qfiledesc_viewer.py
+++ b/angrmanagement/ui/widgets/qfiledesc_viewer.py
@@ -32,6 +32,12 @@ class QFileDescriptorViewer(QFrame):
         self._state.am_subscribe(self._watch_state)
 
     def dump_fd(self, fd):
+        # Clean up when nothing is selected
+        if fd == -1:
+            self._current_fd = None
+            self.textedit.setPlainText("")
+            return
+
         if self._state.am_none:
             return
         self._current_fd = fd
@@ -75,6 +81,6 @@ class QFileDescriptorViewer(QFrame):
             if fd in self.STD:
                 self.select_fd.addItem(self.STD[fd])
             elif isinstance(simfile, SimFileDescriptor):
-                self.select_fd.addItem(simfile.file.name)
+                self.select_fd.addItem(str(simfile.file.name))
             else:
                 self.select_fd.addItem(str(simfile))


### PR DESCRIPTION
Steps to reproduce:
- Load a small CTF-like binary
- Go to main, right click the first instruction -> symbolic execution
- Call state
- Ok
- Press Explore
- Just kinda wait and click around. Eventually it freezes, but I found these two crashes