### PR TITLE
Save greyed out when no project loaded; `Menu` updates `QAction` to saved state on `set_action`

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -37,7 +37,7 @@ class Instance:
     """
     An object to give access to normal angr project objects like a Project, CFG, and other analyses.
     """
-    project: Union[angr.Project, ObjectContainer]
+    project: ObjectContainer
     cfg: Union[angr.analyses.cfg.CFGBase, ObjectContainer]
     cfb: Union[angr.analyses.cfg.CFBlanket, ObjectContainer]
     log: Union[List[LogRecord], ObjectContainer]

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -24,6 +24,14 @@ class FileMenu(Menu):
     """
     def __init__(self, main_window):
         super().__init__("&File", parent=main_window)
+        self._project = main_window.workspace.main_instance.project
+
+        self._save_entries = [
+            MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL | Qt.Key_S)),
+            MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
+        ]
+        self._edit_save()
+        self._project.am_subscribe(self._edit_save)
 
         self.recent_menu = Menu("Load recent")
         self.entries.extend([
@@ -35,8 +43,7 @@ class FileMenu(Menu):
             self.recent_menu,
             MenuSeparator(),
             MenuEntry('&Load angr database...', main_window.load_database, shortcut=QKeySequence(Qt.CTRL | Qt.Key_L)),
-            MenuEntry('&Save angr database...', main_window.save_database, shortcut=QKeySequence(Qt.CTRL | Qt.Key_S)),
-            MenuEntry('S&ave angr database as...', main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
+            *self._save_entries,
             MenuSeparator(),
             MenuEntry('Load a new &trace...', main_window.load_trace),
             MenuSeparator(),
@@ -44,6 +51,11 @@ class FileMenu(Menu):
             MenuSeparator(),
             MenuEntry('E&xit', main_window.quit),
         ])
+
+    def _edit_save(self, **_):
+        enable: bool = not self._project.am_none
+        for i in self._save_entries:
+            (i.enable if enable else i.disable)()
 
     def add_recent(self, path: str):
         for entry in list(self.recent_menu.entries):

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -9,24 +9,32 @@ class MenuEntry:
         self.shortcut = shortcut
         self.checkable = checkable
         self.checked_initially = checked
-        self.default_enabled = enabled
+        self.enabled = enabled
         self.key = key
 
-        self.qaction = None
+        self._qaction = None
+
+    def set_qaction(self, qaction: QAction):
+        self._qaction = qaction
+        self._enable(self.enabled)
 
     def enable(self):
-        if self.qaction is not None:
-            self.qaction.setDisabled(False)
+        self._enable(True)
 
     def disable(self):
-        if self.qaction is not None:
-            self.qaction.setDisabled(True)
+        self._enable(False)
+
+    def _enable(self, b: bool):
+        self.enabled = b
+        if self._qaction is not None:
+            self._qaction.setEnabled(b)
 
     @property
     def checked(self):
-        if self.qaction is None or not self.checkable:
+        if self._qaction is None or not self.checkable:
             return False
-        return self.qaction.isChecked()
+        return self._qaction.isChecked()
+
 
 
 class MenuSeparator:
@@ -96,15 +104,13 @@ class Menu:
         if isinstance(entry, MenuEntry):
             action = QAction(entry.caption, menu)
             action.triggered.connect(entry.action)
-            entry.qaction = action
+            entry.set_qaction(action)
 
             if entry.shortcut is not None:
                 action.setShortcut(entry.shortcut)
             if entry.checkable:
                 action.setCheckable(True)
                 action.setChecked(entry.checked_initially)
-            if not entry.default_enabled:
-                action.setDisabled(True)
 
             if before is None:
                 menu.addAction(action)


### PR DESCRIPTION
Fixes: https://github.com/angr/angr-management/issues/653