### PR TITLE
Add plugin toml files to package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ pyinstaller =
 
 [options.package_data]
 angrmanagement =
+    plugins/**/plugin.toml
     resources/fonts/*.ttf
     resources/images/*
     resources/themes/**/*


### PR DESCRIPTION
Currently these toml files weren't actually being included in the pip packaged version of angr management.