### PR TITLE
Add naive assembly patching

### DIFF
--- a/angrmanagement/ui/dialogs/__init__.py
+++ b/angrmanagement/ui/dialogs/__init__.py
@@ -1,4 +1,5 @@
 from .analysis_options import AnalysisOptionsDialog
+from .assemble_patch import AssemblePatchDialog
 from .breakpoint import BreakpointDialog
 from .load_binary import LoadBinary
 from .load_docker_prompt import LoadDockerPrompt
@@ -7,6 +8,7 @@ from .preferences import Preferences
 
 __all__ = [
     "AnalysisOptionsDialog",
+    "AssemblePatchDialog",
     "BreakpointDialog",
     "LoadBinary",
     "LoadDockerPrompt",

--- a/angrmanagement/ui/dialogs/assemble_patch.py
+++ b/angrmanagement/ui/dialogs/assemble_patch.py
@@ -1,0 +1,182 @@
+# FIXME:
+# - Add symbol resolve once https://github.com/keystone-engine/keystone/issues/351 is fixed
+# - Show symbols in disassembly text
+# - Support editing existing patches
+# - Handle overlap with existing patches
+
+from typing import TYPE_CHECKING, Optional
+
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QVBoxLayout,
+)
+
+try:
+    import keystone
+except ImportError:
+    keystone = None
+
+from angr.knowledge_plugins.patches import Patch
+from archinfo import ArchError
+
+from angrmanagement.config import Conf
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+
+
+class AssemblePatchDialog(QDialog):
+    """
+    Dialog for making a patch from assembly code.
+    """
+
+    def __init__(self, address: int, instance: "Instance", parent=None):
+        super().__init__(parent)
+
+        self.instance: "Instance" = instance
+        self._patch_addr: int = address
+
+        block = self.instance.project.factory.block(self._patch_addr)
+        insn = block.disassembly.insns[0]
+
+        self._original_bytes: bytes = self.instance.project.loader.memory.load(insn.address, insn.size)
+        self._new_bytes: Optional[bytes] = self._original_bytes
+        self._initial_text = insn.mnemonic
+        if insn.op_str:
+            self._initial_text += " " + insn.op_str
+
+        self._init_widgets()
+        self.setWindowTitle(f"Assemble Patch at {self._patch_addr:#x}")
+
+    def sizeHint(self):  # pylint:disable=no-self-use
+        return QSize(400, 150)
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self):
+        self.main_layout = QVBoxLayout()
+        font = QFont(Conf.disasm_font)
+
+        grid_layout = QGridLayout()
+        grid_layout.addWidget(QLabel("Assembly:", self), 0, 0)
+        self._insn_text = QLineEdit(self)
+        self._insn_text.setFont(font)
+        self._insn_text.setText(self._initial_text)
+        self._insn_text.selectAll()
+        grid_layout.addWidget(self._insn_text, 0, 1)
+
+        grid_layout.addWidget(QLabel("Bytes:", self), 1, 0)
+        self._bytes_text = QLineEdit(self)
+        self._bytes_text.setFont(font)
+        self._bytes_text.setReadOnly(True)
+        grid_layout.addWidget(self._bytes_text, 1, 1)
+
+        self._pad_checkbox = QCheckBox("Pad to original instruction size", self)
+        self._pad_checkbox.setChecked(True)
+        grid_layout.addWidget(self._pad_checkbox, 2, 1)
+
+        self.main_layout.addLayout(grid_layout)
+        self.main_layout.addStretch(1)
+        self._status_label = QLabel(self)
+        self.main_layout.addWidget(self._status_label)
+
+        buttons = QDialogButtonBox(parent=self)
+        buttons.setStandardButtons(QDialogButtonBox.StandardButton.Cancel | QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self._on_ok_clicked)
+        buttons.rejected.connect(self.close)
+        self._ok_button = buttons.button(QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        self.main_layout.addWidget(buttons)
+
+        self.setLayout(self.main_layout)
+
+        can_assemble = False
+        status_msg = ""
+        if keystone:
+            try:
+                ks = self.instance.project.arch.keystone
+                can_assemble = ks is not None
+            except ArchError as e:
+                status_msg = str(e)
+        else:
+            status_msg = "Keystone not installed"
+
+        if can_assemble:
+            self._assemble()
+            self._insn_text.textChanged.connect(self._on_text_changed)
+            self._pad_checkbox.stateChanged.connect(self._on_checkbox_changed)
+        else:
+            self._insn_text.setEnabled(False)
+            self._bytes_text.setEnabled(False)
+            self._pad_checkbox.setEnabled(False)
+            self._update_status(status_msg, False)
+
+    def _assemble(self):
+        success = False
+        status_msg = ""
+
+        try:
+            ks = self.instance.project.arch.keystone
+
+            text = self._insn_text.text()
+            if len(text) > 0:
+                self._new_bytes = ks.asm(self._insn_text.text(), self._patch_addr, as_bytes=True)[0] or b""
+            else:
+                self._new_bytes = b""
+
+            # Pad to original instruction length
+            byte_length_delta = len(self._original_bytes) - len(self._new_bytes)
+            if byte_length_delta > 0:
+                if self._pad_checkbox.isChecked():
+                    nop_instruction_bytes = self.instance.project.arch.nop_instruction
+                    self._new_bytes += (byte_length_delta // len(nop_instruction_bytes)) * nop_instruction_bytes
+                    byte_length_delta = len(self._original_bytes) - len(self._new_bytes)
+                    if byte_length_delta:
+                        status_msg = "Warning: Unable to completely pad remainder"
+            elif byte_length_delta < 0:
+                status_msg = "Warning: Patch exceeds original instruction length"
+
+            success = True
+        except keystone.KsError as ks_error:
+            self._new_bytes = b""
+            status_msg = "Error: " + ks_error.message
+
+        self._update_status(status_msg, success and len(self._new_bytes) > 0)
+
+    def _update_status(self, status_msg, can_press_ok):
+        self._bytes_text.setText(self._new_bytes.hex(" "))
+        self._status_label.setText(status_msg)
+        self._status_label.setProperty("class", "status_invalid")
+        self._status_label.style().unpolish(self._status_label)
+        self._status_label.style().polish(self._status_label)
+        self._ok_button.setEnabled(can_press_ok)
+
+    #
+    # Event handlers
+    #
+
+    def _on_text_changed(self, new_text):  # pylint: disable=unused-argument
+        self._assemble()
+
+    def _on_checkbox_changed(self, state):  # pylint: disable=unused-argument
+        self._assemble()
+
+    def _on_ok_clicked(self):
+        if self._new_bytes != self._original_bytes:
+            # FIXME: Patches object should be initialized with project
+            pm = self.instance.project.kb.patches
+            pm.add_patch_obj(Patch(self._patch_addr, self._new_bytes))
+            if self.instance.patches.am_none:
+                self.instance.patches.am_obj = pm
+            self.instance.patches.am_event()
+
+        self.accept()

--- a/angrmanagement/ui/menus/disasm_insn_context_menu.py
+++ b/angrmanagement/ui/menus/disasm_insn_context_menu.py
@@ -45,6 +45,7 @@ class DisasmInsnContextMenu(Menu):
                 MenuEntry("Add &hook...", self._add_hook),
                 MenuEntry("View function &documentation...", self._view_docs),
                 MenuEntry("Toggle &breakpoint", self._toggle_breakpoint),
+                MenuEntry("&Patch...", self._popup_patch_dialog),
             ]
         )
 
