### PR TITLE
Fix default option in a listed option to work (enable Phoenix)

### DIFF
--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -48,7 +48,10 @@ class QDecompilationOption(QTreeWidgetItem):
         # should make a dropdown option
         if hasattr(self.option, "value_type") and self.option.value_type != bool and self.option.candidate_values:
             self._combo_box = QComboBox()
-            self._combo_box.addItems(self.option.candidate_values)
+            self._combo_box.addItems(
+                [self.option.default_value] +
+                [c for c in self.option.candidate_values if c != self.option.default_value]
+            )
             self._combo_box.setToolTip(f"{option.NAME}: {option.DESCRIPTION}")
             # XXX: causes an itemChanged event for the tree
             self._combo_box.currentTextChanged.connect(lambda x: self.setText(0, self._combo_box.currentText()))

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -49,8 +49,8 @@ class QDecompilationOption(QTreeWidgetItem):
         if hasattr(self.option, "value_type") and self.option.value_type != bool and self.option.candidate_values:
             self._combo_box = QComboBox()
             self._combo_box.addItems(
-                [self.option.default_value] +
-                [c for c in self.option.candidate_values if c != self.option.default_value]
+                [self.option.default_value]
+                + [c for c in self.option.candidate_values if c != self.option.default_value]
             )
             self._combo_box.setToolTip(f"{option.NAME}: {option.DESCRIPTION}")
             # XXX: causes an itemChanged event for the tree


### PR DESCRIPTION
Makes the default value in a listed decompiler option always appear first in the list and make it really default. See case of Phoenix structuring option. 