### PR TITLE
DisassemblyView: Track which viewer is displayed

### DIFF
--- a/tests/manual_human_activities.py
+++ b/tests/manual_human_activities.py
@@ -51,7 +51,7 @@ class TestHumanActivities(unittest.TestCase):
 
         # decompile the function
         disasm_view = main.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         disasm_view.display_function(func)
         disasm_view.decompile_current_function()
         main.workspace.main_instance.join_all_jobs()
@@ -107,7 +107,7 @@ class TestHumanActivities(unittest.TestCase):
 
         # decompile the function
         disasm_view = main.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         disasm_view.display_function(func)
         disasm_view.decompile_current_function()
         main.workspace.main_instance.join_all_jobs()
@@ -152,7 +152,7 @@ class TestHumanActivities(unittest.TestCase):
 
         # display function main
         disasm_view = main_window.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         disasm_view.display_function(func)
 
         # get and click the first bbl of function main
@@ -183,7 +183,7 @@ class TestHumanActivities(unittest.TestCase):
 
         # display function main
         disasm_view = main_window.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         disasm_view.display_function(func)
 
         # get and click the first bbl of function main

--- a/tests/test_rename_functions.py
+++ b/tests/test_rename_functions.py
@@ -70,7 +70,7 @@ class TestRenameFunctions(unittest.TestCase):
 
         # decompile the function
         disasm_view = main.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         gui_thread_schedule(disasm_view.display_function, args=(func,))
         disasm_view.decompile_current_function()
         main.workspace.main_instance.join_all_jobs()
@@ -113,7 +113,7 @@ class TestRenameFunctions(unittest.TestCase):
 
         # decompile the function
         disasm_view = main.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         gui_thread_schedule(disasm_view.display_function, args=(func,))
         disasm_view.decompile_current_function()
         main.workspace.main_instance.join_all_jobs()

--- a/tests/test_rename_variables.py
+++ b/tests/test_rename_variables.py
@@ -33,7 +33,7 @@ class TestRenameVariables(unittest.TestCase):
 
         # decompile the function
         disasm_view = self.main.workspace._get_or_create_disassembly_view()
-        disasm_view._t_flow_graph_visible = True
+        disasm_view.display_disasm_graph()
         gui_thread_schedule(disasm_view.display_function, args=(self.func,))
         disasm_view.decompile_current_function()
         self.main.workspace.main_instance.join_all_jobs()


### PR DESCRIPTION
Changes `DisassemblyView`'s logic determining which viewer is being shown from using `isVisible` to just tracking it with a variable. `isVisible` will return `False` if the user is looking at another tab, which can cause view refresh failures.
