### PR TITLE
Build improvements for macos

### DIFF
--- a/.github/workflows/nightly-build.sh
+++ b/.github/workflows/nightly-build.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -ex
 
-python -m venv .venv
+# Set AM_PYTHON if it is not set by the user
+if [ -z "$AM_PYTHON" ]; then
+    AM_PYTHON="python"
+fi
+
+"$AM_PYTHON" -m venv .venv
 if [[ "$OSTYPE" == "msys" ]]; then
     source .venv/Scripts/activate
 else
@@ -11,6 +16,12 @@ fi
 # Install dependencies
 
 python -m pip install -U pip wheel setuptools unicorn==2.0.1.post1
+if [[ "$OSTYPE" == "darwin"* && "$(uname -m)" == "arm64" ]]; then
+    EXTRA_ANGR_ARGS="--no-binary capstone --no-binary pypcode"
+else
+    EXTRA_ANGR_ARGS=""
+fi
+
 
 pip install git+https://github.com/eliben/pyelftools.git
 pip install git+https://github.com/angr/archinfo.git
@@ -18,7 +29,7 @@ pip install git+https://github.com/angr/pyvex.git
 pip install git+https://github.com/angr/cle.git#egg=cle[ar,minidump,uefi,xbe]
 pip install git+https://github.com/angr/claripy.git
 pip install git+https://github.com/angr/ailment.git
-pip install --no-build-isolation git+https://github.com/angr/angr.git#egg=angr[pcode]
+pip install $EXTRA_ANGR_ARGS --no-build-isolation git+https://github.com/angr/angr.git#egg=angr[pcode]
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     pip install git+https://github.com/angr/archr.git#egg=archr
 fi
@@ -33,9 +44,9 @@ mkdir upload
 
 # Prepare onedirs
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    mkdir /tmp/angr-management-dmg
-    cp -r dist/*.app /tmp/angr-management-dmg
-    hdiutil create upload/angr-management-macOS.dmg -volname "angr-management nightly" -srcfolder /tmp/angr-management-dmg
+    pushd dist
+    zip -r ../upload/angr-management-macOS.zip angr-management.app
+    popd
 elif [[ "$OSTYPE" == "linux-gnu" ]]; then
     source /etc/os-release
     tar -C dist -czf upload/angr-management-$ID-$VERSION_ID.tar.gz angr-management

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist
 build
 MANIFEST
 start.spec
+venv
+.venv
+upload
 
 # vim temp files
 *.swp
@@ -31,3 +34,5 @@ packaging/appimage/AppDir
 packaging/appimage/appimage-builder-cache
 packaging/appimage/AppDir
 *.AppImage
+
+.DS_Store


### PR DESCRIPTION
This adds a few things for testing on macOS:

- Allows configuring a custom python to build with, useful for homebrew pythons that aren't `python`
- Installs libraries from source that currently have problems with pre-compiled wheels, to be reverted when issues in those libraries are corrected
- Switches macOS over to using a zip which is more convenient and has a smaller file size
- Adds some stuff to the .gitignore