### PR TITLE
Remove appimage from nightly bundle

### DIFF
--- a/.github/workflows/nightly-build.sh
+++ b/.github/workflows/nightly-build.sh
@@ -23,13 +23,6 @@ pip install git+https://github.com/angr/claripy.git#egg=claripy
 pip install git+https://github.com/angr/ailment.git#egg=ailment
 pip install --no-build-isolation git+https://github.com/angr/angr.git#egg=angr
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    mkdir -p ~/.bin
-    wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage \
-        -O ~/.bin/appimagetool
-    chmod +x ~/.bin/appimagetool
-    export PATH="$HOME/.bin:$PATH"
-
-    pip install "appimage-builder==1.0.2"
     pip install keystone-engine
     pip install git+https://github.com/angr/archr.git#egg=archr
 fi
@@ -42,9 +35,6 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
     python packaging/pyinstaller/bundle.py --onefile
 fi
 python packaging/pyinstaller/bundle.py --onedir
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    bash packaging/appimage/build.sh
-fi
 
 mkdir upload
 
@@ -68,9 +58,4 @@ elif [[ "$OSTYPE" == "linux-gnu" ]]; then
     tar -C $ONEDIR_DIR -czf upload/angr-management-$ID-$VERSION_ID.tar.gz angr-management
 elif [[ "$OSTYPE" == "msys" ]]; then
     7z a upload/angr-management-win64.zip $ONEDIR_DIR/\*
-fi
-
-# Prepare appimage
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    cp packaging/appimage/angr\ management-latest-x86_64.AppImage upload/angr-management.AppImage
 fi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -58,11 +58,6 @@ jobs:
             upload/*.tar.gz
             upload/*.zip
             upload/*.dmg
-      - uses: actions/upload-artifact@v3
-        if: startsWith(matrix.os, 'ubuntu')
-        with:
-          name: angr-management-appimage-${{ matrix.os }}
-          path: upload/*.AppImage
 
   test_ubuntu:
     strategy:


### PR DESCRIPTION
The appimage is currently untested and doesn't offer any obvious benefits over using the onefile build. 