### PR TITLE
CommandPalette: Fix an IndexError.

### DIFF
--- a/angrmanagement/ui/dialogs/command_palette.py
+++ b/angrmanagement/ui/dialogs/command_palette.py
@@ -46,7 +46,7 @@ class PaletteModel(QAbstractItemModel):
         if not index.isValid() or role != Qt.DisplayRole:
             return None
         row = index.row()
-        return self._filtered_items[row]
+        return self._filtered_items[row] if row < len(self._filtered_items) else None
 
     def set_filter_text(self, query: str) -> None:
         """


### PR DESCRIPTION
This PR fixes the following bug that appears after typing a non-existent command in the command palette:

```
Traceback (most recent call last):
  File "...angrmanagement\ui\dialogs\command_palette.py", line 49, in data
    return self._filtered_items[row]  # if row < len(self._filtered_items) else None
           ~~~~~~~~~~~~~~~~~~~~^^^^^
IndexError: list index out of range
```