### PR TITLE
Migrate Feature Map out from Disassembly View into a toolbar

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -99,6 +99,8 @@ class Instance:
         self.register_container("current_trace", lambda: None, Type[Trace], "Currently selected trace")
         self.register_container("traces", lambda: [], List[Trace], "Global traces list")
 
+        self.register_container("active_view_state", lambda: None, "ViewState", "Currently focused view state")
+
         self.breakpoint_mgr = BreakpointManager()
         self.debugger_list_mgr = DebuggerListManager()
         self.debugger_mgr = DebuggerManager(self.debugger_list_mgr)

--- a/angrmanagement/logic/disassembly/info_dock.py
+++ b/angrmanagement/logic/disassembly/info_dock.py
@@ -103,11 +103,13 @@ class InfoDock(QObject):
         self.selected_blocks.clear()  # selecting one block at a time
         self.selected_blocks.add(block_addr)
         self.selected_blocks.am_event()
+        self._update_published_view_state()
 
     def unselect_block(self, block_addr):
         if block_addr in self.selected_blocks:
             self.selected_blocks.remove(block_addr)
             self.selected_blocks.am_event()
+        self._update_published_view_state()
 
     def select_instruction(self, insn_addr, unique=True, insn_pos=None, use_animation=True):
         self.disasm_view.set_synchronized_cursor_address(insn_addr)
@@ -123,15 +125,19 @@ class InfoDock(QObject):
             self.disasm_view.current_graph.show_instruction(insn_addr, insn_pos=insn_pos, use_animation=use_animation)
             self.selected_insns.am_event(insn_addr=insn_addr)
 
+        self._update_published_view_state()
+
     def unselect_instruction(self, insn_addr):
         if insn_addr in self.selected_insns:
             self.selected_insns.remove(insn_addr)
             self.selected_insns.am_event()
+        self._update_published_view_state()
 
     def unselect_all_instructions(self):
         if self.selected_insns:
             self.selected_insns.clear()
             self.selected_insns.am_event()
+        self._update_published_view_state()
 
     def select_operand(self, ins_addr: int, operand_index: int, operand: OperandDescriptor, unique: bool = False):
         """
@@ -173,6 +179,8 @@ class InfoDock(QObject):
         self.selected_labels.add(label_addr)
         self.selected_labels.am_event()
 
+        self._update_published_view_state()
+
     def toggle_label_selection(self, addr: int) -> None:
         """
         Toggle the selection state of a label in the disassembly view.
@@ -189,10 +197,12 @@ class InfoDock(QObject):
         if label_addr in self.selected_labels:
             self.selected_labels.remove(label_addr)
             self.selected_labels.am_event()
+        self._update_published_view_state()
 
     def unselect_all_labels(self):
         self.selected_labels.clear()
         self.selected_labels.am_event()
+        self._update_published_view_state()
 
     def toggle_instruction_selection(self, insn_addr, insn_pos=None, unique=False):
         """
@@ -235,6 +245,8 @@ class InfoDock(QObject):
 
         self.selected_operands.clear()
         self.selected_operands.am_event()
+
+        self._update_published_view_state()
 
     def is_edge_hovered(self, src_addr, dst_addr):
         return self.hovered_edge.am_obj == (src_addr, dst_addr)
@@ -288,3 +300,7 @@ class InfoDock(QObject):
         """
         self.selected_qblock_code_obj = obj
         self.qblock_code_obj_selection_changed.emit()
+
+    def _update_published_view_state(self):
+        self.disasm_view.published_view_state.cursors = self.selected_insns.union(self.selected_labels)
+        self.disasm_view.notify_view_state_updated()

