### PR TITLE
Remove log table ResizeToContents policy, for performance 

### DIFF
--- a/angrmanagement/ui/widgets/qlog_widget.py
+++ b/angrmanagement/ui/widgets/qlog_widget.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, Any, Optional
 
 import PySide6
-from PySide6.QtWidgets import QTableView, QAbstractItemView, QHeaderView
+from PySide6.QtWidgets import QTableView, QAbstractItemView
 from PySide6.QtCore import QAbstractTableModel, Qt
 from PySide6.QtGui import QIcon, QCursor, QGuiApplication, QClipboard, QKeySequence
 
@@ -154,7 +154,7 @@ class QLogWidget(QTableView):
         self.setModel(self.model)
 
         self.setColumnWidth(0, 20)
-        hheader.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        self.setColumnWidth(1, 150)
 
         self.log_view.instance.log.am_subscribe(self._on_new_logrecord)
 


### PR DESCRIPTION
`ResizeToContents` header resize policy on table's with many entries can cause extremely sluggish interaction. Remove this policy on the log table to prevent slowness when resizing the window.

Without this patch:

https://user-images.githubusercontent.com/8210/207719008-b92bda4d-168a-4987-aa96-3670ce1be63a.mp4



With this patch:

https://user-images.githubusercontent.com/8210/207719021-a3e99cea-9cac-4bcb-a862-ef671d05a958.mp4

