### PR TITLE
Main Window status bar improvements

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -398,6 +398,7 @@ class Instance:
             except (Exception, KeyboardInterrupt) as e:  # pylint: disable=broad-except
                 sys.last_traceback = e.__traceback__
                 self.current_job = None
+                _l.exception('Exception while running job "%s":', job.name)
                 self.workspace.log('Exception while running job "%s":' % job.name)
                 self.workspace.log(e)
                 self.workspace.log("Type %debug to debug it")

--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -385,7 +385,7 @@ class Instance:
                 gui_thread_schedule(self.workspace.main_window._progress_dialog.hide, args=())
 
             job = self._jobs_queue.get()
-            gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0))
+            gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0, True))
 
             if any(job.blocking for job in self.jobs):
                 if self.workspace.main_window.isVisible():

--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -79,9 +79,6 @@ class CFGGenerationJob(Job):
         if self._last_progress_callback_triggered is not None and t - self._last_progress_callback_triggered < 0.2:
             return
         self._last_progress_callback_triggered = t
-
-        text = "%.02f%%" % percentage
-
         super()._progress_callback(percentage, text=text)
 
         if cfg is not None:

--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -10,6 +10,10 @@ _l = logging.getLogger(name=__name__)
 
 
 class CFGGenerationJob(Job):
+    """
+    Job for generating the Control Flow Graph.
+    """
+
     DEFAULT_CFG_ARGS = {
         "normalize": True,  # this is what people naturally expect
     }
@@ -34,6 +38,7 @@ class CFGGenerationJob(Job):
 
         self._cfb = None
         self._last_progress_callback_triggered = None
+        self.instance = None
 
     def _run(self, inst):
         self.instance = inst
@@ -64,7 +69,7 @@ class CFGGenerationJob(Job):
             inst.cfb.am_event()
             inst.cfg.am_event()
             super().finish(inst, result)
-        except Exception:
+        except Exception:  # pylint:disable=broad-exception-caught
             _l.error("Exception occurred in CFGGenerationJob.finish().", exc_info=True)
 
     def __repr__(self):

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -2,6 +2,10 @@ from .job import Job
 
 
 class CodeTaggingJob(Job):
+    """
+    Job for tagging functions.
+    """
+
     def __init__(self, on_finish=None):
         super().__init__(name="Code tagging", on_finish=on_finish)
 
@@ -15,9 +19,6 @@ class CodeTaggingJob(Job):
 
             percentage = i / func_count * 100
             super()._progress_callback(percentage)
-
-    def finish(self, inst, result):
-        super().finish(inst, result)
 
     def __repr__(self):
         return "CodeTaggingJob"

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -14,9 +14,7 @@ class CodeTaggingJob(Job):
             func.tags = tuple(ct.tags)
 
             percentage = i / func_count * 100
-            text = "%.02f%%" % percentage
-
-            super()._progress_callback(percentage, text=text)
+            super()._progress_callback(percentage)
 
     def finish(self, inst, result):
         super().finish(inst, result)

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -94,10 +94,9 @@ class Job:
             gui_thread_schedule_async(self._set_progress, args=(text,))
 
     def _set_progress(self, text=None):
+        status = self.name
         if text:
-            status = f"{self.name}: {text} - {self.time_elapsed}"
-        else:
-            status = f"{self.name} - {self.time_elapsed}"
+            status += ": " + text
         GlobalInfo.main_window.progress(status, self.progress_percentage)
 
     def _finish_progress(self):

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -12,6 +12,7 @@ m = ...
 
 
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
 
 
 def _load_autoreload():
@@ -62,8 +63,14 @@ class Job:
         return str(datetime.timedelta(seconds=int(time.time() - self.start_at)))
 
     def run(self, inst):
+        log.info('Job "%s" started', self.name)
+        self._progress_callback(0)
         self.start_at = time.time()
-        return self._run(inst)
+        r = self._run(inst)
+        now = time.time()
+        duration = now - self.start_at
+        log.info('Job "%s" completed after %.2f seconds', self.name, duration)
+        return r
 
     def _run(self, inst):
         raise NotImplementedError()

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -56,7 +56,7 @@ class Job:
                 m.check()
                 poststate = dict(m.modules_mtimes)
                 if prestate != poststate:
