### PR TITLE
Workspace: Drop several default views

### DIFF
--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -75,18 +75,12 @@ class Workspace:
         self.default_tabs = [
             DisassemblyView(self._main_instance, "center"),
             HexView(self._main_instance, "center"),
-            ProximityView(self._main_instance, "center"),
             CodeView(self._main_instance, "center"),
             FunctionsView(self._main_instance, "left"),
         ]
         if Conf.has_operation_mango:
             self.default_tabs.append(DependencyView(self._main_instance, "center"))
         self.default_tabs += [
-            StringsView(self._main_instance, "center"),
-            PatchesView(self._main_instance, "center"),
-            SymexecView(self._main_instance, "center"),
-            StatesView(self._main_instance, "center"),
-            InteractionView(self._main_instance, "center"),
             ConsoleView(self._main_instance, "bottom"),
             LogView(self._main_instance, "bottom"),
         ]


### PR DESCRIPTION
These views are used less often, so clean up the screen and have fewer views being refreshed. Eventually the user should be able to configure the default arrangement to suit their workflow (#268), but keep it simple for now.