### PR TITLE
Pseudocode: Allow themes to change the weight of the font (bold/normal) and the style (italic/normal).

### DIFF
--- a/angrmanagement/config/color_schemes.py
+++ b/angrmanagement/config/color_schemes.py
@@ -1,4 +1,4 @@
-from PySide6.QtGui import QColor
+from PySide6.QtGui import QColor, QFont
 
 COLOR_SCHEMES = {
     "Light": {
@@ -268,10 +268,12 @@ COLOR_SCHEMES = {
         "palette_link": QColor(0x8B, 0xE9, 0xFD),
         "palette_linkvisited": QColor(0xBD, 0x93, 0xF9),
         "pseudocode_comment_color": QColor(0x62, 0x72, 0xA4),
+        "pseudocode_comment_weight": QFont.Weight.Normal,
         "pseudocode_function_color": QColor(0x50, 0xFA, 0x7B),
         "pseudocode_quotation_color": QColor(0xF1, 0xFA, 0x8C),
         "pseudocode_keyword_color": QColor(0xFF, 0x79, 0xC6),
         "pseudocode_types_color": QColor(0x8B, 0xE9, 0xFD),
+        "pseudocode_types_style": QFont.Style.StyleItalic,
         "pseudocode_variable_color": QColor(0xF8, 0xF8, 0xF2),
         "pseudocode_label_color": QColor(0x00, 0xAA, 0xFF),
         "pseudocode_highlight_color": QColor(0x44, 0x47, 0x5A),

--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -1,4 +1,5 @@
 import contextlib
+import enum
 import logging
 import os
 import re
@@ -82,6 +83,37 @@ def font_serializer(config_option, value: QFont) -> str:
     return f"{value.pointSize()}px {value.family()}"
 
 
+def enum_parser_serializer_generator(
+    the_enum: enum.Enum, default
+) -> tuple[Callable[[str, str], enum.Enum], Callable[[str, enum.Enum], str]]:
+    def parser(config_option: str, value: str) -> enum.Enum:
+        try:
+            return the_enum[value]
+        except KeyError:
+            _l.error(
+                "Failed to parse value %r as %s for option %s. Default to %s.",
+                value,
+                type(the_enum),
+                config_option,
+                default,
+            )
+        return default
+
+    def serializer(config_option: str, value: enum.Enum) -> str:
+        if not isinstance(value, the_enum):
+            _l.error(
+                "Failed to serialize value %r as %s for option %s. Default to %s.",
+                value,
+                type(the_enum),
+                config_option,
+                default,
+            )
+            return default
+        return value.name
+
+    return parser, serializer
+
+
 def bool_parser(config_option, value) -> bool:
     if not value:
         return False
@@ -104,6 +136,8 @@ data_serializers = {
     QColor: (color_parser, color_serializer),
     QFont: (font_parser, font_serializer),
     bool: (bool_parser, bool_serializer),
+    QFont.Weight: enum_parser_serializer_generator(QFont.Weight, QFont.Weight.Normal),
+    QFont.Style: enum_parser_serializer_generator(QFont.Style, QFont.Style.StyleNormal),
 }
 
 
@@ -190,12 +224,26 @@ ENTRIES = [
     CE("palette_link", QColor, QColor(0x00, 0x00, 0xFF, 0xFF)),
     CE("palette_linkvisited", QColor, QColor(0xFF, 0x00, 0xFF, 0xFF)),
     CE("pseudocode_comment_color", QColor, QColor(0x00, 0x80, 0x00, 0xFF)),
+    CE("pseudocode_comment_weight", QFont.Weight, QFont.Weight.Bold),
+    CE("pseudocode_comment_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_function_color", QColor, QColor(0x00, 0x00, 0xFF, 0xFF)),
+    CE("pseudocode_function_weight", QFont.Weight, QFont.Weight.Bold),
+    CE("pseudocode_function_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_quotation_color", QColor, QColor(0x00, 0x80, 0x00, 0xFF)),
+    CE("pseudocode_quotation_weight", QFont.Weight, QFont.Weight.Normal),
+    CE("pseudocode_quotation_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_keyword_color", QColor, QColor(0x00, 0x00, 0x80, 0xFF)),
+    CE("pseudocode_keyword_weight", QFont.Weight, QFont.Weight.Bold),
+    CE("pseudocode_keyword_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_types_color", QColor, QColor(0x00, 0x00, 0x80, 0xFF)),
+    CE("pseudocode_types_weight", QFont.Weight, QFont.Weight.Normal),
+    CE("pseudocode_types_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_variable_color", QColor, QColor(0x00, 0x00, 0x00, 0xFF)),
+    CE("pseudocode_variable_weight", QFont.Weight, QFont.Weight.Normal),
+    CE("pseudocode_variable_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_label_color", QColor, QColor(0x00, 0x00, 0xFF)),
+    CE("pseudocode_label_weight", QFont.Weight, QFont.Weight.Normal),
+    CE("pseudocode_label_style", QFont.Style, QFont.Style.StyleNormal),
     CE("pseudocode_highlight_color", QColor, QColor(0xFF, 0xFF, 0x00, 0xFF)),
     CE("proximity_node_background_color", QColor, QColor(0xFA, 0xFA, 0xFA)),
     CE("proximity_node_selected_background_color", QColor, QColor(0xCC, 0xCC, 0xCC)),

--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -3,7 +3,7 @@ import enum
 import logging
 import os
 import re
-from typing import Any, Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional, Tuple, Type
 
 import tomlkit
 import tomlkit.exceptions
@@ -85,7 +85,7 @@ def font_serializer(config_option, value: QFont) -> str:
 
 def enum_parser_serializer_generator(
     the_enum: enum.Enum, default
-) -> tuple[Callable[[str, str], enum.Enum], Callable[[str, enum.Enum], str]]:
+) -> Tuple[Callable[[str, str], enum.Enum], Callable[[str, enum.Enum], str]]:
     def parser(config_option: str, value: str) -> enum.Enum:
         try:
             return the_enum[value]

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -15,7 +15,7 @@ from angr.analyses.decompiler.structured_codegen.c import (
 )
 from angr.sim_type import SimType
 from pyqodeng.core.api import SyntaxHighlighter
-from PySide6.QtGui import QBrush, QFont, QTextCharFormat
+from PySide6.QtGui import QBrush, QColor, QFont, QTextCharFormat
 
 from angrmanagement.config import Conf
 
@@ -25,37 +25,43 @@ if TYPE_CHECKING:
 FORMATS = {}
 
 
+def create_char_format(color: QColor, weight: QFont.Weight, style: QFont.Style) -> QTextCharFormat:
+    f = QTextCharFormat()
+    f.setForeground(QBrush(color))
+    f.setFontWeight(weight)
+    if style == QFont.Style.StyleItalic:
+        f.setFontItalic(True)
+    return f
+
+
 def reset_formats():
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_keyword_color))
-    f.setFontWeight(QFont.Bold)
-    FORMATS["keyword"] = f
+    FORMATS["keyword"] = create_char_format(
+        Conf.pseudocode_keyword_color, Conf.pseudocode_keyword_weight, Conf.pseudocode_keyword_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_quotation_color))
-    FORMATS["quotation"] = f
+    FORMATS["quotation"] = create_char_format(
+        Conf.pseudocode_quotation_color, Conf.pseudocode_quotation_weight, Conf.pseudocode_quotation_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_function_color))
-    f.setFontWeight(QFont.Bold)
-    FORMATS["function"] = f
+    FORMATS["function"] = create_char_format(
+        Conf.pseudocode_function_color, Conf.pseudocode_function_weight, Conf.pseudocode_function_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_comment_color))
-    f.setFontWeight(QFont.Bold)
-    FORMATS["comment"] = f
+    FORMATS["comment"] = create_char_format(
+        Conf.pseudocode_comment_color, Conf.pseudocode_comment_weight, Conf.pseudocode_comment_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_variable_color))
-    FORMATS["variable"] = f
+    FORMATS["variable"] = create_char_format(
+        Conf.pseudocode_variable_color, Conf.pseudocode_variable_weight, Conf.pseudocode_variable_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_types_color))
-    FORMATS["type"] = f
+    FORMATS["type"] = create_char_format(
+        Conf.pseudocode_types_color, Conf.pseudocode_types_weight, Conf.pseudocode_types_style
+    )
 
-    f = QTextCharFormat()
-    f.setForeground(QBrush(Conf.pseudocode_label_color))
-    FORMATS["label"] = f
+    FORMATS["label"] = create_char_format(
+        Conf.pseudocode_label_color, Conf.pseudocode_label_weight, Conf.pseudocode_label_style
+    )
 
 
 def _format_node(obj):


### PR DESCRIPTION
This required changing:

- Adding support to config_manager to parse / serialize `Enum`s. This is made generic with `enum_parser_serializer_generator` b/c all of these parsers/serializers are the same.
- Change the preferences widget to store `Enum`s from themes so that themes can set them.
- Refactor how `qccode_highlighter` creates formats into a single function.

Note that this change does not allow the user to customize the font weight/style through the GUI: they would need to edit their config.