--- a/angrmanagement/resources/themes/Dark/theme.css
+++ b/angrmanagement/resources/themes/Dark/theme.css
@@ -9,7 +9,10 @@ ads--CDockWidgetTab {
 
 QMenuBar {
     background-color: palette(dark);
+}
 
+ToolBarHandle {
+    background-color: palette(dark);
 }
 
 QMainWindow > QToolBar {

--- a/angrmanagement/resources/themes/base.css
+++ b/angrmanagement/resources/themes/base.css
@@ -83,6 +83,16 @@ QToolBar {
     margin: 0;
 }
 
+QMainWindow::separator
+{
+    background: palette(shadow);
+    width: 1px;
+    max-width: 1px;
+    height: 1px;
+    max-height: 1px;
+    border: none;
+}
+
 QSplitter[orientation="1"] {
     min-width: 3px;
     max-width: 3px;

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -38,7 +38,7 @@ from .menus.help_menu import HelpMenu
 from .menus.plugin_menu import PluginMenu
 from .menus.view_menu import ViewMenu
 from .toolbar_manager import ToolbarManager
-from .toolbars import DebugToolbar, FileToolbar
+from .toolbars import DebugToolbar, FeatureMapToolbar, FileToolbar
 from .workspace import Workspace
 
 try:
@@ -73,7 +73,6 @@ class MainWindow(QMainWindow):
 
         # initialization
         self.setMinimumSize(QSize(400, 400))
-        self.setDockNestingEnabled(True)
 
         self.app: Optional["QApplication"] = app
         self.workspace: Workspace = None
@@ -205,7 +204,7 @@ class MainWindow(QMainWindow):
         self._progress_dialog.close()
 
     def _init_toolbars(self):
-        for cls in (FileToolbar, DebugToolbar):
+        for cls in (FileToolbar, DebugToolbar, FeatureMapToolbar):
             self.toolbar_manager.show_toolbar_by_class(cls)
 
     #
@@ -244,11 +243,16 @@ class MainWindow(QMainWindow):
         :return:    None
         """
         QtAds.CDockManager.setConfigFlags(
-            (QtAds.CDockManager.DefaultBaseConfig | QtAds.CDockManager.OpaqueSplitterResize)
+            (
+                QtAds.CDockManager.DefaultBaseConfig
+                | QtAds.CDockManager.OpaqueSplitterResize
+                | QtAds.CDockManager.FocusHighlighting
+            )
             & ~QtAds.CDockManager.DockAreaHasUndockButton
         )
         self.dock_manager = QtAds.CDockManager(self)
         self.dock_manager.setStyleSheet("")  # Clear stylesheet overrides
+        self.setCentralWidget(self.dock_manager)
         wk = Workspace(self, Instance())
         self.workspace = wk
 

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -44,7 +44,8 @@ class ToolbarMenuEntry(MenuEntry):
 
     @property
     def is_visibile(self) -> bool:
-        return self.toolbar_cls in self.main_window.toolbar_manager.active
+        qtb = self.main_window.toolbar_manager.active.get(self.toolbar_cls, None)
+        return qtb is not None and qtb.qtoolbar().isVisible()
 
     def on_toggle(self):
         self.main_window.toolbar_manager.set_toolbar_visible_by_class(self.toolbar_cls, not self.is_visibile)

--- a/angrmanagement/ui/toolbar_manager.py
+++ b/angrmanagement/ui/toolbar_manager.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING, Mapping, Type
 
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDockWidget
 
-from angrmanagement.ui.toolbars import DebugToolbar, FileToolbar
+from angrmanagement.ui.toolbars import DebugToolbar, FeatureMapToolbar, FileToolbar
 
 if TYPE_CHECKING:
     from angrmanagement.ui.main_window import MainWindow
@@ -17,22 +18,33 @@ class ToolbarManager:
     def __init__(self, main_window):
         self._main_window: MainWindow = main_window
         self.active: Mapping[Type[Toolbar], Toolbar] = {}
-        self.all_toolbars = [FileToolbar, DebugToolbar]
+        self.all_toolbars = [FileToolbar, DebugToolbar, FeatureMapToolbar]
 
     @staticmethod
     def get_name_for_toolbar_class(toolbar_cls: Type["Toolbar"]) -> str:
-        return {FileToolbar: "File", DebugToolbar: "Debug"}[toolbar_cls]
+        return {FileToolbar: "File", DebugToolbar: "Debug", FeatureMapToolbar: "Feature Map"}[toolbar_cls]
 
     def show_toolbar_by_class(self, cls: Type["Toolbar"]):
         if cls not in self.active:
             tb = cls(self._main_window)
             self.active[cls] = tb
-            self._main_window.addToolBar(Qt.TopToolBarArea, tb.qtoolbar())
+            qtb = tb.qtoolbar()
+            if isinstance(qtb, QDockWidget):
+                self._main_window.addDockWidget(Qt.TopDockWidgetArea, qtb)
+            else:
+                self._main_window.addToolBar(Qt.TopToolBarArea, qtb)
+        else:
+            self.active[cls].qtoolbar().show()
 
     def hide_toolbar_by_class(self, cls: Type["Toolbar"]):
         if cls in self.active:
             tb = self.active.pop(cls)
-            self._main_window.removeToolBar(tb.qtoolbar())
+            qtb = tb.qtoolbar()
+            if isinstance(qtb, QDockWidget):
+                self._main_window.removeDockWidget(qtb)
+            else:
+                self._main_window.removeToolBar(qtb)
+            tb.shutdown()
 
     def set_toolbar_visible_by_class(self, cls: Type["Toolbar"], visible: bool):
         if visible:

--- a/angrmanagement/ui/toolbars/__init__.py
+++ b/angrmanagement/ui/toolbars/__init__.py
@@ -1,10 +1,12 @@
 from .debug_toolbar import DebugToolbar
+from .feature_map_toolbar import FeatureMapToolbar
 from .file_toolbar import FileToolbar
 from .function_table_toolbar import FunctionTableToolbar
 from .nav_toolbar import NavToolbar
 
 __all__ = [
     "DebugToolbar",
+    "FeatureMapToolbar",
     "FileToolbar",
     "FunctionTableToolbar",
     "NavToolbar",

--- a/angrmanagement/ui/toolbars/feature_map_toolbar.py
+++ b/angrmanagement/ui/toolbars/feature_map_toolbar.py
@@ -1,0 +1,50 @@
+from angrmanagement.ui.widgets.qfeature_map import QFeatureMap
+
+from .toolbar import Toolbar
+from .toolbar_dock import ToolBarDockWidget
+
+
+class FeatureMapToolbar(Toolbar):
+    """
+    Displays the current feature map. Monitors most recently focused view via instance.activate_view_state to show
+    cursors on the feature map, and allows selection in the feature map to control location of active view.
+    """
+
+    def __init__(self, window):
+        super().__init__(window, "Feature Map")
+        self._toolbar = None
+        self._feature_map = None
+        self._is_subscribed = False
+
+    def _subscribe_events(self):
+        self.window.workspace.main_instance.active_view_state.am_subscribe(self._on_view_state_updated)
+        self._feature_map.addr.am_subscribe(self._on_feature_map_addr_selected)
+        self._is_subscribed = True
+
+    def _unsubscribe_events(self):
+        if self._is_subscribed:
+            self.window.workspace.main_instance.active_view_state.am_unsubscribe(self._on_view_state_updated)
+            self._feature_map.addr.am_unsubscribe(self._on_feature_map_addr_selected)
+
+    def qtoolbar(self):
+        if self._toolbar is None:
+            self._feature_map = QFeatureMap(self.window.workspace.main_instance, parent=self.window)
+            self._toolbar = ToolBarDockWidget(self._feature_map, "Feature Map", parent=None)
+            self._subscribe_events()
+        return self._toolbar
+
+    def shutdown(self):
+        self._unsubscribe_events()
+
+    def _on_feature_map_addr_selected(self):
+        target_view = self.window.workspace.view_manager.most_recently_focused_view
+        if hasattr(target_view, "jump_to"):
+            addr = self._feature_map.addr.am_obj
+            if addr is not None:
+                target_view.jump_to(addr)
+
+    def _on_view_state_updated(self):
+        vs = self.window.workspace.main_instance.active_view_state
+        if vs.am_none:
+            return
+        self._feature_map.set_cursor_addrs(vs.cursors)

--- a/angrmanagement/ui/toolbars/toolbar.py
+++ b/angrmanagement/ui/toolbars/toolbar.py
@@ -16,6 +16,11 @@ class Toolbar:
         self._cached: Optional[QToolBar] = None
         self._cached_actions = {}
 
+    def shutdown(self):
+        """
+        Prepare for deletion.
+        """
+
     def qtoolbar(self):
         if self._cached is not None:
             return self._cached

--- a/angrmanagement/ui/toolbars/toolbar_dock.py
+++ b/angrmanagement/ui/toolbars/toolbar_dock.py
@@ -1,0 +1,75 @@
+# pylint:disable=no-self-use
+from PySide6.QtCore import QMargins, QRect, QSize, Qt
+from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import QDockWidget, QFrame, QHBoxLayout, QStyle, QStyleOptionToolBar, QWidget
+
+
+class ToolBarHandle(QWidget):
+    """
+    Paints a tool bar handle.
+    """
+
+    def __init__(self, *vargs, **kwargs):
+        super().__init__(*vargs, **kwargs)
+        self.orientation = False
+
+    def paintEvent(self, _):
+        painter = QPainter(self)
+        painter.setBrush(self.palette().window())
+        r = QRect(0, 0, self.width(), self.height()).marginsAdded(QMargins(1, 1, 1, 1))
+        painter.drawRect(r)
+        opt = QStyleOptionToolBar()
+        style = self.style()
+        if self.orientation:
+            opt.state = QStyle.State_Horizontal
+        opt.features = QStyleOptionToolBar.Movable
+        opt.toolBarArea = Qt.NoToolBarArea
+        opt.rect = r
+        style.drawPrimitive(QStyle.PE_IndicatorToolBarHandle, opt, painter, self)
+        painter.end()
+
+    def sizeHint(self):
+        return QSize(15, 15)
+
+
+class CustomToolBar(QFrame):
+    """
+    Widget to contain the tool bar handle and main widget.
+    """
+
+    def __init__(self, widget, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setWidget(widget)
+
+    def setWidget(self, widget):
+        layout = QHBoxLayout()
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.handle = ToolBarHandle(parent=self)
+        layout.addWidget(self.handle)
+        layout.addWidget(widget)
+        self.setLayout(layout)
+
+    def sizeHint(self):
+        return QSize(25, 25)
+
+
+class ToolBarDockWidget(QDockWidget):
+    """
+    Custom tool bar using QDockWidget for better resize handling than QToolBar for large widgets.
+    """
+
+    def __init__(self, widget, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.toolbar = CustomToolBar(widget)
+        self.setWidget(self.toolbar)
+        self.setTitleBarWidget(self.toolbar.handle)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        horizontal = self.width() > self.height()
+        if horizontal:
+            self.setFeatures(self.features() | QDockWidget.DockWidgetFeature.DockWidgetVerticalTitleBar)
+        else:
+            self.setFeatures(self.features() & ~QDockWidget.DockWidgetFeature.DockWidgetVerticalTitleBar)
+        self.toolbar.handle.orientation = horizontal

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -38,7 +38,7 @@ from angrmanagement.ui.widgets.qblock_code import QVariableObj
 from angrmanagement.ui.widgets.qinst_annotation import QBreakAnnotation, QHookAnnotation
 from angrmanagement.utils import locate_function
 
-from .view import SynchronizedView
+from .view import SynchronizedView, ViewStatePublisherMixin
 
 if TYPE_CHECKING:
     import PySide6
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 _l = logging.getLogger(__name__)
 
 
-class DisassemblyView(SynchronizedView):
+class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
     """
     Disassembly View
     """

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -30,7 +30,6 @@ from angrmanagement.ui.widgets import (
     QBlockAnnotations,
     QDisasmStatusBar,
     QDisassemblyGraph,
-    QFeatureMap,
     QFindAddrAnnotation,
     QLinearDisassembly,
     QLinearDisassemblyView,
@@ -769,19 +768,15 @@ class DisassemblyView(SynchronizedView):
     def _init_widgets(self):
         self._linear_viewer = QLinearDisassembly(self.instance, self, parent=self)
         self._flow_graph = QDisassemblyGraph(self.instance, self, parent=self)
-        self._feature_map = QFeatureMap(self, parent=self)
         self._statusbar = QDisasmStatusBar(self, parent=self)
 
         vlayout = QVBoxLayout()
         vlayout.addWidget(self._statusbar)
-        vlayout.addWidget(self._feature_map)
         vlayout.addWidget(self._flow_graph)
         vlayout.addWidget(self._linear_viewer)
         vlayout.setSpacing(0)
         vlayout.setContentsMargins(0, 0, 0, 0)
 
-        self._feature_map.setMaximumHeight(25)
-        vlayout.setStretchFactor(self._feature_map, 0)
         vlayout.setStretchFactor(self._flow_graph, 1)
         vlayout.setStretchFactor(self._linear_viewer, 1)
         vlayout.setStretchFactor(self._statusbar, 0)
@@ -812,12 +807,8 @@ class DisassemblyView(SynchronizedView):
         self.infodock.hovered_edge.am_subscribe(self.redraw_current_graph)
         self.infodock.selected_labels.am_subscribe(self.redraw_current_graph)
         self.infodock.qblock_code_obj_selection_changed.connect(self.redraw_current_graph)
-        self._feature_map.addr.am_subscribe(self._on_feature_map_addr_changed)
         self.instance.workspace.current_screen.am_subscribe(self.on_screen_changed)
         self.instance.breakpoint_mgr.breakpoints.am_subscribe(self._on_breakpoints_updated)
-
-    def _on_feature_map_addr_changed(self):
-        self._jump_to(self._feature_map.addr.am_obj)
 
     def _on_breakpoints_updated(self, **kwargs):  # pylint:disable=unused-argument
         self.refresh()
@@ -831,7 +822,6 @@ class DisassemblyView(SynchronizedView):
         self.infodock.hovered_edge.am_unsubscribe(self.redraw_current_graph)
         self.infodock.selected_labels.am_unsubscribe(self.redraw_current_graph)
         self.infodock.qblock_code_obj_selection_changed.disconnect(self.redraw_current_graph)
-        self._feature_map.addr.am_unsubscribe(self._on_feature_map_addr_changed)
         self.instance.workspace.current_screen.am_unsubscribe(self.on_screen_changed)
         self.instance.breakpoint_mgr.breakpoints.am_unsubscribe(self._on_breakpoints_updated)
 

--- a/angrmanagement/ui/views/hex_view.py
+++ b/angrmanagement/ui/views/hex_view.py
@@ -38,7 +38,7 @@ from angrmanagement.ui.dialogs.input_prompt import InputPromptDialog
 from angrmanagement.ui.dialogs.jumpto import JumpTo
 from angrmanagement.utils import is_printable
 
-from .view import SynchronizedView
+from .view import SynchronizedView, ViewStatePublisherMixin
 
 log = logging.getLogger(__name__)
 
@@ -1311,7 +1311,7 @@ class HexGraphicsView(QAbstractScrollArea):
         super().keyPressEvent(event)
 
 
-class HexView(SynchronizedView):
+class HexView(ViewStatePublisherMixin, SynchronizedView):
     """
     View and edit memory/object code in classic hex editor format.
     """
@@ -1769,6 +1769,8 @@ class HexView(SynchronizedView):
         self.update_status_text()
         self._update_cfb_highlight_regions()
         self.set_synchronized_cursor_address(self.inner_widget.hex.cursor)
+        self.published_view_state.cursors = [self.inner_widget.hex.cursor]
+        self.notify_view_state_updated()
 
     def update_status_text(self):
         """

--- a/angrmanagement/ui/views/view.py
+++ b/angrmanagement/ui/views/view.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
 
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QAction
@@ -79,6 +79,33 @@ class BaseView(QFrame):
         if self.index > 1:
             s += f"-{self.index}"
         return s
+
+
+class ViewState:
+    """
+    A basic view state to be published through ViewStatePublisherMixin.
+    """
+
+    def __init__(self, cursors: Optional[List[int]] = None):
+        self.cursors: List[int] = cursors or []
+
+
+class ViewStatePublisherMixin:
+    """
+    Views that wish to update the instance 'active' view state for common visualization use this mixin.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.published_view_state = ViewState()
+
+    def on_focused(self):
+        self.notify_view_state_updated()
+
+    def notify_view_state_updated(self):
+        if self.instance.workspace.view_manager.most_recently_focused_view is self:
+            self.instance.active_view_state.am_obj = self.published_view_state
+            self.instance.active_view_state.am_event()
 
 
 class SynchronizedViewState:

--- a/angrmanagement/ui/widgets/qfeature_map.py
+++ b/angrmanagement/ui/widgets/qfeature_map.py
@@ -570,6 +570,7 @@ class QFeatureMapView(QGraphicsView):
         self._scale: float = 1.0
         self._base_width: int = 0
         self._scene.addItem(self._feature_map_item)
+        self._orientation: str = "horizontal"
 
         self.setBackgroundBrush(Conf.palette_base)
         self.setResizeAnchor(QGraphicsView.ViewportAnchor.NoAnchor)
@@ -650,22 +651,43 @@ class QFeatureMapView(QGraphicsView):
         """
         Resize feature map.
         """
+        rotation = 0
         vg = self.viewport().geometry()
+
+        if vg.width() > vg.height():
+            if self._orientation != "horizontal":
+                rotation = -90
+            self._orientation = "horizontal"
+            w, h = vg.width(), vg.height()
+        else:
+            if self._orientation != "vertical":
+                rotation = 90
+            self._orientation = "vertical"
+            w, h = vg.height(), vg.width()
+
+        if rotation:
+            self._scale = 1.0
+
         if self._scale <= 1.0:
             # Only resize to feature map to viewport width if scale is at base level to not disturb preferred size
-            self._base_width = vg.width()
+            self._base_width = w
+
         new_width = int(self._base_width * self._scale)
         changed = False
         if new_width != self._feature_map_item.width:
             self._feature_map_item.width = new_width
             changed = True
-        new_height = vg.height()
+        new_height = h
+
         if new_height != self._feature_map_item.height:
             self._feature_map_item.height = new_height
             changed = True
+
         if changed:
             self._feature_map_item.refresh()
             self.setSceneRect(self._scene.itemsBoundingRect())
+        if rotation:
+            self.rotate(rotation)
 
 
 class QFeatureMap(QWidget):


### PR DESCRIPTION
Note: Implemented with a QDockWidget instead of QToolBar, which from a user perspective acts like QToolBar, but also has built-in resizing capabilities. The QDockWidget title bar is changed to look like a tool bar handle for more consistent interface. Ideally we could also move the toolbars into the advanced dock widgets so they could be placed near any view and not just at the edges of the main window, but I think this works well enough for now. This also appears to be how IDA implements their navigator toolbar.

Demo:

https://user-images.githubusercontent.com/8210/218620487-f9f9efd1-4e46-44cc-8d39-440129e04c2c.mp4

Closes #444