### PR TITLE
Use string representation for QKeySequence construction

### DIFF
--- a/angrmanagement/ui/menus/analyze_menu.py
+++ b/angrmanagement/ui/menus/analyze_menu.py
@@ -15,7 +15,7 @@ class AnalyzeMenu(Menu):
                 MenuEntry(
                     "View in Proximity &Browser",
                     main_window.view_proximity_for_current_function,
-                    shortcut=QKeySequence(Qt.CTRL | Qt.Key_B),
+                    shortcut=QKeySequence("Ctrl+B"),
                 ),
                 MenuEntry("&Interact", main_window.interact, shortcut=QKeySequence(Qt.Key_F6)),
             ],

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -1,4 +1,3 @@
-from PySide6.QtCore import Qt
 from PySide6.QtGui import QKeySequence
 
 from angrmanagement.logic import GlobalInfo
@@ -34,7 +33,7 @@ class FileMenu(Menu):
         self._project = main_window.workspace.main_instance.project
 
         self._save_entries = [
-            MenuEntry("&Save angr database...", main_window.save_database, shortcut=QKeySequence(Qt.CTRL | Qt.Key_S)),
+            MenuEntry("&Save angr database...", main_window.save_database, shortcut=QKeySequence("Ctrl+S")),
             MenuEntry("S&ave angr database as...", main_window.save_database_as, shortcut=QKeySequence("Ctrl+Shift+S")),
             MenuEntry("Save patched binary as...", main_window.save_patched_binary_as),
         ]
@@ -44,9 +43,7 @@ class FileMenu(Menu):
         self.recent_menu = Menu("Load recent")
         self.entries.extend(
             [
-                MenuEntry(
-                    "L&oad a new binary...", main_window.open_file_button, shortcut=QKeySequence(Qt.CTRL | Qt.Key_O)
-                ),
+                MenuEntry("L&oad a new binary...", main_window.open_file_button, shortcut=QKeySequence("Ctrl+O")),
                 *(
                     []
                     if archr is None
@@ -54,25 +51,23 @@ class FileMenu(Menu):
                         MenuEntry(
                             "Loa&d a new docker target...",
                             main_window.open_docker_button,
-                            shortcut=QKeySequence(Qt.SHIFT | Qt.CTRL | Qt.Key_O),
+                            shortcut=QKeySequence("Ctrl+Shift+O"),
                         ),
                     ]
                 ),
                 MenuEntry(
                     "Load a &trace file...",
                     main_window.open_trace_file_button,
-                    shortcut=QKeySequence(Qt.SHIFT | Qt.CTRL | Qt.Key_T),
+                    shortcut=QKeySequence("Ctrl+Shift+T"),
                 ),
                 self.recent_menu,
                 MenuSeparator(),
-                MenuEntry(
-                    "&Load angr database...", main_window.load_database, shortcut=QKeySequence(Qt.CTRL | Qt.Key_L)
-                ),
+                MenuEntry("&Load angr database...", main_window.load_database, shortcut=QKeySequence("Ctrl+L")),
                 *self._save_entries,
                 MenuSeparator(),
                 MenuEntry("Load a new &trace...", main_window.load_trace),
                 MenuSeparator(),
-                MenuEntry("&Preferences...", main_window.preferences, shortcut=QKeySequence(Qt.CTRL | Qt.Key_Comma)),
+                MenuEntry("&Preferences...", main_window.preferences, shortcut=QKeySequence("Ctrl+Comma")),
                 MenuSeparator(),
                 MenuEntry("E&xit", main_window.quit),
             ]

--- a/angrmanagement/ui/menus/help_menu.py
+++ b/angrmanagement/ui/menus/help_menu.py
@@ -1,16 +1,19 @@
-from PySide6.QtCore import Qt
 from PySide6.QtGui import QKeySequence
 
 from .menu import Menu, MenuEntry, MenuSeparator
 
 
 class HelpMenu(Menu):
+    """
+    Main 'Help' menu
+    """
+
     def __init__(self, main_window):
         super().__init__("&Help", parent=main_window)
 
         self.entries.extend(
             [
-                MenuEntry("&Documentation", main_window.open_doc_link, shortcut=QKeySequence(Qt.ALT | Qt.Key_H)),
+                MenuEntry("&Documentation", main_window.open_doc_link, shortcut=QKeySequence("Alt+H")),
                 MenuSeparator(),
                 MenuEntry("About angr...", main_window.open_about_dialog),
             ]

--- a/angrmanagement/ui/menus/log_menu.py
+++ b/angrmanagement/ui/menus/log_menu.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QKeySequence, Qt
+from PySide6.QtGui import QKeySequence
 
 from .menu import Menu, MenuEntry, MenuSeparator
 
@@ -17,7 +17,7 @@ class LogMenu(Menu):
                 MenuEntry(
                     "&Copy selected content",
                     log_widget.copy_selected_messages,
-                    shortcut=QKeySequence(Qt.CTRL | Qt.Key_C),
+                    shortcut=QKeySequence("Ctrl+C"),
                 ),
                 MenuEntry("Copy selected message", log_widget.copy_selected),
                 MenuEntry("Copy all content", log_widget.copy_all_messages),


### PR DESCRIPTION
Trying to use typical operators to construct key sequences has been problematic, and is apparently broken in PySide6 v6.6.2. Use string representation which is more compatible, and easier to read.

Related #1177 