### PR TITLE
Downgrade pyinstaller to 5.6.2

### DIFF
--- a/.github/workflows/nightly-build.sh
+++ b/.github/workflows/nightly-build.sh
@@ -10,7 +10,7 @@ fi
 
 # Install dependencies
 
-python -m pip install -U pip wheel setuptools pyinstaller==5.8 unicorn==2.0.1.post1
+python -m pip install -U pip wheel setuptools pyinstaller==5.6.2 unicorn==2.0.1.post1
 if [[ "$OSTYPE" == "darwin"* ]]; then
     pip install pillow # icon conversion on macOS
 fi


### PR DESCRIPTION
Pyinstaller 5.7 started setting `sys.stdout` to `None` to be consistent with `pythonw.exe` on Windows. Unfortunately all recent versions of z3 assume that `sys.stdout` is not None, so until that is fixed we have to downgrade. I plan to try to fix this in z3 upstream, but based on the CI output in angr/claripy#341, upgrading to a newer z3 might take some time.