### PR TITLE
Allow theme based on system

### DIFF
--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -1,9 +1,9 @@
-from PySide2.QtGui import QColor
-from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
     QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, \
     QSizePolicy, QDialogButtonBox
-from PySide2.QtCore import QSize
-
+    
+from PySide6.QtCore import QSize
 from ..widgets.qcolor_option import QColorOption
 from ...config.config_manager import ENTRIES
 from ...config.color_schemes import COLOR_SCHEMES

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -2,16 +2,15 @@ from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
     QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, \
     QSizePolicy, QDialogButtonBox
-    
+
 from PySide6.QtCore import QSize
+from darkdetect import isDark
 from ..widgets.qcolor_option import QColorOption
 from ...config.config_manager import ENTRIES
 from ...config.color_schemes import COLOR_SCHEMES
 from ...config import Conf, save_config
 from ...logic.url_scheme import AngrUrlScheme
 from ..css import refresh_theme
-
-from darkdetect import isDark
 
 
 class Page(QWidget):

--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -1,8 +1,8 @@
-from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
+from PySide2.QtGui import QColor
+from PySide2.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QListWidget, QListView, QStackedWidget, QWidget, \
     QGroupBox, QLabel, QCheckBox, QPushButton, QLineEdit, QListWidgetItem, QScrollArea, QFrame, QComboBox, \
     QSizePolicy, QDialogButtonBox
-from PySide6.QtCore import QSize
+from PySide2.QtCore import QSize
 
 from ..widgets.qcolor_option import QColorOption
 from ...config.config_manager import ENTRIES
@@ -10,6 +10,8 @@ from ...config.color_schemes import COLOR_SCHEMES
 from ...config import Conf, save_config
 from ...logic.url_scheme import AngrUrlScheme
 from ..css import refresh_theme
+
+from darkdetect import isDark
 
 
 class Page(QWidget):
@@ -143,9 +145,13 @@ class ThemeAndColors(Page):
         self.setLayout(page_layout)
 
     def _load_color_scheme(self, name):
-        for prop, value in COLOR_SCHEMES[name].items():
-            row = self._to_save[prop][1]
-            row.set_color(value)
+        if name in COLOR_SCHEMES:
+            for prop, value in COLOR_SCHEMES[name].items():
+                row = self._to_save[prop][1]
+                row.set_color(value)
+        else:
+            name = "Dark" if isDark() else "Light"
+            self._load_color_scheme(name)
 
     def _on_load_scheme_clicked(self):
         self._load_color_scheme(self._schemes_combo.currentText())

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     getmac
     QtAwesome
     pyobjc-framework-Cocoa; platform_system == "Darwin"
+    darkdetect
 
 python_requires = >= 3.8
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ install_requires =
     pyqodeng >= 0.0.6
     qtterm
     getmac
+    darkdetect
     QtAwesome
     pyobjc-framework-Cocoa; platform_system == "Darwin"
-    darkdetect
 
 python_requires = >= 3.8
 include_package_data = True


### PR DESCRIPTION
By setting the theme to "Current", the theme of the system will be used.
This solution uses [darkdetect](https://github.com/albertosottile/darkdetect).
Should be linked to [#780 ](https://github.com/angr/angr-management/issues/780) and [#805 ](https://github.com/angr/angr-management/issues/805).