### PR TITLE
Install PySide6 instead of only PySide6-Essentials, and pin to < 6.4.0 for now.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     angr[angrDB] == 9.2.25.dev0
     qtconsole
     ipython
-    PySide6-Essentials != 6.4.0
+    PySide6 != 6.4.0
     tomlkit
     pyxdg
     requests[socks]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     angr[angrDB] == 9.2.25.dev0
     qtconsole
     ipython
-    PySide6 != 6.4.0
+    PySide6 < 6.4.0
     tomlkit
     pyxdg
     requests[socks]


### PR DESCRIPTION
- Looks like since PySide6 6.4.0 QWidgets won't even import without having PySide6-Addons installed on Windows.
- The PyPI version of qtpy prevents pyqodeng (the code editor we use) from working when PySide6 6.4.0+ is installed. Pin angr management to < 6.4.0 temporarily until qtpy releases a new version to PyPI.