### PR TITLE
Don't continually prompt for URL scheme registration

### DIFF
--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -227,6 +227,7 @@ ENTRIES = [
     CE("enabled_tabs", str, ""),
     # Recent
     CE("recent_files", list, []),
+    CE("prompted_for_url_scheme_registration", bool, False),
 ]
 
 

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -502,7 +502,7 @@ class MainWindow(QMainWindow):
         registered, _ = scheme.is_url_scheme_registered()
         supported = scheme.is_url_scheme_supported()
 
-        if not registered and supported:
+        if not registered and supported and not Conf.prompted_for_url_scheme_registration:
             btn = QMessageBox.question(
                 None,
                 "Setting up angr URL scheme",
@@ -521,6 +521,10 @@ class MainWindow(QMainWindow):
                         "Error in registering angr URL scheme",
                         "Failed to register the angr URL scheme.\nThe following exception occurred:\n" + str(ex),
                     )
+                    return
+
+            Conf.prompted_for_url_scheme_registration = True
+            save_config()
 
     #
     # Commands


### PR DESCRIPTION
We may want to just remove this prompt, but for now at least stop prompting every time the user declines the scheme registration.
