### PR TITLE
Pyupgrade

### DIFF
--- a/angrmanagement/config/__init__.py
+++ b/angrmanagement/config/__init__.py
@@ -1,4 +1,3 @@
-
 import os
 import atexit
 

--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -522,7 +522,7 @@ class ConfigurationManager: # pylint: disable=assigning-non-slot
 
     @classmethod
     def parse_file(cls, path: str, ignore_unknown_entries: bool=False):
-        with open(path, 'r', encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return cls.parse(f, ignore_unknown_entries=ignore_unknown_entries)
 
     def save(self, f):

--- a/angrmanagement/daemon/__init__.py
+++ b/angrmanagement/daemon/__init__.py
@@ -1,4 +1,3 @@
-
 def monkeypatch_rpyc():
 
     # The AsyncResult in rpyc has a bug that causes a race condition when clients are cascaded. this monkeypatch fixes

--- a/angrmanagement/daemon/client.py
+++ b/angrmanagement/daemon/client.py
@@ -1,4 +1,3 @@
-
 import logging
 import functools
 

--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -32,7 +32,7 @@ class ManagementService(rpyc.Service):
             conn = TargetIDtoCONN[target_id]
         else:
             raise Exception(
-                "The specified target %s is not open in angr management. We have the following ones: %s." % (
+                "The specified target {} is not open in angr management. We have the following ones: {}.".format(
                 target_id,
                 str(TargetIDtoCONN)))
         return conn

--- a/angrmanagement/data/function_graph.py
+++ b/angrmanagement/data/function_graph.py
@@ -1,4 +1,3 @@
-
 from ..utils.graph import to_supergraph
 
 def edge_qualifies(data):

--- a/angrmanagement/data/indirect_jump.py
+++ b/angrmanagement/data/indirect_jump.py
@@ -1,5 +1,4 @@
-
-class IndirectJump(object):
+class IndirectJump:
     """
     A meta class describing an indirect jump instruction.
     """

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -171,7 +171,7 @@ class Instance:
         if name in self.extra_containers:
             cur_ty = self._container_defaults[name][1]
             if ty != cur_ty:
-                raise Exception("Container %s already registered with different type: %s != %s" % (name, ty, cur_ty))
+                raise Exception("Container {} already registered with different type: {} != {}".format(name, ty, cur_ty))
 
         else:
             self._container_defaults[name] = (default_val_func, ty)

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -171,7 +171,7 @@ class Instance:
         if name in self.extra_containers:
             cur_ty = self._container_defaults[name][1]
             if ty != cur_ty:
-                raise Exception("Container {} already registered with different type: {} != {}".format(name, ty, cur_ty))
+                raise Exception(f"Container {name} already registered with different type: {ty} != {cur_ty}")
 
         else:
             self._container_defaults[name] = (default_val_func, ty)

--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -1,4 +1,3 @@
-
 import time
 import logging
 
@@ -57,7 +56,7 @@ class CFGGenerationJob(Job):
             inst.cfg = cfg.model
             inst.cfb.am_event()
             inst.cfg.am_event()
-            super(CFGGenerationJob, self).finish(inst, result)
+            super().finish(inst, result)
         except Exception:
             _l.error("Exception occurred in CFGGenerationJob.finish().", exc_info=True)
 

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -1,11 +1,10 @@
-
 from .job import Job
 
 
 class CodeTaggingJob(Job):
 
     def __init__(self, on_finish=None):
-        super(CodeTaggingJob, self).__init__(name="Code tagging", on_finish=on_finish)
+        super().__init__(name="Code tagging", on_finish=on_finish)
 
     def _run(self, inst):
 
@@ -20,7 +19,7 @@ class CodeTaggingJob(Job):
             super()._progress_callback(percentage, text=text)
 
     def finish(self, inst, result):
-        super(CodeTaggingJob, self).finish(inst, result)
+        super().finish(inst, result)
 
     def __repr__(self):
         return "CodeTaggingJob"

--- a/angrmanagement/data/jobs/ddg_generation.py
+++ b/angrmanagement/data/jobs/ddg_generation.py
@@ -1,4 +1,3 @@
-
 import networkx
 
 from .job import Job
@@ -6,7 +5,7 @@ from .job import Job
 
 class DDGGenerationJob(Job):
     def __init__(self, addr):
-        super(DDGGenerationJob, self).__init__('DDG generation')
+        super().__init__('DDG generation')
         self._addr = addr
 
     def _run(self, inst):
@@ -14,7 +13,7 @@ class DDGGenerationJob(Job):
         return ddg, networkx.relabel_nodes(ddg.graph, lambda n: n.insn_addr)
 
     def finish(self, inst, result):
-        super(DDGGenerationJob, self).finish(inst, result)
+        super().finish(inst, result)
         inst.ddgs[self._addr] = result
 
     def __repr__(self):

--- a/angrmanagement/data/jobs/dependency_analysis.py
+++ b/angrmanagement/data/jobs/dependency_analysis.py
@@ -183,7 +183,7 @@ class DependencyAnalysisJob(Job):
             caller_func_addr = trace.current_function_address()
             callers: Set[int] = set(kb.functions.callgraph.predecessors(caller_func_addr))
             # remove the functions that we already came across - essentially bypassing recursive function calls
-            callers = set(addr for addr in callers if addr not in encountered)
+            callers = {addr for addr in callers if addr not in encountered}
             caller_depth = curr_depth + 1
             if caller_depth >= max_depth:
                 # reached the depth limit. add them to potential analysis starts

--- a/angrmanagement/data/jobs/prototype_finding.py
+++ b/angrmanagement/data/jobs/prototype_finding.py
@@ -1,4 +1,3 @@
-
 from .job import Job
 
 

--- a/angrmanagement/data/jobs/simgr_explore.py
+++ b/angrmanagement/data/jobs/simgr_explore.py
@@ -1,4 +1,3 @@
-
 from .job import Job
 
 

--- a/angrmanagement/data/jobs/simgr_step.py
+++ b/angrmanagement/data/jobs/simgr_step.py
@@ -3,7 +3,7 @@ from .job import Job
 
 class SimgrStepJob(Job):
     def __init__(self, simgr, callback=None, until_branch=False, step_callback=None):
-        super(SimgrStepJob, self).__init__('Simulation manager stepping')
+        super().__init__('Simulation manager stepping')
         self._simgr = simgr
         self._callback = callback
         self._until_branch = until_branch
@@ -23,7 +23,7 @@ class SimgrStepJob(Job):
         return self._simgr
 
     def finish(self, inst, result):
-        super(SimgrStepJob, self).finish(inst, result)
+        super().finish(inst, result)
         if self._callback is not None:
             self._callback(result)
 

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -1,17 +1,16 @@
-
 from .job import Job
 
 
 class VFGGenerationJob(Job):
     def __init__(self, addr):
-        super(VFGGenerationJob, self).__init__('VFG generation')
+        super().__init__('VFG generation')
         self._addr = addr
 
     def _run(self, inst):
         return inst.project.analyses.VFG(function_start=self._addr)
 
     def finish(self, inst, result):
-        super(VFGGenerationJob, self).finish(inst, result)
+        super().finish(inst, result)
         inst.vfgs[self._addr] = result
 
     def __repr__(self):

--- a/angrmanagement/data/library_docs.py
+++ b/angrmanagement/data/library_docs.py
@@ -27,7 +27,7 @@ class LibraryDocs:
             for filename in os.listdir(path):
                 if filename.endswith(".json"):
                     jpath = os.path.join(path, filename)
-                    with open(jpath, "r") as jfile:
+                    with open(jpath) as jfile:
                         data = json.load(jfile)
                         docs.append(data)
 

--- a/angrmanagement/data/object_container.py
+++ b/angrmanagement/data/object_container.py
@@ -105,4 +105,4 @@ class ObjectContainer(EventSentinel):
         return not self == other
 
     def __repr__(self):
-        return '(container: %s)%s' % (self.am_name, repr(self._am_obj))
+        return '(container: {}){}'.format(self.am_name, repr(self._am_obj))

--- a/angrmanagement/data/object_container.py
+++ b/angrmanagement/data/object_container.py
@@ -105,4 +105,4 @@ class ObjectContainer(EventSentinel):
         return not self == other
 
     def __repr__(self):
-        return '(container: {}){}'.format(self.am_name, repr(self._am_obj))
+        return f'(container: {self.am_name}){repr(self._am_obj)}'

--- a/angrmanagement/errors.py
+++ b/angrmanagement/errors.py
@@ -1,4 +1,3 @@
-
 class AngrManagementError(Exception):
     pass
 

--- a/angrmanagement/logic/disassembly/jump_history.py
+++ b/angrmanagement/logic/disassembly/jump_history.py
@@ -1,5 +1,3 @@
-
-
 class JumpHistory:
     """
     A class to store the navigation history of a reversing session. Typically found at DisassemblyView._jump_history

--- a/angrmanagement/logic/singleton.py
+++ b/angrmanagement/logic/singleton.py
@@ -70,7 +70,7 @@ class SingleInstance:
             self.fp.flush()
             try:
                 fcntl.lockf(self.fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except IOError:
+            except OSError:
                 logger.debug(
                     "Another instance is already running, quitting.")
                 raise SingleInstanceException()

--- a/angrmanagement/logic/threads.py
+++ b/angrmanagement/logic/threads.py
@@ -99,7 +99,7 @@ class GUIObjProxy:
         for name in cls._special_names:
             if hasattr(theclass, name):
                 namespace[name] = make_method(name)
-        return type("%s(%s)" % (cls.__name__, theclass.__name__), (cls,), namespace)
+        return type("{}({})".format(cls.__name__, theclass.__name__), (cls,), namespace)
 
     def __new__(cls, obj, *args, **kwargs):
         """

--- a/angrmanagement/logic/threads.py
+++ b/angrmanagement/logic/threads.py
@@ -99,7 +99,7 @@ class GUIObjProxy:
         for name in cls._special_names:
             if hasattr(theclass, name):
                 namespace[name] = make_method(name)
-        return type("{}({})".format(cls.__name__, theclass.__name__), (cls,), namespace)
+        return type(f"{cls.__name__}({theclass.__name__})", (cls,), namespace)
 
     def __new__(cls, obj, *args, **kwargs):
         """

--- a/angrmanagement/logic/url_scheme.py
+++ b/angrmanagement/logic/url_scheme.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 import subprocess
@@ -107,7 +106,7 @@ class AngrUrlScheme:
 
     def _register_url_scheme_linux(self):
 
-        cmd_0 = ["xdg-mime", "default", "angr.desktop", "x-scheme-handler/{url_scheme}".format(url_scheme=self.URL_SCHEME)]
+        cmd_0 = ["xdg-mime", "default", "angr.desktop", f"x-scheme-handler/{self.URL_SCHEME}"]
 
         # test if xdg-mime is available
         retcode = subprocess.call(["xdg-mime"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -160,14 +159,14 @@ Type=Application
 
         # xdg-mine query
         proc = subprocess.Popen(["xdg-mime", "query", "default",
-            "x-scheme-handler/{url_scheme}".format(url_scheme=self.URL_SCHEME)],
+            f"x-scheme-handler/{self.URL_SCHEME}"],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, _ = proc.communicate()
         if not stdout:
             return False, None
 
         # Load Exec=
-        with open(angr_desktop_path, "r") as f:
+        with open(angr_desktop_path) as f:
             data = f.read()
         lines = data.split("\n")
         cmdline = None

--- a/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
+++ b/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
@@ -136,7 +136,7 @@ class LoadComponentsDialog(QDialog):
             try:
                 data = json.load(f)
             except ValueError as ex:
-                raise TypeError("File {} does not contain valid JSON data.\nException: {}.".format(path, ex))
+                raise TypeError(f"File {path} does not contain valid JSON data.\nException: {ex}.")
 
         return self._load_json(data)
 
@@ -146,7 +146,7 @@ class LoadComponentsDialog(QDialog):
         try:
             data = json.loads(content.decode("utf-8"))
         except ValueError as ex:
-            raise TypeError("URL {} does not contain valid JSON data.\nException: {}.".format(url, ex))
+            raise TypeError(f"URL {url} does not contain valid JSON data.\nException: {ex}.")
         return self._load_json(data)
 
     def _load_json(self, data: List[Dict]):

--- a/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
+++ b/angrmanagement/plugins/bughouse/ui/load_components_dialog.py
@@ -65,7 +65,7 @@ class LoadComponentsDialog(QDialog):
                 tree = self._load_json_from_file(path)
             self.tree = tree
             return True
-        except (ValueError, TypeError, IOError) as ex:
+        except (ValueError, TypeError, OSError) as ex:
             QMessageBox.critical(self,
                                  "Loading error",
                                  "Failed to load components information. Please make sure the component file is "
@@ -130,13 +130,13 @@ class LoadComponentsDialog(QDialog):
 
     def _load_json_from_file(self, path):
         if not os.path.isfile(path):
-            raise IOError("File %s does not exist." % path)
+            raise OSError("File %s does not exist." % path)
 
-        with open(path, "r") as f:
+        with open(path) as f:
             try:
                 data = json.load(f)
             except ValueError as ex:
-                raise TypeError("File %s does not contain valid JSON data.\nException: %s." % (path, ex))
+                raise TypeError("File {} does not contain valid JSON data.\nException: {}.".format(path, ex))
 
         return self._load_json(data)
 
@@ -146,7 +146,7 @@ class LoadComponentsDialog(QDialog):
         try:
             data = json.loads(content.decode("utf-8"))
         except ValueError as ex:
-            raise TypeError("URL %s does not contain valid JSON data.\nException: %s." % (url, ex))
+            raise TypeError("URL {} does not contain valid JSON data.\nException: {}.".format(url, ex))
         return self._load_json(data)
 
     def _load_json(self, data: List[Dict]):

--- a/angrmanagement/plugins/chess_manager/__init__.py
+++ b/angrmanagement/plugins/chess_manager/__init__.py
@@ -1,4 +1,3 @@
-
 from .chess_url_handler import ChessUrlHandler
 from .chess_connector import ChessConnector
 from .poi_plugin import POIViewer

--- a/angrmanagement/plugins/chess_manager/chess_url_handler.py
+++ b/angrmanagement/plugins/chess_manager/chess_url_handler.py
@@ -96,7 +96,7 @@ class ChessUrlHandler(BasePlugin):
         # load it if it exists
         entries = { }
         if os.path.isfile(rootdirs_path):
-            with open(rootdirs_path, "r") as f:
+            with open(rootdirs_path) as f:
                 try:
                     entries = tomlkit.load(f)
                 except tomlkit.exceptions.ParseError:
@@ -163,7 +163,7 @@ class ChessUrlHandler(BasePlugin):
         # load it
         entries = { }
         if os.path.isfile(rootdirs_path):
-            with open(rootdirs_path, "r") as f:
+            with open(rootdirs_path) as f:
                 try:
                     entries = tomlkit.load(f)
                 except tomlkit.exceptions.ParseError:

--- a/angrmanagement/plugins/chess_manager/poi_plugin.py
+++ b/angrmanagement/plugins/chess_manager/poi_plugin.py
@@ -225,7 +225,7 @@ class POIViewer(BasePlugin):
             poi_path = self._open_poi_dialog(tfilter='JSON files (*.json)')
 
         if poi_path is not None:
-            with open(poi_path, 'r') as f:
+            with open(poi_path) as f:
                 try:
                     return json.load(f)
                 except json.JSONDecodeError as ex:

--- a/angrmanagement/plugins/execution_statistics_viewer/execution_statistics_viewer.py
+++ b/angrmanagement/plugins/execution_statistics_viewer/execution_statistics_viewer.py
@@ -41,7 +41,7 @@ class ExecutionStatisticsViewer(BasePlugin):
         """Prior to stepping the active states, increment the passthrough count on the basic block(s) that will be
         executed next."""
         if self.bb_addrs is None:
-            self.bb_addrs = set(b.addr for b in self.instance.cfg.nodes())
+            self.bb_addrs = {b.addr for b in self.instance.cfg.nodes()}
         for s in simgr.active:
             for i_addr in s.block().instruction_addrs:
                 if i_addr in self.bb_addrs:

--- a/angrmanagement/plugins/memory_checker/memory_checker.py
+++ b/angrmanagement/plugins/memory_checker/memory_checker.py
@@ -40,7 +40,7 @@ class MemoryChecker(BasePlugin):
             if p <  len_list and base <= ptr_dict.peekitem(p)[0] < base + size:
                 if state.posix.stderr.writable:
                     addr, act = ptr_dict.peekitem(p)
-                    err_str = "\n=== Use-After-Free Plugin ===\nMemory Address:{:#x}\nInstrument Address:{:#x}\n".format(addr, act.ins_addr)
+                    err_str = f"\n=== Use-After-Free Plugin ===\nMemory Address:{addr:#x}\nInstrument Address:{act.ins_addr:#x}\n"
                     state.posix.stderr.write(None ,err_str.encode())
                 return True
         return False

--- a/angrmanagement/plugins/plugin_description.py
+++ b/angrmanagement/plugins/plugin_description.py
@@ -66,7 +66,7 @@ class PluginDescription:
 
     @classmethod
     def from_toml(cls, file_path: str) -> List['PluginDescription']:
-        with open(file_path, "r", encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             data = tomlkit.load(f)
 
         # load metadata

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -282,7 +282,7 @@ class PluginManager:
             return None
 
     def _handle_error(self, plugin, func, sensitive, exc):
-        self.workspace.log("Plugin {} errored during {}".format(plugin.get_display_name(), func.__name__))
+        self.workspace.log(f"Plugin {plugin.get_display_name()} errored during {func.__name__}")
         self.workspace.log(exc)
         if sensitive:
             self.workspace.log("Deactivating %s for error during sensitive operation" % plugin.get_display_name())

--- a/angrmanagement/plugins/plugin_manager.py
+++ b/angrmanagement/plugins/plugin_manager.py
@@ -282,7 +282,7 @@ class PluginManager:
             return None
 
     def _handle_error(self, plugin, func, sensitive, exc):
-        self.workspace.log("Plugin %s errored during %s" % (plugin.get_display_name(), func.__name__))
+        self.workspace.log("Plugin {} errored during {}".format(plugin.get_display_name(), func.__name__))
         self.workspace.log(exc)
         if sensitive:
             self.workspace.log("Deactivating %s for error during sensitive operation" % plugin.get_display_name())
@@ -367,7 +367,7 @@ class PluginManager:
         raise IndexError("Not enough columns")
 
     def count_func_columns(self):
-        return sum((len(plugin.FUNC_COLUMNS) for plugin in self.active_plugins.values()))
+        return sum(len(plugin.FUNC_COLUMNS) for plugin in self.active_plugins.values())
 
     def extract_func_column(self, func, idx):
         for plugin in self.active_plugins.values():

--- a/angrmanagement/plugins/seed_table/seed_table_plugin.py
+++ b/angrmanagement/plugins/seed_table/seed_table_plugin.py
@@ -28,7 +28,7 @@ class querySignaler(QObject):
 class SeedTableModel(QAbstractTableModel):
 
     def __init__(self, workspace, table, dropdown, countlabel):
-        super(SeedTableModel, self).__init__()
+        super().__init__()
         self.query_signal = querySignaler()
         self.query_signal.querySignal.connect(self.querySignalHandle)
         self.seed_db = SeedTable(workspace, self.query_signal, seed_callback=self.add_seed)

--- a/angrmanagement/plugins/trace_viewer/trace_plugin.py
+++ b/angrmanagement/plugins/trace_viewer/trace_plugin.py
@@ -336,7 +336,7 @@ class TraceViewer(BasePlugin):
                                          "The HTTP request returned an unexpected status code %d." % ex.status_code)
                     trace = None
             else:
-                with open(trace_path, 'r') as f:
+                with open(trace_path) as f:
                     trace = json.load(f)
 
             if base_addr is None:
@@ -370,7 +370,7 @@ class TraceViewer(BasePlugin):
         if trace_file_name is None:
             return None, None
 
-        with open(trace_file_name, 'r') as f:
+        with open(trace_file_name) as f:
             trace = json.load(f)
 
         if not isinstance(trace, dict):

--- a/angrmanagement/plugins/varec/varec.py
+++ b/angrmanagement/plugins/varec/varec.py
@@ -91,7 +91,7 @@ class VaRec(BasePlugin):
 
         for v in view.codegen._variable_kb.variables[view.function.addr]._unified_variables:
             if not v.renamed:
-                v.name = "@@%s@@%s@@" % (v.name, VaRec.randstr())
+                v.name = "@@{}@@{}@@".format(v.name, VaRec.randstr())
 
         view.codegen.regenerate_text()
         d = {
@@ -165,7 +165,7 @@ class VaRec(BasePlugin):
                 var_name = m.group(1)
                 predicted = varname_to_predicted[var_name]
                 predicted = sorted(predicted, key=lambda x: x['confidence'], reverse=True)
-                v.candidate_names = set(pred['pred_name'] for pred in predicted)
+                v.candidate_names = {pred['pred_name'] for pred in predicted}
                 for pred in predicted:
                     if pred['pred_name'] not in used_names:
                         v.name = pred['pred_name']

--- a/angrmanagement/plugins/varec/varec.py
+++ b/angrmanagement/plugins/varec/varec.py
@@ -91,7 +91,7 @@ class VaRec(BasePlugin):
 
         for v in view.codegen._variable_kb.variables[view.function.addr]._unified_variables:
             if not v.renamed:
-                v.name = "@@{}@@{}@@".format(v.name, VaRec.randstr())
+                v.name = f"@@{v.name}@@{VaRec.randstr()}@@"
 
         view.codegen.regenerate_text()
         d = {

--- a/angrmanagement/ui/dialogs/func_doc.py
+++ b/angrmanagement/ui/dialogs/func_doc.py
@@ -47,7 +47,7 @@ class FuncDocDialog(QDialog):
         text_edit.setText(self._doc)
 
         url_label = QLabel(self)
-        hyperlink = "<a href=\"{}\">{}</a>".format(self._url, self._url)
+        hyperlink = f"<a href=\"{self._url}\">{self._url}</a>"
         url_label.setText(hyperlink)
         url_label.setOpenExternalLinks(True)
 

--- a/angrmanagement/ui/dialogs/func_doc.py
+++ b/angrmanagement/ui/dialogs/func_doc.py
@@ -47,7 +47,7 @@ class FuncDocDialog(QDialog):
         text_edit.setText(self._doc)
 
         url_label = QLabel(self)
-        hyperlink = "<a href=\"%s\">%s</a>" % (self._url, self._url)
+        hyperlink = "<a href=\"{}\">{}</a>".format(self._url, self._url)
         url_label.setText(hyperlink)
         url_label.setOpenExternalLinks(True)
 

--- a/angrmanagement/ui/dialogs/load_docker_prompt.py
+++ b/angrmanagement/ui/dialogs/load_docker_prompt.py
@@ -13,7 +13,7 @@ class LoadDockerPromptError(Exception):
 
 class LoadDockerPrompt(QInputDialog):
     def __init__(self, parent=None):
-        super(LoadDockerPrompt, self).__init__(parent)
+        super().__init__(parent)
 
         self.setComboBoxItems(get_docker_images(self))
         self.setOption(QInputDialog.UsePlainTextEditForTextInput, True)

--- a/angrmanagement/ui/dialogs/new_state.py
+++ b/angrmanagement/ui/dialogs/new_state.py
@@ -219,7 +219,7 @@ class NewState(QDialog):
             env_dialog = EnvConfig(env_config=self._env_config, instance=self.instance, parent=self)
             env_dialog.exec_()
             self._env_config = env_dialog.env_config
-            env_button.setText("{} Items".format(len(self._env_config)))
+            env_button.setText(f"{len(self._env_config)} Items")
 
         env_button.clicked.connect(env_edit_button)
 
@@ -238,7 +238,7 @@ class NewState(QDialog):
             fs_dialog = FilesystemMount(fs_config=self._fs_config, instance=self.instance, parent=self)
             fs_dialog.exec_()
             self._fs_config = fs_dialog.fs_config
-            fs_button.setText("{} Items".format(len(self._fs_config)))
+            fs_button.setText(f"{len(self._fs_config)} Items")
 
         fs_button.clicked.connect(fs_edit_button)
 

--- a/angrmanagement/ui/documents/__init__.py
+++ b/angrmanagement/ui/documents/__init__.py
@@ -1,2 +1,1 @@
-
 from .qcodedocument import QCodeDocument

--- a/angrmanagement/ui/menus/analyze_menu.py
+++ b/angrmanagement/ui/menus/analyze_menu.py
@@ -1,4 +1,3 @@
-
 from PySide6.QtGui import QKeySequence
 from PySide6.QtCore import Qt
 

--- a/angrmanagement/ui/menus/disasm_options_menu.py
+++ b/angrmanagement/ui/menus/disasm_options_menu.py
@@ -1,10 +1,9 @@
-
 from .menu import Menu, MenuEntry, MenuSeparator
 
 
 class DisasmOptionsMenu(Menu):
     def __init__(self, disasm_view):
-        super(DisasmOptionsMenu, self).__init__("", parent=disasm_view)
+        super().__init__("", parent=disasm_view)
 
         self._show_minimap_action = MenuEntry('Show &minimap', self._show_minimap, checkable=True,
                                               checked=self.parent.show_minimap

--- a/angrmanagement/ui/menus/help_menu.py
+++ b/angrmanagement/ui/menus/help_menu.py
@@ -1,4 +1,3 @@
-
 from PySide6.QtGui import QKeySequence
 from PySide6.QtCore import Qt
 

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -62,8 +62,8 @@ class Menu:
 
     def action_by_key(self, key):
         if not self._keyed_entries:
-            self._keyed_entries = dict((ent.key, ent) for ent in
-                    self.entries if isinstance(ent, MenuEntry))
+            self._keyed_entries = {ent.key: ent for ent in
+                    self.entries if isinstance(ent, MenuEntry)}
         return self._keyed_entries.get(key, None)
 
     def qmenu(self, extra_entries=None, cached=True):

--- a/angrmanagement/ui/toolbars/file_toolbar.py
+++ b/angrmanagement/ui/toolbars/file_toolbar.py
@@ -12,7 +12,7 @@ except ImportError:
 
 class FileToolbar(Toolbar):
     def __init__(self, main_window):
-        super(FileToolbar, self).__init__(main_window, 'File')
+        super().__init__(main_window, 'File')
 
         self.actions = [
             ToolbarAction(QIcon(os.path.join(IMG_LOCATION, 'toolbar-file-open.ico')),

--- a/angrmanagement/ui/toolbars/function_table_toolbar.py
+++ b/angrmanagement/ui/toolbars/function_table_toolbar.py
@@ -1,4 +1,3 @@
-
 import os
 
 from PySide6.QtGui import QIcon

--- a/angrmanagement/ui/toolbars/toolbar.py
+++ b/angrmanagement/ui/toolbars/toolbar.py
@@ -21,7 +21,7 @@ class ToolbarAction:
 
 class ToolbarSplitter(ToolbarAction):
     def __init__(self):
-        super(ToolbarSplitter, self).__init__(None, None, None, None)
+        super().__init__(None, None, None, None)
 
 
 class Toolbar:

--- a/angrmanagement/ui/views/console_view.py
+++ b/angrmanagement/ui/views/console_view.py
@@ -1,4 +1,3 @@
-
 import logging
 from PySide6.QtWidgets import QHBoxLayout
 from PySide6.QtCore import QSize

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -1,4 +1,3 @@
-
 from collections import defaultdict
 import logging
 from typing import Union, Optional, Tuple, TYPE_CHECKING

--- a/angrmanagement/ui/views/interaction_view.py
+++ b/angrmanagement/ui/views/interaction_view.py
@@ -452,7 +452,7 @@ class InteractionView(BaseView):
 # Subclass QPlainTextEdit
 class SmartPlainTextEdit(QtWidgets.QPlainTextEdit):
     def __init__(self, parent, callback):
-        super(SmartPlainTextEdit, self).__init__(parent)
+        super().__init__(parent)
         self._callback = callback
 
     def keyPressEvent(self, event):

--- a/angrmanagement/ui/views/patches_view.py
+++ b/angrmanagement/ui/views/patches_view.py
@@ -1,4 +1,3 @@
-
 from PySide6.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog
 
 from .view import BaseView

--- a/angrmanagement/ui/views/states_view.py
+++ b/angrmanagement/ui/views/states_view.py
@@ -7,7 +7,7 @@ from ..widgets.qstate_table import QStateTable
 
 class StatesView(BaseView):
     def __init__(self, instance, default_docking_position, *args, **kwargs):
-        super(StatesView, self).__init__('states', instance, default_docking_position, *args, **kwargs)
+        super().__init__('states', instance, default_docking_position, *args, **kwargs)
 
         self.base_caption = 'States'
         self._state_table = None  # type: QStateTable

--- a/angrmanagement/ui/views/strings_view.py
+++ b/angrmanagement/ui/views/strings_view.py
@@ -12,7 +12,7 @@ from ..widgets.qfunction_combobox import QFunctionComboBox
 
 class StringsView(BaseView):
     def __init__(self, instance, default_docking_position, *args, **kwargs):
-        super(StringsView, self).__init__('strings', instance, default_docking_position, *args, **kwargs)
+        super().__init__('strings', instance, default_docking_position, *args, **kwargs)
 
         self.base_caption = 'Strings'
 

--- a/angrmanagement/ui/widgets/__init__.py
+++ b/angrmanagement/ui/widgets/__init__.py
@@ -1,4 +1,3 @@
-
 from .qaddress_input import QAddressInput
 from .qstate_combobox import QStateComboBox
 from .qdisasm_statusbar import QDisasmStatusBar

--- a/angrmanagement/ui/widgets/qaddress_input.py
+++ b/angrmanagement/ui/widgets/qaddress_input.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import QLineEdit
 class QAddressInput(QLineEdit):
     def __init__(self, textchanged_callback: Optional[Callable], instance, parent=None,
                  default: Optional[str]=None):
-        super(QAddressInput, self).__init__(parent)
+        super().__init__(parent)
 
         self.instance = instance
 

--- a/angrmanagement/ui/widgets/qast_viewer.py
+++ b/angrmanagement/ui/widgets/qast_viewer.py
@@ -8,7 +8,7 @@ from ...config import Conf
 
 class QASTViewer(QFrame):
     def __init__(self, ast, workspace=None, custom_painting=False, display_size=True, byte_format=None, parent=None):
-        super(QASTViewer, self).__init__(parent)
+        super().__init__(parent)
 
         # configs
         self._custom_painting = custom_painting
@@ -85,14 +85,14 @@ class QASTViewer(QFrame):
     @property
     def width(self):
         if not self._custom_painting:
-            return super(QASTViewer, self).width()
+            return super().width()
         else:
             return self._width
 
     @property
     def height(self):
         if not self._custom_painting:
-            return super(QASTViewer, self).height()
+            return super().height()
         else:
             return self._height
 

--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -341,7 +341,7 @@ class QLinearBlock(QBlock):
 
     @staticmethod
     def format_address(addr):
-        return '{:08x}'.format(addr)
+        return f'{addr:08x}'
 
     def layout_widgets(self):
         y_offset = 0

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -344,7 +344,7 @@ class QAilConstObj(QAilTextObj):
         if data_str:
             self.add_text(data_str)
         else:
-            self.add_text("%#x" % (obj.value,))
+            self.add_text("{:#x}".format(obj.value))
 
     def should_highlight(self) -> bool:
         return (isinstance(self.infodock.selected_qblock_code_obj, QAilConstObj) and
@@ -388,7 +388,7 @@ class QAilRegisterObj(QAilTextObj):
             self.add_variable(obj.variable)
         else:
             if hasattr(obj, 'reg_name'):
-                s = "%s" % (obj.reg_name,)
+                s = "{}".format(obj.reg_name)
             else:
                 s = "reg_%d<%d>" % (obj.reg_offset, obj.bits // 8)
             self.add_text(s)
@@ -623,7 +623,7 @@ class QIROpVexStoreObj(QIROpTextObj):
 
     def create_subobjs(self, obj:pyvex.stmt.Store):
         # "ST%s(%s) = %s" % (self.endness[-2:].lower(), self.addr, self.data)
-        self.add_text('ST%s(' % (obj.endness[-2:].lower(),))
+        self.add_text('ST{}('.format(obj.endness[-2:].lower()))
         self.add_irobj(obj.addr)
         self.add_text(') = ')
         self.add_irobj(obj.data)
@@ -635,7 +635,7 @@ class QIROpVexLoadObj(QIROpTextObj):
     """
 
     def create_subobjs(self, obj:pyvex.expr.Load):
-        self.add_text('LD%s:%s(' % (obj.end[-2:].lower(), obj.ty[4:]))
+        self.add_text('LD{}:{}('.format(obj.end[-2:].lower(), obj.ty[4:]))
         self.add_irobj(obj.addr)
         self.add_text(')')
 

--- a/angrmanagement/ui/widgets/qblock_code.py
+++ b/angrmanagement/ui/widgets/qblock_code.py
@@ -344,7 +344,7 @@ class QAilConstObj(QAilTextObj):
         if data_str:
             self.add_text(data_str)
         else:
-            self.add_text("{:#x}".format(obj.value))
+            self.add_text(f"{obj.value:#x}")
 
     def should_highlight(self) -> bool:
         return (isinstance(self.infodock.selected_qblock_code_obj, QAilConstObj) and
@@ -388,7 +388,7 @@ class QAilRegisterObj(QAilTextObj):
             self.add_variable(obj.variable)
         else:
             if hasattr(obj, 'reg_name'):
-                s = "{}".format(obj.reg_name)
+                s = f"{obj.reg_name}"
             else:
                 s = "reg_%d<%d>" % (obj.reg_offset, obj.bits // 8)
             self.add_text(s)
@@ -623,7 +623,7 @@ class QIROpVexStoreObj(QIROpTextObj):
 
     def create_subobjs(self, obj:pyvex.stmt.Store):
         # "ST%s(%s) = %s" % (self.endness[-2:].lower(), self.addr, self.data)
-        self.add_text('ST{}('.format(obj.endness[-2:].lower()))
+        self.add_text(f'ST{obj.endness[-2:].lower()}(')
         self.add_irobj(obj.addr)
         self.add_text(') = ')
         self.add_irobj(obj.data)
@@ -635,7 +635,7 @@ class QIROpVexLoadObj(QIROpTextObj):
     """
 
     def create_subobjs(self, obj:pyvex.expr.Load):
-        self.add_text('LD{}:{}('.format(obj.end[-2:].lower(), obj.ty[4:]))
+        self.add_text(f'LD{obj.end[-2:].lower()}:{obj.ty[4:]}(')
         self.add_irobj(obj.addr)
         self.add_text(')')
 

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -1,4 +1,3 @@
-
 import re
 
 from pyqodeng.core.api import SyntaxHighlighter

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -48,7 +48,7 @@ class QDecompilationOption(QTreeWidgetItem):
         if hasattr(self.option, "value_type") and self.option.value_type != bool and self.option.candidate_values:
             self._combo_box = QComboBox()
             self._combo_box.addItems(self.option.candidate_values)
-            self._combo_box.setToolTip("%s: %s" % (option.NAME, option.DESCRIPTION))
+            self._combo_box.setToolTip("{}: {}".format(option.NAME, option.DESCRIPTION))
             # XXX: causes an itemChanged event for the tree
             self._combo_box.currentTextChanged.connect(lambda x: self.setText(0, self._combo_box.currentText()))
             self.treeWidget().setItemWidget(self, 0, self._combo_box)

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -48,7 +48,7 @@ class QDecompilationOption(QTreeWidgetItem):
         if hasattr(self.option, "value_type") and self.option.value_type != bool and self.option.candidate_values:
             self._combo_box = QComboBox()
             self._combo_box.addItems(self.option.candidate_values)
-            self._combo_box.setToolTip("{}: {}".format(option.NAME, option.DESCRIPTION))
+            self._combo_box.setToolTip(f"{option.NAME}: {option.DESCRIPTION}")
             # XXX: causes an itemChanged event for the tree
             self._combo_box.currentTextChanged.connect(lambda x: self.setText(0, self._combo_box.currentText()))
             self.treeWidget().setItemWidget(self, 0, self._combo_box)

--- a/angrmanagement/ui/widgets/qdepgraph_block.py
+++ b/angrmanagement/ui/widgets/qdepgraph_block.py
@@ -71,9 +71,9 @@ class QDepGraphBlock(QCachedGraphicsItem):
             self._definition_str = f"Register {register_name} @ {addr_str}"
         elif isinstance(atom, MemoryLocation):
             if isinstance(atom.addr, SpOffset):
-                self._definition_str = "Stack sp{:+#x} @ {}".format(atom.addr.offset, addr_str)
+                self._definition_str = f"Stack sp{atom.addr.offset:+#x} @ {addr_str}"
             elif isinstance(atom.addr, int):
-                self._definition_str = "Memory {:#x} @ {}".format(atom.addr, addr_str)
+                self._definition_str = f"Memory {atom.addr:#x} @ {addr_str}"
 
         if not self._definition_str:
             # fallback
@@ -97,9 +97,9 @@ class QDepGraphBlock(QCachedGraphicsItem):
             else:
                 offset = self.addr - the_func.addr
                 if not the_func.name:
-                    self._function_str = "{:#x}{:+x}".format(the_func.addr, offset)
+                    self._function_str = f"{the_func.addr:#x}{offset:+x}"
                 else:
-                    self._function_str = "{}{:+x}".format(the_func.name, offset)
+                    self._function_str = f"{the_func.name}{offset:+x}"
             # instruction
             self._instruction_str = "{}:  {}".format(self._function_str,
                                                  self._instance.get_instruction_text_at(self.addr))

--- a/angrmanagement/ui/widgets/qdepgraph_block.py
+++ b/angrmanagement/ui/widgets/qdepgraph_block.py
@@ -68,12 +68,12 @@ class QDepGraphBlock(QCachedGraphicsItem):
             # convert it to a register name
             arch = self._instance.project.arch
             register_name = arch.translate_register_name(atom.reg_offset, size=atom.size)
-            self._definition_str = "Register {} @ {}".format(register_name, addr_str)
+            self._definition_str = f"Register {register_name} @ {addr_str}"
         elif isinstance(atom, MemoryLocation):
             if isinstance(atom.addr, SpOffset):
-                self._definition_str = "Stack sp%+#x @ %s" % (atom.addr.offset, addr_str)
+                self._definition_str = "Stack sp{:+#x} @ {}".format(atom.addr.offset, addr_str)
             elif isinstance(atom.addr, int):
-                self._definition_str = "Memory %#x @ %s" % (atom.addr, addr_str)
+                self._definition_str = "Memory {:#x} @ {}".format(atom.addr, addr_str)
 
         if not self._definition_str:
             # fallback
@@ -97,11 +97,11 @@ class QDepGraphBlock(QCachedGraphicsItem):
             else:
                 offset = self.addr - the_func.addr
                 if not the_func.name:
-                    self._function_str = "%#x%+x" % (the_func.addr, offset)
+                    self._function_str = "{:#x}{:+x}".format(the_func.addr, offset)
                 else:
-                    self._function_str = "%s%+x" % (the_func.name, offset)
+                    self._function_str = "{}{:+x}".format(the_func.name, offset)
             # instruction
-            self._instruction_str = "%s:  %s" % (self._function_str,
+            self._instruction_str = "{}:  {}".format(self._function_str,
                                                  self._instance.get_instruction_text_at(self.addr))
             # text
             self._text = get_string_for_display(self._instance.cfg,

--- a/angrmanagement/ui/widgets/qfunction_combobox.py
+++ b/angrmanagement/ui/widgets/qfunction_combobox.py
@@ -5,7 +5,7 @@ from angr.knowledge_plugins import FunctionManager
 
 class QFunctionComboBox(QComboBox):
     def __init__(self, show_all_functions=False, selection_callback=None, parent=None):
-        super(QFunctionComboBox, self).__init__(parent)
+        super().__init__(parent)
 
         self._show_all_functions = show_all_functions
         self._selection_callback = selection_callback

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -399,7 +399,7 @@ class QFunctionTable(QWidget):
             self._table_view.function_manager = v
         else:
             raise ValueError("QFunctionTableView is uninitialized.")
-        self._last_known_func_addrs = set(func.addr for func in self._table_view._model.func_list)
+        self._last_known_func_addrs = {func.addr for func in self._table_view._model.func_list}
         self.filter_functions(self._filter_box.text())
         self.update_displayed_function_count()
 

--- a/angrmanagement/ui/widgets/qgraph.py
+++ b/angrmanagement/ui/widgets/qgraph.py
@@ -238,7 +238,7 @@ class QZoomableDraggableGraphicsView(QSaveableGraphicsView):
         elif event.type() == QEvent.MouseButtonRelease:
             newtype = QEvent.GraphicsSceneMouseRelease
         else:
-            raise ValueError('Unknown event type {}'.format(event.type()))
+            raise ValueError(f'Unknown event type {event.type()}')
 
         # pulled from QGraphicsView::mousePressEvent in the qt codebase:
         mouseEvent = QGraphicsSceneMouseEvent(newtype)

--- a/angrmanagement/ui/widgets/qipython_widget.py
+++ b/angrmanagement/ui/widgets/qipython_widget.py
@@ -1,4 +1,3 @@
-
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole.inprocess import QtInProcessKernelManager
 from IPython.lib import guisupport

--- a/angrmanagement/ui/widgets/qlog_widget.py
+++ b/angrmanagement/ui/widgets/qlog_widget.py
@@ -171,7 +171,7 @@ class QLogWidget(QTableView):
         selection = self.selectionModel().selectedRows()
         for row_index in selection:
             record = self.model.log[row_index.row()]
-            content.append("%s | %s | %s | %s" % (
+            content.append("{} | {} | {} | {}".format(
                 QLogTableModel.level_to_text(record.level),
                 str(record.timestamp),
                 record.source,
@@ -189,7 +189,7 @@ class QLogWidget(QTableView):
     def copy_all(self):
         content = [ ]
         for record in self.model.log:
-            content.append("%s | %s | %s | %s" % (
+            content.append("{} | {} | {} | {}".format(
                 QLogTableModel.level_to_text(record.level),
                 str(record.timestamp),
                 record.source,

--- a/angrmanagement/ui/widgets/qmemory_viewer.py
+++ b/angrmanagement/ui/widgets/qmemory_viewer.py
@@ -11,20 +11,20 @@ from .qast_viewer import QASTViewer
 l = logging.getLogger('ui.widgets.qregister_viewer')
 
 
-class AddressPiece(object):
+class AddressPiece:
     __slots__ = ['address']
 
     def __init__(self, address):
         self.address = address
 
 
-class NewLinePiece(object):
+class NewLinePiece:
     pass
 
 
 class QMemoryView(QWidget):
     def __init__(self, state, instance, parent=None):
-        super(QMemoryView, self).__init__(parent)
+        super().__init__(parent)
         self.instance = instance
 
         self.state = state
@@ -120,7 +120,7 @@ class QMemoryView(QWidget):
 
 class QMemoryViewer(QFrame):
     def __init__(self, state, parent, workspace):
-        super(QMemoryViewer, self).__init__(parent)
+        super().__init__(parent)
         self.workspace = workspace
 
         self._scrollarea = None  # type: QScrollArea

--- a/angrmanagement/ui/widgets/qpathtree.py
+++ b/angrmanagement/ui/widgets/qpathtree.py
@@ -13,7 +13,7 @@ l = logging.getLogger('ui.widgets.qpathtree')
 
 class QPathTree(QFrame):
     def __init__(self, simgr, state, symexec_view, workspace, parent=None):
-        super(QPathTree, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         self.symexec_view = symexec_view
         self.workspace = workspace

--- a/angrmanagement/ui/widgets/qphivariable.py
+++ b/angrmanagement/ui/widgets/qphivariable.py
@@ -1,4 +1,3 @@
-
 from PySide6.QtCore import Qt, QRectF
 
 from .qgraph_object import QCachedGraphicsItem
@@ -72,7 +71,7 @@ class QPhiVariable(QCachedGraphicsItem):
         painter.drawText(x, self._config.disasm_font_ascent, " = ")
         x += self._config.disasm_font_width * 3
         painter.setPen(Qt.darkGreen)
-        painter.drawText(x, self._config.disasm_font_ascent, u'\u0278(')
+        painter.drawText(x, self._config.disasm_font_ascent, '\u0278(')
         x += self._config.disasm_font_width * 2
 
         for i, (subvar_ident, ident_width) in enumerate(zip(self._subvar_idents, self._subvar_ident_widths)):

--- a/angrmanagement/ui/widgets/qregister_viewer.py
+++ b/angrmanagement/ui/widgets/qregister_viewer.py
@@ -39,7 +39,7 @@ class QRegisterViewer(QFrame):
     ARCH_REGISTERS['ARMHF'] = ARCH_REGISTERS['ARM']
 
     def __init__(self, state, parent, workspace):
-        super(QRegisterViewer, self).__init__(parent)
+        super().__init__(parent)
 
         self._state = state
         self.workspace = workspace

--- a/angrmanagement/ui/widgets/qstate_block.py
+++ b/angrmanagement/ui/widgets/qstate_block.py
@@ -74,9 +74,9 @@ class QStateBlock(QGraphicsItem):
             else:
                 offset = addr - the_func.addr
                 if not the_func.name:
-                    self._function_str = "{:#x}{:+x}".format(the_func.addr, offset)
+                    self._function_str = f"{the_func.addr:#x}{offset:+x}"
                 else:
-                    self._function_str = "{}{:+x}".format(the_func.name, offset)
+                    self._function_str = f"{the_func.name}{offset:+x}"
         self._function_str = "Function: %s" % self._function_str
 
     def mousePressEvent(self, event): #pylint: disable=no-self-use

--- a/angrmanagement/ui/widgets/qstate_block.py
+++ b/angrmanagement/ui/widgets/qstate_block.py
@@ -17,7 +17,7 @@ class QStateBlock(QGraphicsItem):
     LINE_MARGIN = 3
 
     def __init__(self, is_selected, symexec_view, state=None, history=None):
-        super(QStateBlock, self).__init__()
+        super().__init__()
 
         self.symexec_view = symexec_view
         self._instance = self.symexec_view.instance
@@ -74,9 +74,9 @@ class QStateBlock(QGraphicsItem):
             else:
                 offset = addr - the_func.addr
                 if not the_func.name:
-                    self._function_str = "%#x%+x" % (the_func.addr, offset)
+                    self._function_str = "{:#x}{:+x}".format(the_func.addr, offset)
                 else:
-                    self._function_str = "%s%+x" % (the_func.name, offset)
+                    self._function_str = "{}{:+x}".format(the_func.name, offset)
         self._function_str = "Function: %s" % self._function_str
 
     def mousePressEvent(self, event): #pylint: disable=no-self-use

--- a/angrmanagement/ui/widgets/qstate_combobox.py
+++ b/angrmanagement/ui/widgets/qstate_combobox.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QComboBox
 
 class QStateComboBox(QComboBox):
     def __init__(self, instance, allow_none=True, parent=None):
-        super(QStateComboBox, self).__init__(parent)
+        super().__init__(parent)
         self.states = instance.states
         self.allow_none = allow_none
         self._init_items()

--- a/angrmanagement/ui/widgets/qstate_table.py
+++ b/angrmanagement/ui/widgets/qstate_table.py
@@ -1,4 +1,3 @@
-
 import re
 
 from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractItemView, QMenu
@@ -182,7 +181,7 @@ class QStateTable(QTableWidget):
             name = current_name + " copy"
 
         # Increment the counter until there is no conflict with existing names
-        all_names = set(s.gui_data.name for s in self.states)
+        all_names = {s.gui_data.name for s in self.states}
         while name in all_names:
             ctr += 1
             name = current_name + " copy %d" % ctr

--- a/angrmanagement/ui/widgets/qstring_table.py
+++ b/angrmanagement/ui/widgets/qstring_table.py
@@ -148,7 +148,7 @@ class QStringModel(QAbstractTableModel):
 
 class QStringTable(QTableView):
     def __init__(self, instance, parent, selection_callback=None):
-        super(QStringTable, self).__init__(parent)
+        super().__init__(parent)
 
         self._instance = instance
         self._selected = selection_callback

--- a/angrmanagement/ui/widgets/qsymexec_graph.py
+++ b/angrmanagement/ui/widgets/qsymexec_graph.py
@@ -15,7 +15,7 @@ class QSymExecGraph(QZoomableDraggableGraphicsView):
     TOP_PADDING = 2000
 
     def __init__(self, current_state, workspace, symexec_view, parent=None):
-        super(QSymExecGraph, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         self.state = current_state
         self._symexec_view = symexec_view

--- a/angrmanagement/ui/widgets/qvariable.py
+++ b/angrmanagement/ui/widgets/qvariable.py
@@ -10,7 +10,7 @@ class QVariable(QCachedGraphicsItem):
     OFFSET_LEFT_PADDING = 12
 
     def __init__(self, instance, disasm_view, variable, config, parent=None):
-        super(QVariable, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         # initialization
         self.instance = instance
@@ -35,7 +35,7 @@ class QVariable(QCachedGraphicsItem):
         pass
 
     def refresh(self):
-        super(QVariable, self).refresh()
+        super().refresh()
 
         if self._variable_ident_item is not None:
             self._variable_ident_item.setVisible(self.disasm_view.show_variable_identifier)

--- a/angrmanagement/ui/widgets/qvextemps_viewer.py
+++ b/angrmanagement/ui/widgets/qvextemps_viewer.py
@@ -11,7 +11,7 @@ l = logging.getLogger('ui.widgets.qvextemps_viewer')
 class QVEXTempsViewer(QFrame):
 
     def __init__(self, state, parent, workspace):
-        super(QVEXTempsViewer, self).__init__(parent)
+        super().__init__(parent)
         self.workspace = workspace
 
         self.state = state

--- a/angrmanagement/ui/widgets/qxref_viewer.py
+++ b/angrmanagement/ui/widgets/qxref_viewer.py
@@ -260,7 +260,7 @@ class QXRefViewer(QTableView):
 
     def __init__(self, addr=None, variable_manager=None, variable=None, xrefs_manager=None, dst_addr=None,
                  instance: 'Instance'=None, xref_dialog=None, parent=None):
-        super(QXRefViewer, self).__init__(parent)
+        super().__init__(parent)
 
         self.verticalHeader().setVisible(False)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)

--- a/angrmanagement/ui/widgets/state_inspector.py
+++ b/angrmanagement/ui/widgets/state_inspector.py
@@ -11,7 +11,7 @@ class StateInspector(QTabWidget):
     Dispaly detail information for a selected state.
     '''
     def __init__(self, workspace, state, parent=None):
-        super(StateInspector, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.workspace = workspace
         self._state = state
 

--- a/angrmanagement/utils/block_objects.py
+++ b/angrmanagement/utils/block_objects.py
@@ -1,5 +1,3 @@
-
-
 class FunctionHeader:
 
     __slots__ = ('name', 'prototype', 'args', )

--- a/angrmanagement/utils/cfg.py
+++ b/angrmanagement/utils/cfg.py
@@ -1,4 +1,3 @@
-
 import logging
 from collections import defaultdict
 

--- a/angrmanagement/utils/edge.py
+++ b/angrmanagement/utils/edge.py
@@ -1,5 +1,3 @@
-
-
 class EdgeSort:
     DIRECT_JUMP = 0
     TRUE_BRANCH = 1

--- a/angrmanagement/utils/func.py
+++ b/angrmanagement/utils/func.py
@@ -15,7 +15,7 @@ def type2str(ty: Optional[SimType]) -> str:
     if ty is None:
         return "void"
     if isinstance(ty, SimTypePointer):
-        return "{}*".format(type2str(ty.pts_to))
+        return f"{type2str(ty.pts_to)}*"
     if ty.label:
         return ty.label
     return repr(ty)

--- a/angrmanagement/utils/graph.py
+++ b/angrmanagement/utils/graph.py
@@ -1,4 +1,3 @@
-
 import itertools
 from collections import defaultdict
 
@@ -199,7 +198,7 @@ class OutBranch:
     def __repr__(self):
         if self.ins_addr is None:
             return "<OutBranch at None, type %s>" % self.type
-        return "<OutBranch at %#x, type %s>" % (self.ins_addr, self.type)
+        return "<OutBranch at {:#x}, type {}>".format(self.ins_addr, self.type)
 
     def add_target(self, addr):
         self.targets.add(addr)

--- a/angrmanagement/utils/graph.py
+++ b/angrmanagement/utils/graph.py
@@ -198,7 +198,7 @@ class OutBranch:
     def __repr__(self):
         if self.ins_addr is None:
             return "<OutBranch at None, type %s>" % self.type
-        return "<OutBranch at {:#x}, type {}>".format(self.ins_addr, self.type)
+        return f"<OutBranch at {self.ins_addr:#x}, type {self.type}>"
 
     def add_target(self, addr):
         self.targets.add(addr)

--- a/angrmanagement/utils/graph_layouter.py
+++ b/angrmanagement/utils/graph_layouter.py
@@ -1,4 +1,3 @@
-
 from collections import defaultdict
 from typing import List
 

--- a/angrmanagement/utils/io.py
+++ b/angrmanagement/utils/io.py
@@ -1,4 +1,3 @@
-
 import re
 import os
 import urllib.parse

--- a/angrmanagement/utils/namegen.py
+++ b/angrmanagement/utils/namegen.py
@@ -1,4 +1,3 @@
-
 import random
 
 ADJECTIVES = [
@@ -2408,11 +2407,11 @@ ANIMALS = [
 "zorro",
 ]
 
-class NameGenerator(object):
+class NameGenerator:
 
     @staticmethod
     def random_name():
 
         global ADJECTIVES, ANIMALS
 
-        return "%s %s" % (random.choice(ADJECTIVES), random.choice(ANIMALS))
+        return "{} {}".format(random.choice(ADJECTIVES), random.choice(ANIMALS))

--- a/angrmanagement/utils/namegen.py
+++ b/angrmanagement/utils/namegen.py
@@ -2414,4 +2414,4 @@ class NameGenerator:
 
         global ADJECTIVES, ANIMALS
 
-        return "{} {}".format(random.choice(ADJECTIVES), random.choice(ANIMALS))
+        return f"{random.choice(ADJECTIVES)} {random.choice(ANIMALS)}"

--- a/tests/test_urlscheme.py
+++ b/tests/test_urlscheme.py
@@ -1,4 +1,3 @@
-
 from angrmanagement.daemon import handle_url
 
 


### PR DESCRIPTION
This applies a lot of overdue upgrades to angrmanagemetn. The main 3 are:
1. python2 `super()` -> python3 `super()`
2. Prefer f-strings to `"a {1} b".format(c)` and `"a %s b" % (c,)`
3. `class ABC(object):` -> `class ABC:`

This was run with the flag: `--py38-plus`