### PR TITLE
Memoize QFunctionTableModel::data()

### DIFF
--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -40,6 +40,7 @@ class QFunctionTableModel(QAbstractTableModel):
         self._raw_func_list = func_list
         self.instance = instance
         self._config = Conf
+        self._data_cache = {}
 
     def __len__(self):
         if self._func_list is not None:
@@ -58,6 +59,7 @@ class QFunctionTableModel(QAbstractTableModel):
     def func_list(self, v):
         self._func_list = None
         self._raw_func_list = v
+        self._data_cache.clear()
         self.emit(SIGNAL("layoutChanged()"))
 
     def filter(self, keyword):
@@ -69,6 +71,7 @@ class QFunctionTableModel(QAbstractTableModel):
             self._func_list = [ func for func in self._raw_func_list if
                                 self._func_match_keyword(func, keyword, extra_columns=extra_columns) ]
 
+        self._data_cache.clear()
         self.emit(SIGNAL("layoutChanged()"))
 
     def rowCount(self, *args, **kwargs): # pylint:disable=unused-argument
@@ -101,6 +104,16 @@ class QFunctionTableModel(QAbstractTableModel):
             return None
 
         col = index.column()
+
+        key = (row, col, role)
+        if key in self._data_cache:
+            value = self._data_cache[key]
+        else:
+            value = self._data_uncached(row, col, role)
+            self._data_cache[key] = value
+        return value
+
+    def _data_uncached(self, row, col, role):
         func = self.func_list[row]
 
         if role == Qt.DisplayRole:


### PR DESCRIPTION
Any time the table view is scrolled or resized, the table's model's data() function will be called for each visible cell/role. This can become remarkably sluggish as the number of visible cells grows. Cache the function table cell data for smoother interaction.

Demo on a 4k screen at 1x scaling:

Scrolling without this patch:

https://user-images.githubusercontent.com/8210/207716092-2da99022-1915-466f-9cc4-acafcecc7b44.mp4

Scrolling with this patch:

https://user-images.githubusercontent.com/8210/207716110-e1cb9e95-3e73-4e32-ba55-1614e145bb2c.mp4