-                    log.warning("Autoreload found changed modules")
+                    log.warning("Auto-reload found changed modules")
 
     @property
     def time_elapsed(self) -> str:

--- a/angrmanagement/data/jobs/variable_recovery.py
+++ b/angrmanagement/data/jobs/variable_recovery.py
@@ -99,11 +99,7 @@ class VariableRecoveryJob(Job):
             return
         self._last_progress_callback_triggered = t
 
-        progress_text = "%.02f%%" % percentage
-        if text:
-            progress_text += " | " + text
-
-        super()._progress_callback(percentage, text=progress_text)
+        super()._progress_callback(percentage, text=text)
 
     def finish(self, inst, result):
         self.ccc = None  # essentially disabling self.prioritize_function()

--- a/angrmanagement/data/jobs/variable_recovery.py
+++ b/angrmanagement/data/jobs/variable_recovery.py
@@ -84,7 +84,7 @@ class VariableRecoveryJob(Job):
             max_function_size=4096,
             workers=0 if self.workers is None else self.workers,
             prioritize_func_addrs=func_addrs_to_prioritize,
-            skip_other_funcs=False if self.func_addr is None else True,
+            skip_other_funcs=self.func_addr is not None,
             auto_start=self.auto_start,
             **self.variable_recovery_args,
         )

--- a/angrmanagement/ui/widgets/__init__.py
+++ b/angrmanagement/ui/widgets/__init__.py
@@ -7,6 +7,7 @@ from .qdisasm_statusbar import QDisasmStatusBar
 
 # other widgets
 from .qfeature_map import QFeatureMap
+from .qicon_label import QIconLabel
 from .qinst_annotation import QAvoidAddrAnnotation, QBlockAnnotations, QFindAddrAnnotation, QHookAnnotation
 from .qlinear_viewer import QLinearDisassembly, QLinearDisassemblyView
 from .qstate_combobox import QStateComboBox
@@ -14,15 +15,16 @@ from .qsymexec_graph import QSymExecGraph
 from .qtrace_map import QTraceMap
 
 __all__ = [
-    "QAddressInput",
     "DisassemblyLevel",
-    "QDisassemblyGraph",
-    "QDisasmStatusBar",
-    "QFeatureMap",
+    "QAddressInput",
     "QAvoidAddrAnnotation",
     "QBlockAnnotations",
+    "QDisasmStatusBar",
+    "QDisassemblyGraph",
+    "QFeatureMap",
     "QFindAddrAnnotation",
     "QHookAnnotation",
+    "QIconLabel",
     "QLinearDisassembly",
     "QLinearDisassemblyView",
     "QStateComboBox",

--- a/angrmanagement/ui/widgets/qicon_label.py
+++ b/angrmanagement/ui/widgets/qicon_label.py
@@ -1,0 +1,40 @@
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QSize, Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+if TYPE_CHECKING:
+    from PySide6.QtGui import QIcon
+
+
+class QIconLabel(QWidget):
+    """
+    Show a label with an icon on the left.
+    """
+
+    clicked = Signal()
+
+    def __init__(self, icon: "QIcon", text: str = ""):
+        super().__init__()
+        lyt = QHBoxLayout()
+        lyt.setContentsMargins(0, 0, 0, 0)
+
+        self._icon_label = QLabel()
+        self._icon_label.setPixmap(icon.pixmap(QSize(16, 16)))
+        lyt.addWidget(self._icon_label)
+
+        self._text_label = QLabel(text)
+        lyt.addWidget(self._text_label)
+
+        self.setLayout(lyt)
+        self._update_visibility()
+
+    def mouseReleaseEvent(self, _):
+        self.clicked.emit()
+
+    def setText(self, text):
+        self._text_label.setText(text)
+        self._update_visibility()
+
+    def _update_visibility(self):
+        self._text_label.setVisible(self._text_label.text() != "")


### PR DESCRIPTION
* Attempts to tidy status bar by moving long-running status items over to the right
* Adds job interrupt button to status bar
* Shrinks the big progress bar
* Makes stop watch only show up after 5 seconds of job runtime, increments on regular interval (Fixes #905), and adds a little icon

Preview:

![image](https://user-images.githubusercontent.com/8210/221719177-10caac9e-308e-47f5-8d8f-53196f06af8e.png)


This could be cleaner, but is good enough for now. Let's improve when more things are being shown in the status bar.