### PR TITLE
Fix menu of "load recent"

### DIFF
--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -1,5 +1,3 @@
-import os.path
-
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QKeySequence
 
@@ -20,7 +18,7 @@ class RecentMenuEntry(MenuEntry):
 
     def __init__(self, path):
         self.path = path
-        super().__init__(os.path.basename(path), self.action_target)
+        super().__init__(path, self.action_target)
 
     def action_target(self):
         GlobalInfo.main_window.load_file(self.path)

--- a/angrmanagement/ui/menus/menu.py
+++ b/angrmanagement/ui/menus/menu.py
@@ -149,5 +149,5 @@ class Menu:
 
     def remove(self, action):
         self.entries.remove(action)
-        if self._qmenu is not None and type(action) is MenuEntry:
+        if self._qmenu is not None and isinstance(action, MenuEntry):
             self._qmenu.removeAction(action._qaction)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31790712/234013791-839b153d-35cd-41ed-8bef-4f984064bce0.png)
- There could be files in different directories but with the same basename, so I think it's more reasonable to display their full path.
- Do "load a new binary" of one same file by multiple times, there will be duplication in recent files because entries' `_qmenu` isn't removed

This PR fixes these.