### PR TITLE
Add command palette feature

### DIFF
--- a/angrmanagement/logic/commands/__init__.py
+++ b/angrmanagement/logic/commands/__init__.py
@@ -1,0 +1,9 @@
+from .command import BasicCommand, Command, ViewCommand
+from .command_manager import CommandManager
+
+__all__ = [
+    "BasicCommand",
+    "Command",
+    "CommandManager",
+    "ViewCommand",
+]

--- a/angrmanagement/logic/commands/command.py
+++ b/angrmanagement/logic/commands/command.py
@@ -1,0 +1,77 @@
+from typing import TYPE_CHECKING, Callable, Optional, Type
+
+if TYPE_CHECKING:
+    from angrmanagement.ui.views import BaseView
+    from angrmanagement.ui.workspace import Workspace
+
+
+class Command:
+    """
+    Command to be run.
+    """
+
+    _name: Optional[str] = None
+    _caption: Optional[str] = None
+
+    @property
+    def name(self) -> str:
+        """
+        Short name for invocation. By default this name will be derived from the class name.
+        """
+        return self._name or self.__class__.__name__
+
+    @property
+    def caption(self) -> str:
+        """
+        Message to be displayed to identify the command, e.g. in the command palette.
+        """
+        return self._caption or self.name
+
+    @property
+    def is_visible(self) -> bool:
+        """
+        Determines whether this command should be displayed or not.
+        """
+        return True
+
+    def run(self) -> None:
+        """
+        Runs the command.
+        """
+
+
+class BasicCommand(Command):
+    """
+    Basic command to invoke a callable.
+    """
+
+    def __init__(self, name: str, caption: str, action: Callable):
+        self._name = name
+        self._caption = caption
+        self._action: Callable = action
+
+    def run(self):
+        self._action()
+
+
+class ViewCommand(Command):
+    """
+    Commands to invoke a callable on a view.
+    """
+
+    def __init__(self, name: str, caption: str, action: Callable, view_class: Type["BaseView"], workspace: "Workspace"):
+        self._name = name
+        self._caption = caption
+        self._action: Callable = action
+        self._view_class: Type["BaseView"] = view_class
+        self._workspace: "Workspace" = workspace
+
+    @property
+    def is_visible(self) -> bool:
+        view = self._workspace.view_manager.most_recently_focused_view
+        return isinstance(view, self._view_class)
+
+    def run(self) -> None:
+        view = self._workspace.view_manager.most_recently_focused_view
+        if isinstance(view, self._view_class):
+            self._action(view)

--- a/angrmanagement/logic/commands/command_manager.py
+++ b/angrmanagement/logic/commands/command_manager.py
@@ -1,0 +1,31 @@
+from typing import TYPE_CHECKING, Dict, Sequence
+
+if TYPE_CHECKING:
+    from .command import Command
+
+
+class CommandManager:
+    """
+    Manages available commands.
+    """
+
+    def __init__(self):
+        self._commands: Dict[str, "Command"] = {}
+
+    def register_command(self, command: "Command"):
+        assert command.name not in self._commands, "Command by this name already registered"
+        self._commands[command.name] = command
+
+    def register_commands(self, commands: Sequence["Command"]):
+        for command in commands:
+            self.register_command(command)
+
+    def unregister_command(self, command: "Command"):
+        self._commands.pop(command.name, None)
+
+    def unregister_commands(self, commands: Sequence["Command"]):
+        for command in commands:
+            self.unregister_command(command)
+
+    def get_commands(self):
+        return self._commands.values()

