### PR TITLE
Update QtGui enum

### DIFF
--- a/angrmanagement/ui/widgets/qdatadep_graph.py
+++ b/angrmanagement/ui/widgets/qdatadep_graph.py
@@ -84,7 +84,7 @@ class QDataDepPreview(QtWidgets.QFrame):
             self._caption.setText(self._DST_JUMP_TEXT)
 
     def _init_widgets(self):
-        parent_background_color = self.parent().palette().color(QtGui.QPalette.Background)
+        parent_background_color = self.parent().palette().color(QtGui.QPalette.Window)
         self.setStyleSheet(f"background-color: {parent_background_color.name()};")
         self.setFrameStyle(QtWidgets.QFrame.Raised | QtWidgets.QFrame.Panel)
         self._layout_manager.addWidget(self.preview_graph, 0, QtCore.Qt.AlignCenter)


### PR DESCRIPTION
Trying to load in a trace file for its data dependency graph results in the error `AttributeError: type object 'PySide6.QtGui.QPalette' has no attribute 'Background'`. 

Fix this by updating the obsolete `Background` flag to the `Window` flag (see https://doc.qt.io/qt-5/qpalette.html)