@@ -90,6 +91,9 @@ class DisasmInsnContextMenu(Menu):
         if r is not None:
             _, ins_addr, operand = r
             self._disasm_view.parse_operand_and_popup_xref_dialog(ins_addr, operand, async_=True)
+
+    def _popup_patch_dialog(self):
+        self._disasm_view.popup_patch_dialog()
 
     #
     # Public Methods

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -14,6 +14,7 @@ from angrmanagement.data.instance import ObjectContainer
 from angrmanagement.logic import GlobalInfo
 from angrmanagement.logic.commands import ViewCommand
 from angrmanagement.logic.disassembly import InfoDock, JumpHistory
+from angrmanagement.ui.dialogs.assemble_patch import AssemblePatchDialog
 from angrmanagement.ui.dialogs.dependson import DependsOn
 from angrmanagement.ui.dialogs.func_doc import FuncDocDialog
 from angrmanagement.ui.dialogs.hook import HookDialog
@@ -547,6 +548,10 @@ class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
             dialog.show()
         else:
             dialog.exec_()
+
+    def popup_patch_dialog(self):
+        dlg = AssemblePatchDialog(self._insn_addr_on_context_menu, self.instance)
+        dlg.exec_()
 
     #
     # Public methods

--- a/angrmanagement/ui/widgets/qinstruction.py
+++ b/angrmanagement/ui/widgets/qinstruction.py
@@ -59,6 +59,14 @@ class QInstruction(QCachedGraphicsItem):
     def contextMenuEvent(self, event: "PySide6.QtWidgets.QGraphicsSceneContextMenuEvent") -> None:
         pass
 
+    def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent):
+        self.infodock.unselect_all_instructions()
+        self.infodock.toggle_instruction_selection(self.addr, insn_pos=self.scenePos(), unique=True)
+        self.disasm_view._insn_addr_on_context_menu = self.addr
+        self.disasm_view._insn_menu.insn_addr = self.addr
+        self.disasm_view.popup_patch_dialog()
+        event.accept()
+
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent):
         if self.instance.workspace.plugins.handle_click_insn(self, event):
             # stop handling this event if the event has been handled by a plugin
@@ -92,6 +100,11 @@ class QInstruction(QCachedGraphicsItem):
 
         if self.selected:
             return self._config.disasm_view_node_instruction_selected_background_color
+
+        if not self.instance.patches.am_none:
+            patches = self.instance.patches.get_all_patches(self.insn.addr, self.insn.size)
+            if len(patches):
+                return Qt.darkYellow
 
         return None  # None here means transparent, reusing the block color
 


### PR DESCRIPTION
Adds initial support for creating a patch via assembly. Double-click on an instruction, or right-click on an instruction and select Patch, to open the Assemble Patch dialog. 

Limitations to be improved in follow-ups:
* Patched logic is not yet reflected in disassembly view
* Symbols are not resolved in patch assembly
* Overlapping patches are not handled
* Patch editing
* Patch minimizing

Demo: Patching fauxware `authenticate` rejection case return value

https://user-images.githubusercontent.com/8210/222021975-8c14a7e6-2a7b-476b-9e51-3f3f1188f232.mp4