--- a/angrmanagement/ui/dialogs/command_palette.py
+++ b/angrmanagement/ui/dialogs/command_palette.py
@@ -1,0 +1,176 @@
+import difflib
+from typing import TYPE_CHECKING, Dict, List
+
+from PySide6.QtCore import QAbstractItemModel, QModelIndex, QSize, Qt
+from PySide6.QtGui import QBrush, QTextDocument
+from PySide6.QtWidgets import QDialog, QLineEdit, QListView, QStyle, QStyledItemDelegate, QVBoxLayout
+from thefuzz import process
+
+if TYPE_CHECKING:
+    from angrmanagement.logic.commands import Command
+    from angrmanagement.ui.workspace import Workspace
+
+
+class CommandPaletteModel(QAbstractItemModel):
+    """
+    Data provider for command palette.
+    """
+
+    def __init__(self, workspace: "Workspace"):
+        super().__init__()
+        self.workspace: "Workspace" = workspace
+        self._available_commands: List["Command"] = sorted(
+            [cmd for cmd in self.workspace.command_manager.get_commands() if cmd.is_visible],
+            key=lambda cmd: cmd.caption,
+        )
+        self._command_to_caption: Dict["Command", str] = {c: c.caption for c in self._available_commands}
+        self._filtered_commands: List["Command"] = self._available_commands
+        self._filter_text: str = ""
+
+    def rowCount(self, _):
+        return len(self._filtered_commands)
+
+    def columnCount(self, _):  # pylint:disable=no-self-use
+        return 1
+
+    def index(self, row, col, _):
+        return self.createIndex(row, col, None)
+
+    def parent(self, _):  # pylint:disable=no-self-use
+        return QModelIndex()
+
+    def data(self, index, role):
+        if not index.isValid() or role != Qt.DisplayRole:
+            return None
+        row = index.row()
+        return self._filtered_commands[row]
+
+    def set_filter_text(self, query: str):
+        """
+        Filter the list of available commands by captions matching `query`.
+        """
+        self.beginResetModel()
+        self._filter_text = query
+        if query == "":
+            self._filtered_commands = self._available_commands
+        else:
+            self._filtered_commands = [
+                command for _, _, command in process.extract(query, self._command_to_caption, limit=50)
+            ]
+        self.endResetModel()
+
+
+class CommandPaletteItemDelegate(QStyledItemDelegate):
+    """
+    Delegate to draw individual command entries in the palette.
+
+    Query sub-sequence matches against command names are shown in bold.
+    """
+
+    @staticmethod
+    def _get_text_document(index):
+        model: CommandPaletteModel = index.model()
+        text_in = index.data().caption
+
+        if not model._filter_text:
+            text_out = text_in
+        else:
+            # Render matching sub-sequences in bold
+            matcher = difflib.SequenceMatcher(None, text_in.upper(), model._filter_text.upper())
+            text_out = ""
+            last_idx = 0
+            for idx, _, size in matcher.get_matching_blocks():
+                text_out += text_in[last_idx:idx] + f"<b>{text_in[idx:idx + size]}</b>"
+                last_idx = idx + size
+            text_out += text_in[last_idx:]
+
+        td = QTextDocument()
+        td.setHtml(text_out)
+        return td
+
+    def paint(self, painter, option, index):
+        if index.column() == 0:
+            if option.state & QStyle.State_Selected:
+                b = QBrush(option.palette.highlight())
+                painter.fillRect(option.rect, b)
+
+            td = self._get_text_document(index)
+            td.setDefaultFont(option.font)
+            painter.save()
+            painter.translate(option.rect.topLeft())
+            td.drawContents(painter)
+            painter.restore()
+        else:
+            super().paint(painter, option, index)
+
+    def sizeHint(self, option, index) -> QSize:
+        if index.column() == 0:
+            td = self._get_text_document(index)
+            td.setDefaultFont(option.font)
+            s = td.size()
+            return QSize(s.width(), s.height())
+        return super().sizeHint(option, index)
+
+
+class CommandPaletteDialog(QDialog):
+    """
+    Dialog for selecting commands.
+    """
+
+    def __init__(self, workspace, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Command Palette")
+        self._model = CommandPaletteModel(workspace)
+        self._delegate = CommandPaletteItemDelegate()
+        self._init_widgets()
+        self.selected_command = None
+
+    def sizeHint(self):  # pylint:disable=no-self-use
+        return QSize(500, 400)
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        self._layout: QVBoxLayout = QVBoxLayout()
+
+        self._query: QLineEdit = QLineEdit(self)
+        self._query.textChanged.connect(self._set_filter_text)
+        self._layout.addWidget(self._query)
+
+        self._view: QListView = QListView(self)
+        self._view.setModel(self._model)
+        self._view.setItemDelegate(self._delegate)
+        self._view.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self._view.clicked.connect(self.accept)
+        self._layout.addWidget(self._view)
+
+        self.setLayout(self._layout)
+        self._set_filter_text("")
+
+    def _set_filter_text(self, text):
+        self._model.set_filter_text(text)
+        self._view.setCurrentIndex(self._model.index(0, 0, None))
+
+    def _get_selected(self):
+        for i in self._view.selectedIndexes():
+            return i.data()
+        return None
+
+    #
+    # Event handlers
+    #
+
+    def keyPressEvent(self, event):
+        key = event.key()
+        if key in {Qt.Key_Up, Qt.Key_Down}:
+            self._view.keyPressEvent(event)
+        elif key in {Qt.Key_Enter, Qt.Key_Return}:
+            self.accept()
+        else:
+            super().keyPressEvent(event)
+
+    def accept(self):
+        self.selected_command = self._get_selected()
+        super().accept()

--- a/angrmanagement/ui/menus/view_menu.py
+++ b/angrmanagement/ui/menus/view_menu.py
@@ -83,6 +83,10 @@ class ViewMenu(Menu):
 
         self.entries.extend(
             [
+                MenuEntry(
+                    "Command Palette...", main_window.show_command_palette, shortcut=QKeySequence("Ctrl+Shift+P")
+                ),
+                MenuSeparator(),
                 ToolbarMenu(main_window),
                 MenuSeparator(),
                 MenuEntry("Next Tab", main_window.workspace.view_manager.next_tab, shortcut=QKeySequence("Ctrl+Tab")),

--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -116,6 +116,8 @@ class ViewManager:
         dock = self.view_to_dock.pop(view, None)
         if dock:
             dock.closeDockWidget()
+        if view is self.most_recently_focused_view:
+            self.most_recently_focused_view = None
 
     def raise_view(self, view: "BaseView"):
         """

--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -74,6 +74,7 @@ class ViewManager:
 
         area = self.DOCKING_POSITIONS.get(view.default_docking_position, QtAds.RightDockWidgetArea)
         self.main_window.dock_manager.addDockWidgetTab(area, dw)
+        self.main_window.init_shortcuts_on_dock(dw)
 
         self.views.append(view)
         self.docks.append(dw)

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -13,6 +13,7 @@ from angrmanagement.data.breakpoint import Breakpoint, BreakpointType
 from angrmanagement.data.instance import ObjectContainer
 from angrmanagement.data.jobs.loading import LoadBinaryJob
 from angrmanagement.data.trace import BintraceTrace, Trace
+from angrmanagement.logic.commands import CommandManager
 from angrmanagement.logic.debugger import DebuggerWatcher
 from angrmanagement.logic.debugger.bintrace import BintraceDebugger
 from angrmanagement.plugins import PluginManager
@@ -64,6 +65,7 @@ class Workspace:
         self._main_instance = instance
         instance.workspace = self
 
+        self.command_manager: CommandManager = CommandManager()
         self.view_manager: ViewManager = ViewManager(self)
         self.plugins: PluginManager = PluginManager(self)
         self.variable_recovery_job: Optional[VariableRecoveryJob] = None
@@ -98,6 +100,8 @@ class Workspace:
         self.on_debugger_state_updated()
 
         self._analysis_configuration: Optional[AnalysesConfiguration] = None
+
+        DisassemblyView.register_commands(self)
 
     #
     # Properties

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     requests[socks]
     tomlkit
     pyobjc-framework-Cocoa;platform_system == "Darwin"
+    thefuzz[speedup]
 python_requires = >=3.8
 include_package_data = True
 


### PR DESCRIPTION
This patch adds a new **Command Palette** feature to search through and activate commands, similar to tools like [Sublime Text](https://www.sublimetext.com/), to support faster keyboard-driven navigation around angr-management, and for the cases when you may not know or remember the keybinding for some action.

Usage: <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> activates the command palette dialog where available commands are listed. Typing in the dialog box does a fuzzy match filter on commands. <kbd>&uarr;</kbd> and <kbd>&darr;</kbd> can navigate command selection, and <kbd>Return</kbd> or mouse click runs the command.

Notes:
* Current commands include most of the things found in the main window menus, and several actions that can be performed on the Disassembly View. Disassembly View must be most-recently focused view to activate commands on it.
* This adds new install requirements: [thefuzz](https://pypi.org/project/thefuzz/) for fuzzy string matching, and by extension [Levenshtein](https://pypi.org/project/Levenshtein/)
* I don't consider the Command API stable yet, so although plugins can easily register commands (via `workspace.command_manager.register_command`), they may break as the feature evolves.
* In the near future I'd like to refactor current menu items to also adopt the the `Command` interface, for unified visibility/update query and execution.
* Some future planned additions: more commands, fuzzy matching go-to for symbol/etc navigation, keybinding indicators, recent commands list

Demo:

https://user-images.githubusercontent.com/8210/220810607-3cde6335-8497-4b67-998b-6e28d46afc6b.mp4

Closes: #607 
