### PR TITLE
Fix app title on mac

### DIFF
--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -8,7 +8,6 @@ import time
 import warnings
 import platform
 import signal
-import pathlib
 
 if sys.platform.startswith("darwin"):
     from Foundation import NSBundle
@@ -149,7 +148,7 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
         if bundle:
             app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
             if app_info:
-                app_info['CFBundleName'] = pathlib.Path(name).stem
+                app_info['CFBundleName'] = name
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName(name)

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -149,7 +149,7 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
         if bundle:
             app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
             if app_info:
-                app_info['CFBundleName'] = pathlib.Path(sys.argv[0]).stem
+                app_info['CFBundleName'] = pathlib.Path(name).stem
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName(name)

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -145,11 +145,13 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
 
     # Fix app title on macOS
     if sys.platform.startswith("darwin"):
-        bundle = NSBundle.mainBundle()
-        if bundle:
-            app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
-            if app_info:
-                app_info['CFBundleName'] = name
+        try:
+            bundle = NSBundle.mainBundle()
+            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            info["CFBundleName"] = name
+        except Exception as e:
+            # This happens before logging is setup so use stderr
+            print(f"{type(e).__name__}: {e}", file=sys.stderr)
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName(name)

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -1,6 +1,4 @@
 # pylint:disable=import-outside-toplevel,unused-import,no-member
-from . import __version__
-
 import asyncio
 import sys
 import os
@@ -13,6 +11,8 @@ import signal
 
 if sys.platform.startswith("darwin"):
     from Foundation import NSBundle  # pylint: disable=import-error
+
+from . import __version__  # pylint: disable=wrong-import-position
 
 
 def shut_up(*args, **kwargs):  # pylint:disable=unused-argument

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -9,10 +9,10 @@ import warnings
 import platform
 import signal
 
+from . import __version__
+
 if sys.platform.startswith("darwin"):
     from Foundation import NSBundle  # pylint: disable=import-error
-
-from . import __version__  # pylint: disable=wrong-import-position
 
 
 def shut_up(*args, **kwargs):  # pylint:disable=unused-argument

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -14,6 +14,7 @@ import signal
 if sys.platform.startswith("darwin"):
     from Foundation import NSBundle  # pylint: disable=import-error
 
+
 def shut_up(*args, **kwargs):  # pylint:disable=unused-argument
     return
 warnings.simplefilter = shut_up

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -1,4 +1,6 @@
 # pylint:disable=import-outside-toplevel,unused-import,no-member
+from . import __version__
+
 import asyncio
 import sys
 import os
@@ -10,9 +12,7 @@ import platform
 import signal
 
 if sys.platform.startswith("darwin"):
-    from Foundation import NSBundle
-
-from . import __version__
+    from Foundation import NSBundle  # pylint: disable=import-error
 
 def shut_up(*args, **kwargs):  # pylint:disable=unused-argument
     return

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -10,6 +10,9 @@ import platform
 import signal
 import pathlib
 
+if sys.platform.startswith("darwin"):
+    from Foundation import NSBundle
+
 from . import __version__
 
 def shut_up(*args, **kwargs):  # pylint:disable=unused-argument
@@ -142,7 +145,6 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
 
     # Fix app title on macOS
     if sys.platform.startswith("darwin"):
-        from Foundation import NSBundle
         bundle = NSBundle.mainBundle()
         if bundle:
             app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -8,6 +8,7 @@ import time
 import warnings
 import platform
 import signal
+import pathlib
 
 from . import __version__
 
@@ -138,6 +139,15 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
     QApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     # Use highDPI pixmaps
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
+
+    # Fix app title on macOS
+    if sys.platform.startswith("darwin"):
+        from Foundation import NSBundle
+        bundle = NSBundle.mainBundle()
+        if bundle:
+            app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            if app_info:
+                app_info['CFBundleName'] = pathlib.Path(sys.argv[0]).stem
 
     app = QApplication(sys.argv)
     app.setApplicationDisplayName(name)

--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -149,7 +149,7 @@ def start_management(filepath=None, use_daemon=None, profiling=False):
             bundle = NSBundle.mainBundle()
             info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
             info["CFBundleName"] = name
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             # This happens before logging is setup so use stderr
             print(f"{type(e).__name__}: {e}", file=sys.stderr)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     qtterm
     getmac
     QtAwesome
-	pyobjc-framework-Cocoa; platform_system == "Darwin"
+    pyobjc-framework-Cocoa; platform_system == "Darwin"
 
 python_requires = >= 3.8
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     qtterm
     getmac
     QtAwesome
+	pyobjc-framework-Cocoa; platform_system == "Darwin"
 
 python_requires = >= 3.8
 include_package_data = True


### PR DESCRIPTION
Upon merging this we probably want to open an issue to fix the application name itself on a mac as this only fixes the title. A PR which fixes the application name will likely make this code redundant.

To make this work for the dock: If we used `CFBundleDisplayName` instead of `CFBundleName` this would set the name in the dock as well, but that string is loaded into the dock and such before the app has a chance to change it, so changing it afterwards wouldn't work (well, it might for future things that query for the name, if such things exist).

It might be dynamically editable via Cocoa; some mac apps do dynamically edit their dock entries.