### PR TITLE
ViewManager.raise_view: Fix the splash of docks when they are tabbed.

### DIFF
--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -120,7 +120,8 @@ class ViewManager:
         if dock is None:
             return
 
-        dock.show()
+        if not dock.isTabbed():
+            dock.show()
         dock.raise_()
         view.focusWidget()
 


### PR DESCRIPTION
Reproducible on PySide6 6.3.1 + Windows.