### PR TITLE
Don't allow setting an object container's contents to itself

### DIFF
--- a/angrmanagement/data/object_container.py
+++ b/angrmanagement/data/object_container.py
@@ -60,6 +60,8 @@ class ObjectContainer(EventSentinel):
 
     @am_obj.setter
     def am_obj(self, v):
+        if v is self:
+            raise ValueError("Cannot set am_obj to self")
         if type(self._am_obj) is ObjectContainer:
             self._am_obj.am_unsubscribe(self.__forwarder)
         if type(v) is ObjectContainer:


### PR DESCRIPTION
This is a mistake I've made a few times and I felt that adding in a check might save myself and others time debugging in the future.