### PR TITLE
Added support for ComboBox in Decompiler Options with Phoenix support

### DIFF
--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -32,7 +32,6 @@ class QDecompilationOption(QTreeWidgetItem):
 
         # optional and may not exist
         self._combo_box = None
-        self._option_text_item = None
 
         if self.type == OptionType.OPTIMIZATION_PASS:
             self.setText(0, option.NAME)

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -1,8 +1,7 @@
 from typing import Optional, TYPE_CHECKING
 
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QTreeWidget, QTreeWidgetItem, QPushButton, QComboBox, \
-    QCheckBox
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QTreeWidget, QTreeWidgetItem, QPushButton, QComboBox
 
 from angr.analyses.decompiler.decompilation_options import options as dec_options
 from angr.analyses.decompiler.optimization_passes import get_optimization_passes, get_default_optimization_passes

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -22,7 +22,7 @@ class OptionType:
 
 class QDecompilationOption(QTreeWidgetItem):
     """
-    The UI entry for a single decompliation option. Get status with item.checkState(0).
+    The UI entry for a single decompliation option. Get status with item.state.
     """
     def __init__(self, parent, option, type_: int, enabled=True):
         super().__init__(parent)
@@ -66,7 +66,7 @@ class QDecompilationOption(QTreeWidgetItem):
         if self._combo_box:
             return self._combo_box.currentText()
         else:
-            return bool(self.checkState(0))
+            return bool(self.checkState(0) == Qt.CheckState.Checked)
 
 
 class QDecompilationOptions(QWidget):


### PR DESCRIPTION
## Features
- add support for non-boolean options through option type interface and selections
- add support for specifically Phoenix options

![options_demo](https://user-images.githubusercontent.com/21327264/202842991-f290d786-3073-441e-8002-875d2d5401b2.png)

This PR is linked to https://github.com/angr/angr/pull/3615
