### PR TITLE
Respect single_step_range when seeking through bintrace map

### DIFF
--- a/angrmanagement/logic/debugger/bintrace.py
+++ b/angrmanagement/logic/debugger/bintrace.py
@@ -140,7 +140,13 @@ class BintraceDebugger(Debugger):
             _l.error('Could not seek to event %d', n)
             return
 
-        until = t.get_prev_exec_event(until)
+        if self._trace_dbg.single_step_range is None:
+            step_region_addr, step_region_size = None, 1
+        else:
+            self._trace_dbg.single_step_range: Tuple[int, int]
+            step_region_addr, step_region_size = self._trace_dbg.single_step_range
+
+        until = t.get_prev_exec_event(until, addr=step_region_addr, size=step_region_size)
         if until is None:
             _l.error('No execution event prior to event %d', n)
             return


### PR DESCRIPTION
bintrace now supports single stepping through loaded object ranges while skipping execution events from loaded objects; it simply uses the range that covers all non-CLE loaded objects. This improves user experience when stepping through the trace of a binary by not having to step through a bunch of library code unless you really want to. User can still set {break,watch}points for arbitrary addresses, then single step to nearest main object code.