### PR TITLE
Add call explorer view

### DIFF
--- a/angrmanagement/logic/debugger/bintrace.py
+++ b/angrmanagement/logic/debugger/bintrace.py
@@ -1,14 +1,18 @@
 import os
 import logging
-from typing import Optional
+from typing import Optional, Tuple, Sequence
 
 from angr import SimState
+from angr.knowledge_plugins import Function
+
 
 try:
     import bintrace
     from bintrace.debugger_angr import AngrTraceDebugger
+    from bintrace import TraceEvent
 except ImportError as e:
     bintrace = None
+    TraceEvent = 'TraceEvent'
 
 from ...data.trace import BintraceTrace
 from ...data.breakpoint import BreakpointType
@@ -27,14 +31,14 @@ class BintraceDebugger(Debugger):
         super().__init__(workspace)
         assert bintrace is not None
         assert isinstance(trace, BintraceTrace)
-        self._trace: 'bintrace.Trace' = trace
-        self._trace_dbg: AngrTraceDebugger = AngrTraceDebugger(self._trace.trace,
-                                                               self.workspace.instance.project.am_obj)
+        self._trace: BintraceTrace = trace
+        self._btrace: bintrace.Trace = trace.trace
+        self._trace_dbg: AngrTraceDebugger = AngrTraceDebugger(self._btrace, self.workspace.instance.project.am_obj)
         self._cached_simstate = None
 
     def __str__(self):
         pc = self.simstate.solver.eval(self.simstate.regs.pc)
