### PR TITLE
Hide preferences icon on macOS

### DIFF
--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -1,3 +1,5 @@
+import platform
+
 from PySide6.QtGui import QAction, QKeySequence
 
 from angrmanagement.logic import GlobalInfo
@@ -73,7 +75,7 @@ class FileMenu(Menu):
                     main_window.preferences,
                     shortcut=QKeySequence("Ctrl+Comma"),
                     role=QAction.PreferencesRole,
-                    icon=icon("preferences"),
+                    icon=icon("preferences") if platform.system() != "Darwin" else None,
                 ),
                 MenuSeparator(),
                 MenuEntry("E&xit", main_window.quit),


### PR DESCRIPTION
The preferences option gets relocated to the application menu on macos, so the preferences option looks weird in that context.

With icon:
<img width="283" alt="image" src="https://github.com/angr/angr-management/assets/1341797/ad7ad562-7d9e-4a40-9093-e659b3453227">
Without icon:
<img width="281" alt="image" src="https://github.com/angr/angr-management/assets/1341797/78d32566-e926-45d4-a492-c3cb1cf2b28f">
