### PR TITLE
setup.cfg: Pin PySide6 <=6.6.1 for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    PySide6>=6.4.2
+    PySide6>=6.4.2,<=6.6.1
     PySide6-QtAds
     QtAwesome
     QtPy~=2.3.0


### PR DESCRIPTION
Key sequences are changed again... Pin while dependencies are updated.

Broken in PySide6 v6.6.2:
	from PySide6 import QtCore
	QtCore.Qt.AltModifier | QtCore.Qt.Key.Key_C


Tracking:
- https://github.com/jupyter/qtconsole/pull/601
- https://github.com/angr/angr-management/pull/1178
- https://github.com/angr/pyqodeng/pull/11