-        return f'{os.path.basename(self._trace.trace.path)} @ {pc:x}'
+        return f'{os.path.basename(self._btrace.path)} @ {pc:x}'
 
     def _on_state_change(self):
         """
@@ -128,7 +132,7 @@ class BintraceDebugger(Debugger):
         """
         Replay to the Nth event, skipping over stop events and ending on the nearest execution event.
         """
-        t = self._trace.trace
+        t = self._btrace
         assert 0 <= n < t.get_num_events()
 
         until = t.get_nth_event(n)
@@ -143,3 +147,143 @@ class BintraceDebugger(Debugger):
 
         self._trace_dbg.state = t.replay(self._trace_dbg.state, until)
         self._on_state_change()
+
+    def get_current_function(self):
+        if self._trace_dbg.state is None:
+            return None
+        else:
+            return self.get_function_for_event(self._trace_dbg.state.event)
+
+    def replay_to_event(self, until):
+        self._trace_dbg.state = self._btrace.replay(self._trace_dbg.state, until)
+        self._on_state_change()
+
+
+    #
+    # Trace Analysis
+    #
+    # FIXME: Factor this out of debugger
+    #
+
+    def get_function_for_event(self, event: TraceEvent) -> Optional[Function]:
+        """
+        Find currently execution function at `event`.
+        """
+        # Rewind to last block event
+        if event and not isinstance(event, bintrace.FBBlockEvent):
+            event = self._btrace.get_prev_bb_event(event, vcpu=self._trace_dbg.vcpu)
+        if event is None:
+            return None
+
+        # Determine what function we are in currently.
+        node = self.workspace.instance.cfg.get_node(event.Addr())
+        if node is None:
+            return None
+
+        kb = self.workspace.instance.project.kb
+        if node.function_address in kb.functions:
+            return kb.functions[node.function_address], event
+        else:
+            _l.warning('Node %s not found in functions db', node)
+            return None
+
+    def get_called_functions(self, event: Optional[TraceEvent] = None,
+                                   only_after_event: bool = False) -> Sequence[Tuple[Function, TraceEvent]]:
+        """
+        Enumerate 1st order outgoing calls of function at `event`.
+        """
+        if event is None:
+            if self._trace_dbg.state:
+                event = self._trace_dbg.state.event
+            else:
+                return []
+
+        # Get current function
+        func = self.get_function_for_event(event)
+        if func is None:
+            _l.warning('Could not determine function for event %s', event)
+            return []
+
+        func, event = func
+        _l.debug('Function for event %s: %s', event, func.name)
+
+        if not only_after_event:
+            # Rewind to function entry
+            # FIXME: Does not properly handle nested calls to this function!
+            while event.Addr() != func.addr:
+                event = self._btrace.get_prev_bb_event(event, vcpu=self._trace_dbg.vcpu)
+                if event is None:
+                    _l.error('Did not find start of function %s (%#x) in trace', func.name, func.addr)
+                    return []
+
+        called_addrs = []
+        keep_looking = True
+        while keep_looking:
+            # Step until next function exit
+            called_func_entry_event = self._btrace.get_next_bb_event(event, vcpu=self._trace_dbg.vcpu)
+            if called_func_entry_event is None:
+                # End of trace
+                break
+
+            # FIXME: Possible failure in func.block_addrs_set not matching
+            addr = called_func_entry_event.Addr()
+            is_a_function_exit = (addr not in func.block_addrs_set) or (addr == func.addr)
+            if not is_a_function_exit:
+                event = called_func_entry_event
+                continue
+
+            # Check exit type
+            exit_block_addr = event.Addr()
+            b = self.workspace.instance.project.factory.block(exit_block_addr)
+            if b.vex.jumpkind == 'Ijk_Ret':
+                _l.debug('Exit is a return to caller')
+                break
+
+            called_addrs.append((addr, called_func_entry_event))
+
+            if b.vex.jumpkind != 'Ijk_Call':
+                _l.debug('Exit is a tail-call')
+                break
+
+            # FIXME: fallthru might indicate trace vs cfg inconsistency
+            # Seek through events to find return site of this call
+            event = called_func_entry_event
+            ret_addr = b.instruction_addrs[0] + b.size
+            num_nested_calls = 0
+            if self.workspace.instance.project.arch.name == 'AMD64':
+                # FIXME Remove this hardcoding
+                stack_reg = 7
+                expected_sp = called_func_entry_event.Regs(stack_reg) + 8
+            else:
+                assert False, 'FIXME: Stack pointer check for non-x86_64'
+
+            _l.debug('Seeking to return site for call...')
+            while True:
+                event = self._btrace.get_next_exec_event(event, addr=ret_addr, vcpu=self._trace_dbg.vcpu)
+                if event is None:
+                    _l.error('Unexpected end of trace while looking for return site in %s @ %#x '
+                             '(call may have caused termination)', func.name, ret_addr)
+                    keep_looking = False
+                    break
+
+                # Check the stack pointer at return site to ensure it matches target call
+                # and does not actually belong to a nested call
+                bb_event = self._btrace.get_prev_bb_event(event, vcpu=self._trace_dbg.vcpu)
+                if bb_event.Regs(stack_reg) == expected_sp:
+                    _l.debug('Found return block at event %s', bb_event)
+                    event = bb_event
+                    break
+                _l.debug('Skipping over nested call (%d)', num_nested_calls)
+                num_nested_calls += 1
+
+        all_funcs = self.workspace.instance.project.kb.functions
+        return [((all_funcs[addr] if (addr in all_funcs) else addr), e) for (addr, e) in called_addrs]
+
+    def get_called_functions_recursive(self, event: Optional[TraceEvent] = None,
+                                             max_depth: Optional[int] = None, depth: int = 0):
+        if max_depth is not None and max_depth == depth:
+            return
+        for func_or_addr, sub_ev in self.get_called_functions(event):
+            yield func_or_addr, sub_ev, depth
+            if not isinstance(func_or_addr, int):
+                yield from self.get_called_functions_recursive(sub_ev, max_depth=max_depth, depth=(depth + 1))

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -100,6 +100,7 @@ class ViewMenu(Menu):
             MenuEntry('&Registers', main_window.workspace.show_registers_view),
             MenuEntry('&Stack', main_window.workspace.show_stack_view),
             MenuEntry('&Breakpoints', main_window.workspace.show_breakpoints_view),
+            MenuEntry('&Call Explorer', main_window.workspace.show_call_explorer_view),
             MenuSeparator(),
             MenuEntry('&Console', main_window.workspace.show_console_view),
             MenuEntry('&Log', main_window.workspace.show_log_view),

--- a/angrmanagement/ui/views/__init__.py
+++ b/angrmanagement/ui/views/__init__.py
@@ -19,3 +19,4 @@ from .stack_view import StackView
 from .traces_view import TracesView
 from .trace_map_view import TraceMapView
 from .breakpoints_view import BreakpointsView
+from .call_explorer_view import CallExplorerView

--- a/angrmanagement/ui/views/call_explorer_view.py
+++ b/angrmanagement/ui/views/call_explorer_view.py
@@ -1,0 +1,180 @@
+import logging
+from typing import Optional, Union
+
+from PySide2.QtGui import QFont, QStandardItemModel, QStandardItem
+from PySide2.QtCore import QSize, Qt
+from PySide2.QtWidgets import QHeaderView, QVBoxLayout, QTreeWidget, QTreeView, QLabel
+from angr.knowledge_plugins import Function
+
+try:
+    from bintrace import TraceEvent
+except ImportError as e:
+    TraceEvent = 'TraceEvent'
+
+from ...logic.debugger.bintrace import BintraceDebugger
+from ...logic.debugger import DebuggerWatcher
+from ...config import Conf
+from .view import BaseView
+
+
+_l = logging.getLogger(name=__name__)
+
+
+class CallTreeModel(QStandardItemModel):
+    """
+    Model for the call tree.
+    """
+    Headers = ['Function']
+
+    def hasChildren(self, index):
+        item: Optional['CallTreeItem'] = self.itemFromIndex(index)
+        if isinstance(item, CallTreeItem):
+            return item.expandable
+        return super().hasChildren(index)
+
+    def headerData(self, section, orientation, role):  # pylint:disable=unused-argument
+        if role != Qt.DisplayRole:
+            return None
+        if section < len(self.Headers):
+            return self.Headers[section]
+        return None
+
+
+class CallTreeItem(QStandardItem):
+    """
+    Item in call tree representing a function.
+    """
+
+    def __init__(self, function, event):
+        name = hex(function) if isinstance(function, int) else function.name
+        super().__init__(name)
+        self.function: Union[int, Function] = function
+        self.event: TraceEvent = event
+        self.populated: bool = False
+        self.expandable: bool = True
+
+
+class CallExplorerView(BaseView):
+    """
+    Call Explorer view.
+    """
+
+    def __init__(self, workspace, default_docking_position, *args, **kwargs):
+        super().__init__('call_explorer', workspace, default_docking_position, *args, **kwargs)
+
+        self._last_updated_func: Optional[Union[int, Function]] = None
+        self._inhibit_update: bool = False
+
+        self.base_caption = 'Call Explorer'
+        self._tree: Optional[QTreeWidget] = None
+        self._init_widgets()
+        self.reload()
+
+        self.width_hint = 500
+        self.height_hint = 400
+        self.updateGeometry()
+
+        self._dbg_manager = workspace.instance.debugger_mgr
+        self._dbg_watcher = DebuggerWatcher(self._on_debugger_state_updated, self._dbg_manager.debugger)
+        self._on_debugger_state_updated()
+
+    @staticmethod
+    def minimumSizeHint(*args, **kwargs):  # pylint:disable=unused-argument
+        return QSize(200, 200)
+
+    def _init_widgets(self):
+        vlayout = QVBoxLayout()
+        self._top_level_function_level = QLabel()
+        self._reset_function_label()
+        vlayout.addWidget(self._top_level_function_level)
+        self._tree = QTreeView(self)
+        self._model = CallTreeModel(self._tree)
+        self._tree.setModel(self._model)
+        self._tree.setFont(QFont(Conf.disasm_font))
+        header = self._tree.header()
+        header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        self._tree.expanded.connect(self._on_item_expanded)
+        self._tree.clicked.connect(self._on_item_clicked)
+        self._tree.doubleClicked.connect(self._on_item_double_clicked)
+        vlayout.addWidget(self._tree)
+        self.setLayout(vlayout)
+
+    #
+    # Events
+    #
+
+    def closeEvent(self, event):
+        self._dbg_watcher.shutdown()
+        super().closeEvent(event)
+
+    def _on_item_clicked(self, index):
+        """
+        Highlights the corresponding call site.
+        """
+        item = self._model.itemFromIndex(index)
+
+        # Do not try to update on a single click. Allow user to browse through the call tree
+        original_inhibit = self._inhibit_update
+        self._inhibit_update = True
+
+        # Replay up to just before call
+        dbg = self.workspace.instance.debugger_mgr.debugger
+        dbg.replay_to_event(dbg._btrace.get_prev_exec_event(item.event, vcpu=dbg._trace_dbg.vcpu))
+
+        self._inhibit_update = original_inhibit
+
+    def _on_item_double_clicked(self, index):
+        """
+        Navigates into the call.
+        """
+        item = self._model.itemFromIndex(index)
+        # Replay after the jump, jumping into the called function
+        # FIXME: Doesn't consider proper selected debugger, assumes bintrace
+        dbg = self.workspace.instance.debugger_mgr.debugger
+        dbg.replay_to_event(dbg._btrace.get_next_exec_event(item.event, vcpu=dbg._trace_dbg.vcpu))
+
+    def _on_item_expanded(self, index):
+        """
+        Descend into call tree for this node.
+        """
+        expanding_item = self._model.itemFromIndex(index)
+        if not expanding_item.populated:
+            dbg = self.workspace.instance.debugger_mgr.debugger
+            if dbg.am_none:
+                return
+            called = dbg.get_called_functions(expanding_item.event)
+            for func_or_addr, event in called:
+                expanding_item.appendRow(CallTreeItem(func_or_addr, event))
+            expanding_item.expandable = len(called) > 0
+            expanding_item.populated = True
+
+    def _on_debugger_state_updated(self):
+        """
+        Update current call state.
+        """
+        if self._inhibit_update:
+            return
+
+        dbg = self._dbg_watcher.debugger
+        if isinstance(dbg.am_obj, BintraceDebugger):
+            func = dbg.get_current_function()
+            if func is not None:
+                func = func[0]
+        else:
+            func = None
+
+        if func is self._last_updated_func:
+            return
+
+        self._model.clear()
+        self._last_updated_func = func
+
+        if func is not None and isinstance(dbg.am_obj, BintraceDebugger):
+            self._top_level_function_level.setText(f'Current function: {func.name}')
+            for func, event in dbg.get_called_functions():
+                self._model.appendRow(CallTreeItem(func, event))
+        else:
+            self._reset_function_label()
+
+    def _reset_function_label(self):
+        self._top_level_function_level.setText('Current function: Unknown')

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -20,7 +20,8 @@ from ..data.jobs.loading import LoadBinaryJob
 from ..data.jobs import CodeTaggingJob, PrototypeFindingJob, VariableRecoveryJob, FlirtSignatureRecognitionJob
 from .views import (FunctionsView, DisassemblyView, SymexecView, StatesView, StringsView, ConsoleView, CodeView,
                     InteractionView, PatchesView, DependencyView, ProximityView, TypesView, HexView, LogView,
-                    DataDepView, RegistersView, StackView, TracesView, TraceMapView, BreakpointsView)
+                    DataDepView, RegistersView, StackView, TracesView, TraceMapView, BreakpointsView,
+                    CallExplorerView)
 from .view_manager import ViewManager
 from .menus.disasm_insn_context_menu import DisasmInsnContextMenu
 
@@ -658,6 +659,11 @@ class Workspace:
         self.raise_view(view)
         view.setFocus()
 
+    def show_call_explorer_view(self):
+        view = self._get_or_create_call_explorer_view()
+        self.raise_view(view)
+        view.setFocus()
+
     def show_console_view(self):
         view = self._get_or_create_console_view()
         self.raise_view(view)
@@ -897,6 +903,16 @@ class Workspace:
 
         if view is None:
             view = BreakpointsView(self, 'center')
+            self.add_view(view)
+
+        return view
+
+    def _get_or_create_call_explorer_view(self) -> CallExplorerView:
+        # Take the first function call explorer view
+        view = self.view_manager.first_view_in_category('call_explorer')
+
+        if view is None:
+            view = CallExplorerView(self, 'right')
             self.add_view(view)
 
         return view


### PR DESCRIPTION
https://user-images.githubusercontent.com/8210/165675122-9449bfa8-f3ca-4c15-931e-7b4b8bfa9529.mp4

Adds an 'Outgoing Calls' view that identifies the current function at trace position and all 1st order calls made from the function at the current trace position, in an easy to use tree view. Calls can be expanded to see nested function calls, etc. The list is generated on demand as the user seeks through the trace or expands one of the call entries, and is pretty fast.

If you click on one of the listed functions, it will seek in the trace to the call site of that function. If you double-click on the function, it will step into the function at that point in the trace and update the call tree.

This view could also be expanded for non-trace viewing applications; like in Ghidra, there is an incoming and outgoing calls view that shows all discovered edges; but its left for future work. I'd also like to see function arguments displayed.

Note: Only works for x86-64 at the moment, because it checks stack pointer at block events and this register is hardcoded. Additional arches will be added in a follow-up.