### PR TITLE
Add kwargs to Workspace._instance_project_initalization

### DIFF
--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -939,7 +939,7 @@ class Workspace:
     #
     # Instance Callbacks
     #
-    def _instance_project_initalization(self):
+    def _instance_project_initalization(self, **kwargs):  # pylint:disable=unused-argument
         if self.main_instance.project.am_none:
             return
 


### PR DESCRIPTION
 Workspace._instance_project_initalization does not specify kwargs, so it throws an exception when trying to call it (such as loading a adb). Closes #1050.