### PR TITLE
DisassemblyView: Initialize, re-load on CFB update

### DIFF
--- a/angrmanagement/data/instance.py
+++ b/angrmanagement/data/instance.py
@@ -492,14 +492,6 @@ class Instance:
             if the_func is not None:
                 self.on_function_selected(the_func)
 
-            # Initialize the linear viewer
-            if len(self.workspace.view_manager.views_by_category["disassembly"]) == 1:
-                view = self.workspace.view_manager.first_view_in_category("disassembly")
-            else:
-                view = self.workspace.view_manager.current_view_in_category("disassembly")
-            if view is not None:
-                view._linear_viewer.initialize()
-
             # Reload the pseudocode view
             view = self.workspace.view_manager.first_view_in_category("pseudocode")
             if view is not None:

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -75,8 +75,6 @@ class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
         # whether we want to show exception edges and all nodes that are only reachable through exception edges
         self._show_exception_edges = True
 
-        self._linear_viewer: Optional[QLinearDisassembly] = None
-        self._flow_graph: Optional[QDisassemblyGraph] = None
         self._prefer_graph = True
         self._current_view: Union[QLinearDisassembly, QDisassemblyGraph, None] = None
 
@@ -322,6 +320,10 @@ class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
 
     def on_screen_changed(self):
         self._current_view.refresh()
+
+    def _on_cfb_event(self, **kwargs):
+        if not kwargs:
+            self._linear_viewer.reload()
 
     #
     # UI
@@ -837,6 +839,7 @@ class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
         self.infodock.qblock_code_obj_selection_changed.connect(self.redraw_current_graph)
         self.instance.workspace.current_screen.am_subscribe(self.on_screen_changed)
         self.instance.breakpoint_mgr.breakpoints.am_subscribe(self._on_breakpoints_updated)
+        self.instance.cfb.am_subscribe(self._on_cfb_event)
 
     def _on_breakpoints_updated(self, **kwargs):  # pylint:disable=unused-argument
         self.refresh()
@@ -852,6 +855,7 @@ class DisassemblyView(ViewStatePublisherMixin, SynchronizedView):
         self.infodock.qblock_code_obj_selection_changed.disconnect(self.redraw_current_graph)
         self.instance.workspace.current_screen.am_unsubscribe(self.on_screen_changed)
         self.instance.breakpoint_mgr.breakpoints.am_unsubscribe(self._on_breakpoints_updated)
+        self.instance.cfb.am_unsubscribe(self._on_cfb_event)
 
     def closeEvent(self, event):
         self._unregister_events()

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -94,6 +94,7 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         self.verticalScrollBar().actionTriggered.connect(self._on_vertical_scroll_bar_triggered)
 
         self._init_widgets()
+        self.initialize()
 
     def reload(self, old_infodock: Optional["InfoDock"] = None):
         curr_offset = self._offset


### PR DESCRIPTION
* Initialize linear viewer at creation, fixing broken linear viewer in new views
* Move logic to trigger disassembly view update out of instance callback, make view update itself