### PR TITLE
Use QAbstractItemView.ScrollPerPixel

### DIFF
--- a/angrmanagement/ui/views/breakpoints_view.py
+++ b/angrmanagement/ui/views/breakpoints_view.py
@@ -93,7 +93,7 @@ class QBreakpointTableWidget(QTableView):
         vheader.setDefaultSectionSize(20)
 
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self.model: QBreakpointTableModel = QBreakpointTableModel(self.breakpoint_mgr)
         self.setModel(self.model)

--- a/angrmanagement/ui/views/registers_view.py
+++ b/angrmanagement/ui/views/registers_view.py
@@ -98,7 +98,7 @@ class QRegisterTableWidget(QTableView):
         vheader.setDefaultSectionSize(20)
 
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self.model: QRegisterTableModel = QRegisterTableModel(self)
         self.setModel(self.model)

--- a/angrmanagement/ui/views/stack_view.py
+++ b/angrmanagement/ui/views/stack_view.py
@@ -87,7 +87,7 @@ class QStackTableWidget(QTableView):
         vheader.setDefaultSectionSize(20)
 
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self.model: QStackTableModel = QStackTableModel(self)
         self.setModel(self.model)

--- a/angrmanagement/ui/views/traces_view.py
+++ b/angrmanagement/ui/views/traces_view.py
@@ -83,7 +83,7 @@ class QTraceTableWidget(QTableView):
         vheader.setDefaultSectionSize(20)
 
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self.model: QTraceTableModel = QTraceTableModel(instance)
         self.setModel(self.model)

--- a/angrmanagement/ui/widgets/qlog_widget.py
+++ b/angrmanagement/ui/widgets/qlog_widget.py
@@ -145,7 +145,7 @@ class QLogWidget(QTableView):
         hheader.setStretchLastSection(True)
         vheader.setVisible(False)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
         vheader.setDefaultSectionSize(20)
         self.setShowGrid(False)
 

--- a/angrmanagement/ui/widgets/qstring_table.py
+++ b/angrmanagement/ui/widgets/qstring_table.py
@@ -156,7 +156,7 @@ class QStringTable(QTableView):
         self.setShowGrid(False)
         self.verticalHeader().setVisible(False)
         self.verticalHeader().setDefaultSectionSize(24)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
         self._model = QStringModel(None)
         self._proxy = QSortFilterProxyModel(self)

--- a/angrmanagement/ui/widgets/qxref_viewer.py
+++ b/angrmanagement/ui/widgets/qxref_viewer.py
@@ -261,7 +261,7 @@ class QXRefViewer(QTableView):
 
         self.verticalHeader().setVisible(False)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.setHorizontalScrollMode(self.ScrollPerPixel)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
         self.setShowGrid(False)
 
         self.verticalHeader().setSectionResizeMode(QHeaderView.Fixed)


### PR DESCRIPTION
Access the enum value from the base class instead of the inherited. Fixes an issue with PySide6 compat and is also more consistent with surrounding code