### PR TITLE
Support aarch64 in qregister_viewer

### DIFF
--- a/angrmanagement/ui/widgets/qregister_viewer.py
+++ b/angrmanagement/ui/widgets/qregister_viewer.py
@@ -85,6 +85,43 @@ class QRegisterViewer(QFrame):
                 "pc",
             ]
         },
+        "AARCH64": {
+            "common": [
+                "x0",
+                "x1",
+                "x2",
+                "x3",
+                "x4",
+                "x5",
+                "x6",
+                "x7",
+                "x8",
+                "x9",
+                "x10",
+                "x11",
+                "x12",
+                "x13",
+                "x14",
+                "x15",
+                "x16",
+                "x17",
+                "x18",
+                "x19",
+                "x20",
+                "x21",
+                "x22",
+                "x23",
+                "x24",
+                "x25",
+                "x26",
+                "x27",
+                "x28",
+                "x29",
+                "x30",
+                "sp",
+                "pc",
+            ]
+        },
     }
 
     ARCH_REGISTERS["ARMEL"] = ARCH_REGISTERS["ARM"]


### PR DESCRIPTION
Make register viewer in symbolic execution available for AARCH64
![image](https://user-images.githubusercontent.com/31790712/219301343-af92e029-2d4f-4e12-a7ca-72032206c991.png)


This stops the error:
```
angrmanagement.ui.widgets.qregister_viewer | Architecture AARCH64 is not listed in QRegisterViewer.ARCH_REGISTERS.
```