### PR TITLE
Only load the autoreload module when autoload is enabled.

### DIFF
--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -1,3 +1,4 @@
+# pylint:disable=global-statement
 from typing import Optional
 import logging
 import time
@@ -31,6 +32,10 @@ def _load_autoreload():
 
 
 class Job:
+    """
+    The base class of all Jobs in angr management.
+    """
+
     def __init__(self, name, on_finish=None, blocking=False):
         self.name = name
         self.progress_percentage = 0.

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -4,19 +4,31 @@ import time
 import datetime
 import ctypes
 
+from IPython.extensions.autoreload import ModuleReloader
+
 from ...logic import GlobalInfo
 from ...logic.threads import gui_thread_schedule_async
 
-try:
-    from IPython.extensions.autoreload import ModuleReloader
-    m = ModuleReloader()
-    m.enabled = True
-    m.check_all = True
-    m.check()
-except ImportError:
-    m = None
+m = ...
+
 
 l = logging.getLogger(__name__)
+
+
+def _load_autoreload():
+    """
+    Load the autoreload extension module. Delay the import and initialization to reduce angr management's startup time.
+    """
+
+    global m
+    try:
+        m = ModuleReloader()
+        m.enabled = True
+        m.check_all = True
+        m.check()
+    except ImportError:
+        m = None
+
 
 class Job:
     def __init__(self, name, on_finish=None, blocking=False):
@@ -30,12 +42,15 @@ class Job:
         # callbacks
         self._on_finish = on_finish
 
-        if m is not None and GlobalInfo.autoreload:
-            prestate = dict(m.modules_mtimes)
-            m.check()
-            poststate = dict(m.modules_mtimes)
-            if prestate != poststate:
-                l.warning("Autoreload found changed modules")
+        if GlobalInfo.autoreload:
+            if m is ...:
+                _load_autoreload()
+            if m is not None:
+                prestate = dict(m.modules_mtimes)
+                m.check()
+                poststate = dict(m.modules_mtimes)
+                if prestate != poststate:
+                    l.warning("Autoreload found changed modules")
 
     @property
     def time_elapsed(self) -> str:


### PR DESCRIPTION
This PR reduces 0.7 seconds from the startup time of angr management on my laptop.