### PR TITLE
Make multiprocessing work fine on Windows PyInstaller builds.

### DIFF
--- a/angrmanagement/__main__.py
+++ b/angrmanagement/__main__.py
@@ -1,5 +1,6 @@
 # pylint:disable=import-outside-toplevel,unused-import,no-member
 import asyncio
+import multiprocessing
 import sys
 import os
 import ctypes
@@ -272,4 +273,5 @@ def main():
 
 
 if __name__ == '__main__':
+    multiprocessing.freeze_support()
     main()

--- a/start.py
+++ b/start.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+import multiprocessing
+
 from angrmanagement.__main__ import main
 
 
 if __name__ == '__main__':
+    multiprocessing.freeze_support()
     main()


### PR DESCRIPTION
Close #836.