### PR TITLE
Remove address 0x prefix in several spots

### DIFF
--- a/angrmanagement/ui/widgets/qdisasm_statusbar.py
+++ b/angrmanagement/ui/widgets/qdisasm_statusbar.py
@@ -130,7 +130,7 @@ class QDisasmStatusBar(QFrame):
 
     def _update_function_label(self):
         if self._function:
-            s = f'{self._function.name} ({self._function.addr:#x})'
+            s = f'{self._function.name} ({self._function.addr:x})'
         else:
             s = ''
         self._function_label.setText(s)

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -167,7 +167,7 @@ class QFunctionTableModel(QAbstractTableModel):
         if idx < len(self.Headers):
             data = self._get_column_data(func, idx)
             if idx == self.ADDRESS_COL:
-                return hex(data)
+                return f'{data:x}'
             elif idx == self.TAGS_COL:
                 return self._get_tags_display_string(data)
             else:

--- a/angrmanagement/ui/widgets/qpatch_table.py
+++ b/angrmanagement/ui/widgets/qpatch_table.py
@@ -21,8 +21,8 @@ class QPatchTableItem:
         patch = self.patch
 
         widgets = [
-            QTableWidgetItem("%#x" % patch.addr),
-            QTableWidgetItem("%d bytes" % len(patch)),
+            QTableWidgetItem(f'{patch.addr:x}'),
+            QTableWidgetItem(f'{len(patch)} bytes'),
             QTableWidgetItem(binascii.hexlify(self.old_bytes).decode("ascii") if self.old_bytes else "<unknown>"),
             QTableWidgetItem(binascii.hexlify(patch.new_bytes).decode("ascii")),
             QTableWidgetItem(patch.comment or ''),

--- a/angrmanagement/ui/widgets/qstate_table.py
+++ b/angrmanagement/ui/widgets/qstate_table.py
@@ -28,7 +28,7 @@ class QStateTableItem(QTableWidgetItem):
         base_name = state.gui_data.base_name
         is_changed = 'No' if state.gui_data.is_original else 'Yes'
         mode = state.mode
-        address = '%#x' % state.addr if isinstance(state.addr, int) else 'Symbolic'
+        address = '%x' % state.addr if isinstance(state.addr, int) else 'Symbolic'
         state_options = {o for o, v in state.options._options.items() if v is True}
         options_plus = state_options - angr.sim_options.modes[mode]
         options_minus = angr.sim_options.modes[mode] - state_options

--- a/angrmanagement/ui/widgets/qstring_table.py
+++ b/angrmanagement/ui/widgets/qstring_table.py
@@ -131,7 +131,7 @@ class QStringModel(QAbstractTableModel):
         if col < len(self.HEADER):
             data = self._get_column_data(v, col)
             if col == self.ADDRESS_COL and type(data) is int:
-                return hex(data)
+                return f'{data:x}'
             return data
 
     def _get_column_data(self, v: MemoryData, col: int) -> Any:


### PR DESCRIPTION
Addresses are always given in hex. Save some screen space by eliminating 0x prefix.