### PR TITLE
Use CFB on_object_added callback for live feature map updates

### DIFF
--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -39,7 +39,9 @@ class CFGGenerationJob(Job):
         self.instance = inst
         exclude_region_types = {"kernel", "tls"}
         # create a temporary CFB for displaying partially analyzed binary during CFG recovery
-        temp_cfb = inst.project.analyses.CFB(exclude_region_types=exclude_region_types)
+        temp_cfb = inst.project.analyses.CFB(
+            exclude_region_types=exclude_region_types, on_object_added=self._on_cfb_object_added
+        )
         self._cfb = temp_cfb
         cfg = inst.project.analyses.CFG(
             progress_callback=self._progress_callback,
@@ -97,3 +99,6 @@ class CFGGenerationJob(Job):
         # instance will exist because _run must be used first
         self.instance.cfg = cfg
         self.instance.cfb = cfb
+
+    def _on_cfb_object_added(self, addr, obj):
+        self.instance.cfb.am_event(object_added=(addr, obj))

--- a/angrmanagement/ui/views/hex_view.py
+++ b/angrmanagement/ui/views/hex_view.py
@@ -1330,7 +1330,7 @@ class HexView(ViewStatePublisherMixin, SynchronizedView):
         self._breakpoint_highlights: Sequence[BreakpointHighlightRegion] = []
 
         self._init_widgets()
-        self.instance.cfb.am_subscribe(self._reload_data)
+        self.instance.cfb.am_subscribe(self._on_cfb_event)
         self.instance.patches.am_subscribe(self._update_highlight_regions_from_patches)
         self.instance.breakpoint_mgr.breakpoints.am_subscribe(self._update_highlight_regions_from_breakpoints)
         self._data_cache = {}
@@ -1340,6 +1340,10 @@ class HexView(ViewStatePublisherMixin, SynchronizedView):
         self._dbg_manager = self.instance.debugger_mgr
         self._dbg_watcher = DebuggerWatcher(self._on_debugger_state_updated, self._dbg_manager.debugger)
         self._on_debugger_state_updated()
+
+    def _on_cfb_event(self, **kwargs):
+        if not kwargs:
+            self._reload_data()
 
     def closeEvent(self, event):
         self._dbg_watcher.shutdown()


### PR DESCRIPTION
Brings back live CFB updates. There is room for improvement, but this at least restores the previous level functionality with better performance.

Needs angr/angr#3806

Pending:
- [x] Fix races

Demo:

https://user-images.githubusercontent.com/8210/218686417-83a97f90-545b-4c55-88b2-511c4bab2e79.mp4

