### PR TITLE
Access workspace from globals instead of removed instance.workspace member

### DIFF
--- a/angrmanagement/data/jobs/decompile_function.py
+++ b/angrmanagement/data/jobs/decompile_function.py
@@ -1,3 +1,5 @@
+from angrmanagement.logic import GlobalInfo
+
 from .job import Job
 
 
@@ -22,4 +24,4 @@ class DecompileFunctionJob(Job):
         # cache the result
         inst.kb.structured_code[(self.function.addr, "pseudocode")] = decompiler.cache
 
-        inst.workspace.plugins.decompile_callback(self.function)
+        GlobalInfo.main_window.workspace.plugins.decompile_callback(self.function)

--- a/angrmanagement/data/jobs/dependency_analysis.py
+++ b/angrmanagement/data/jobs/dependency_analysis.py
@@ -12,6 +12,7 @@ from angr.knowledge_plugins.key_definitions.constants import OP_BEFORE
 from angr.sim_type import SimType
 from PySide6.QtWidgets import QMessageBox
 
+from angrmanagement.logic import GlobalInfo
 from angrmanagement.logic.threads import gui_thread_schedule_async
 
 from .job import Job
@@ -252,7 +253,7 @@ class DependencyAnalysisJob(Job):
 
     @staticmethod
     def _display_closures(inst, sink_atom: "Atom", sink_addr: int, closures):
-        view = inst.workspace.view_manager.first_view_in_category("dependencies")
+        view = GlobalInfo.main_window.workspace.view_manager.first_view_in_category("dependencies")
         if view is None:
             return
 
@@ -263,4 +264,4 @@ class DependencyAnalysisJob(Job):
             view.reload()
         except Exception:
             log.warning("An error occurred when displaying the closures.", exc_info=True)
-        inst.workspace.view_manager.raise_view(view)
+        GlobalInfo.main_window.workspace.view_manager.raise_view(view)


### PR DESCRIPTION
I found two more references to inst.workspace I did not catch before. Let's just access the workspace from globals for the time being.