### PR TITLE
Use native menu bar on macOS

### DIFF
--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import os
 import pickle
-import sys
 import time
 from functools import partial
 from typing import TYPE_CHECKING, Optional
@@ -333,11 +332,6 @@ class MainWindow(QMainWindow):
 
         for path in Conf.recent_files:
             self._file_menu.add_recent(path)
-
-        # TODO: Eventually fix menu bars to have native support on MacOS
-        # if on a Mac, don't use the native menu bar (bug mitigation from QT)
-        if sys.platform == "darwin":
-            self.menuBar().setNativeMenuBar(False)
 
         self.menuBar().addMenu(self._file_menu.qmenu())
         self.menuBar().addMenu(self._view_menu.qmenu())


### PR DESCRIPTION
Return to using the native menubar for better macOS integration.

![image](https://github.com/angr/angr-management/assets/8210/b5f97086-b49a-4c30-93a6-a6dc0da5f683)

Appears to work just fine with PySide6 6.6.1 on Sonoma 14.3.1 . Tested post-launch plugin load is able to register menu items.

Related #231 