### PR TITLE
Fix qlinear_viewer to avoid error on wheelEvent

### DIFF
--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -326,6 +326,9 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         if offset == self._offset and start_line == self._start_line_in_object:
             return
 
+        # make sure self._offset is not None after return
+        self._offset = offset
+
         # Convert the offset to memory region
         base_offset: int
         mr: MemoryRegion


### PR DESCRIPTION
When switch Disassembly view to the linear view and scroll the view while the binary is still loading (the view is still blank), an TypeError will raise

```
  File "/xxx/angrmanagement/ui/widgets/qlinear_viewer.py", line 169, in wheelEvent
    self.verticalScrollBar().setValue(self.offset * self._line_height)
                                      ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```

Cause:

`self.offset` could still be `None` after `prepare_objects()` and when `wheelEvent()` uses it to do calculations,  error raises