### PR TITLE
Use UDBZ format for macos disk image

### DIFF
--- a/.github/workflows/nightly-build.sh
+++ b/.github/workflows/nightly-build.sh
@@ -35,7 +35,7 @@ mkdir upload
 if [[ "$OSTYPE" == "darwin"* ]]; then
     mkdir /tmp/angr-management-dmg
     cp -r dist/*.app /tmp/angr-management-dmg
-    hdiutil create upload/angr-management-macOS.dmg -volname "angr-management nightly" -srcfolder /tmp/angr-management-dmg
+    hdiutil create upload/angr-management-macOS.dmg -volname "angr-management nightly" -srcfolder /tmp/angr-management-dmg -format UDBZ
 elif [[ "$OSTYPE" == "linux-gnu" ]]; then
     source /etc/os-release
     tar -C dist -czf upload/angr-management-$ID-$VERSION_ID.tar.gz angr-management


### PR DESCRIPTION
This'll hopefully get the macOS bundle size more under control