### PR TITLE
Re-add the BinSync plugin (as a stub)

### DIFF
--- a/angrmanagement/plugins/angr_binsync/__init__.py
+++ b/angrmanagement/plugins/angr_binsync/__init__.py
@@ -1,9 +1,3 @@
-import logging
+from binsync.decompilers.angr.plugin import BinSyncPlugin
 
-try:
-    # we need to import the plugin to register it
-    from binsync.decompilers.angr.plugin import BinSyncPlugin  # noqa: F401
-except ImportError:
-    logging.getLogger(__name__).error(
-        "[!] BinSync is not installed, please `pip install binsync` for THIS python interpreter"
-    )
+__all__ = ["BinSyncPlugin"]

--- a/angrmanagement/plugins/angr_binsync/__init__.py
+++ b/angrmanagement/plugins/angr_binsync/__init__.py
@@ -1,0 +1,4 @@
+try:
+    from binsync.decompilers.angr import *
+except ImportError:
+    print("[!] BinSync is not installed, please `pip install binsync` for THIS python interpreter")

--- a/angrmanagement/plugins/angr_binsync/__init__.py
+++ b/angrmanagement/plugins/angr_binsync/__init__.py
@@ -1,4 +1,9 @@
+import logging
+
 try:
-    from binsync.decompilers.angr import *
+    # we need to import the plugin to register it
+    from binsync.decompilers.angr.plugin import BinSyncPlugin  # noqa: F401
 except ImportError:
-    print("[!] BinSync is not installed, please `pip install binsync` for THIS python interpreter")
+    logging.getLogger(__name__).error(
+        "[!] BinSync is not installed, please `pip install binsync` for THIS python interpreter"
+    )

--- a/angrmanagement/plugins/angr_binsync/plugin.toml
+++ b/angrmanagement/plugins/angr_binsync/plugin.toml
@@ -1,0 +1,13 @@
+[meta]
+plugin_metadata_version = 0
+
+[plugin]
+name = "BinSync"
+shortname = "binsync"
+version = "0.0.0"
+description = ""
+long_description = ""
+platforms = ["windows", "linux", "macos"]
+min_angr_version = "9.0.0.0"
+author = "The BinSync Team"
+entrypoints = ["__init__.py"]

--- a/angrmanagement/plugins/angr_binsync/plugin.toml
+++ b/angrmanagement/plugins/angr_binsync/plugin.toml
@@ -11,3 +11,4 @@ platforms = ["windows", "linux", "macos"]
 min_angr_version = "9.0.0.0"
 author = "The BinSync Team"
 entrypoints = ["__init__.py"]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     tomlkit
     pyobjc-framework-Cocoa;platform_system == "Darwin"
     thefuzz[speedup]
-    binsync>=3.9.0
+    binsync==3.22.0
 
 python_requires = >=3.8
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,8 @@ install_requires =
     tomlkit
     pyobjc-framework-Cocoa;platform_system == "Darwin"
     thefuzz[speedup]
+    binsync>=3.9.0
+
 python_requires = >=3.8
 include_package_data = True
 


### PR DESCRIPTION
## Why
Previously, BinSync was removed from angr-management since the code was too large and changed too frequently, which resulted in PR changes to both the BinSync repo and this one. [Recently](https://github.com/binsync/binsync/commit/3ca7530595614f8d0d6651ac124224f2327179f6), BinSync has transitioned all plugins to be inside the `binsync` library, which has made the code needed for decompilers just a stub.

I'm re-adding BinSync since this code in angr-management should rarely change, and it's only two files (one is the description TOML). 