### PR TITLE
Always attempt to use the Decompiler Clinic Cache

### DIFF
--- a/angrmanagement/ui/widgets/qdisasm_graph.py
+++ b/angrmanagement/ui/widgets/qdisasm_graph.py
@@ -121,9 +121,14 @@ class QDisassemblyGraph(QDisassemblyBaseControl, QZoomableDraggableGraphicsView)
         scene = self.scene()
 
         if self._disassembly_level is DisassemblyLevel.AIL:
-            self.disasm = self.workspace.instance.project.analyses.Clinic(
-                self._function_graph.function)
-            self._supergraph = to_ail_supergraph(self.disasm.graph)
+            func = self._function_graph.function
+            try:
+                # always check if decompiler has cached a clinic object first
+                self.disasm = self.workspace.instance.kb.structured_code[(func.addr, 'pseudocode')].clinic
+            except (KeyError, AttributeError):
+                self.disasm = self.workspace.instance.project.analyses.Clinic(func)
+
+            self._supergraph = to_ail_supergraph(self.disasm.cc_graph)
             nodefunc = lambda n: n
             branchfunc = lambda n: None
         else:


### PR DESCRIPTION
As the title says, use the Decompilers cached clinic object instead of always trying to regenerate it. This is a similar PR to #591,  but that PR is blocked on needing a new job system. A full fix will need to be finished in #591 where if a Clinic object is not cached we generate a new Decompilation object that has a Clinic object in it (not just a clinic object). For now, this just fixes the problem of updates to the Clinic Graph (done by the decompiler) are not reflected in the AIL Graph View. 
