### PR TITLE
Refactor view base class hierarchy

### DIFF
--- a/angrmanagement/ui/view_manager.py
+++ b/angrmanagement/ui/view_manager.py
@@ -6,7 +6,7 @@ import PySide6QtAds as QtAds
 from bidict import bidict
 from PySide6.QtWidgets import QSizePolicy
 
-from .views.view import ViewStatePublisherMixin
+from angrmanagement.ui.views.view import InstanceView
 
 if TYPE_CHECKING:
     from .views.view import BaseView
@@ -116,7 +116,7 @@ class ViewManager:
         view = self.view_to_dock.inverse.get(new, None)
         if view:
             self._promote_view(view)
-        if isinstance(view, ViewStatePublisherMixin):
+        if isinstance(view, InstanceView):
             view.on_focused()
 
     def _on_dock_widget_closed(self, dock: QtAds.CDockWidget) -> None:

--- a/angrmanagement/ui/views/breakpoints_view.py
+++ b/angrmanagement/ui/views/breakpoints_view.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QMenu, QTableView,
 from angrmanagement.data.breakpoint import Breakpoint, BreakpointManager, BreakpointType
 from angrmanagement.ui.dialogs import BreakpointDialog
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     import PySide6
@@ -143,13 +143,13 @@ class QBreakpointTableWidget(QTableView):
             self.breakpoint_mgr.remove_breakpoint(b)
 
 
-class BreakpointsView(BaseView):
+class BreakpointsView(InstanceView):
     """
     Breakpoints table view.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("breakpoints", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("breakpoints", workspace, default_docking_position, instance)
         self.base_caption = "Breakpoints"
         self._tbl_widget: Optional[QBreakpointTableWidget] = None
         self._init_widgets()

--- a/angrmanagement/ui/views/call_explorer_view.py
+++ b/angrmanagement/ui/views/call_explorer_view.py
@@ -8,7 +8,7 @@ from angrmanagement.config import Conf
 from angrmanagement.logic.debugger import DebuggerWatcher
 from angrmanagement.logic.debugger.bintrace import BintraceDebugger
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins import Function
@@ -54,13 +54,13 @@ class CallTreeItem(QStandardItem):
         self.expandable: bool = True
 
 
-class CallExplorerView(BaseView):
+class CallExplorerView(InstanceView):
     """
     Call Explorer view.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("call_explorer", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("call_explorer", workspace, default_docking_position, instance)
 
         self._last_updated_func: Optional[Union[int, Function]] = None
         self._inhibit_update: bool = False

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -30,21 +30,19 @@ from angrmanagement.ui.widgets.qccode_edit import QCCodeEdit
 from angrmanagement.ui.widgets.qdecomp_options import QDecompilationOptions
 
 from .disassembly_view import DisassemblyView
-from .view import BaseView
+from .view import FunctionView
 
 log = logging.getLogger(__name__)
 
 
-class CodeView(BaseView):
+class CodeView(FunctionView):
     """
     A view to display pseudocode or source code. You should control this view by manipulating and observing its four
     ObjectContainers: .addr, .current_node, .codegen, and .function.
     """
 
-    FUNCTION_SPECIFIC_VIEW = True
-
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("pseudocode", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("pseudocode", workspace, default_docking_position, instance)
 
         self.base_caption = "Pseudocode"
 
@@ -93,16 +91,6 @@ class CodeView(BaseView):
     @property
     def document(self):
         return self._doc
-
-    @property
-    def function(self) -> ObjectContainer:
-        return self._function
-
-    @function.setter
-    def function(self, v):
-        if v is not self._function.am_obj:
-            self._function.am_obj = v
-            self._function.am_event(focus=True)
 
     #
     # Public methods

--- a/angrmanagement/ui/views/console_view.py
+++ b/angrmanagement/ui/views/console_view.py
@@ -4,18 +4,18 @@ from PySide6.QtCore import QSize
 from PySide6.QtWidgets import QHBoxLayout
 from traitlets.config.configurable import MultipleInstanceError
 
-from .view import BaseView
+from .view import InstanceView
 
 _l = logging.getLogger(name=__name__)
 
 
-class ConsoleView(BaseView):
+class ConsoleView(InstanceView):
     """
     Console view providing IPython interactive session.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("console", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("console", workspace, default_docking_position, instance)
 
         self.base_caption = "Console"
         self._ipython_widget = None

--- a/angrmanagement/ui/views/data_dep_view.py
+++ b/angrmanagement/ui/views/data_dep_view.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 from angr.analyses.data_dep import MemDepNode, RegDepNode, TmpDepNode
@@ -13,27 +12,24 @@ from angrmanagement.ui.dialogs.data_dep_graph_search import QDataDepGraphSearch
 from angrmanagement.ui.widgets.qdatadep_graph import QDataDepGraph
 from angrmanagement.ui.widgets.qdatadepgraph_block import QDataDepGraphBlock
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     from angr import SimState
     from angr.analyses import DataDependencyGraphAnalysis
     from angr.analyses.data_dep import BaseDepNode
     from capstone import CsInsn
-_l = logging.getLogger(__name__)
 
 
-class DataDepView(BaseView):
+class DataDepView(InstanceView):
     """Workspace view used to display a data dependency graph on the screen"""
 
     @property
     def function(self):
         raise NotImplementedError("Does not apply!")
 
-    FUNCTION_SPECIFIC_VIEW = False
-
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("data_dependency", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("data_dependency", workspace, default_docking_position, instance)
 
         self.base_caption = "Data Dependency"
 

--- a/angrmanagement/ui/views/dep_view.py
+++ b/angrmanagement/ui/views/dep_view.py
@@ -9,20 +9,20 @@ from PySide6.QtWidgets import QHBoxLayout
 from angrmanagement.ui.widgets.qdep_graph import QDependencyGraph
 from angrmanagement.ui.widgets.qdepgraph_block import QDepGraphBlock
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.key_definitions.atoms import Atom
     from angr.knowledge_plugins.key_definitions.definition import Definition
 
 
-class DependencyView(BaseView):
+class DependencyView(InstanceView):
     """
     Creates view for dependency analysis.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("dependencies", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("dependencies", workspace, default_docking_position, instance)
 
         self.base_caption = "Dependencies"
 

--- a/angrmanagement/ui/views/functions_view.py
+++ b/angrmanagement/ui/views/functions_view.py
@@ -2,16 +2,16 @@ from PySide6.QtWidgets import QVBoxLayout
 
 from angrmanagement.ui.widgets.qfunction_table import QFunctionTable
 
-from .view import BaseView
+from .view import InstanceView
 
 
-class FunctionsView(BaseView):
+class FunctionsView(InstanceView):
     """
     View displaying functions in the project.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("functions", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("functions", workspace, default_docking_position, instance)
 
         self.base_caption = "Functions"
         self._function_table: QFunctionTable

--- a/angrmanagement/ui/views/hex_view.py
+++ b/angrmanagement/ui/views/hex_view.py
@@ -38,7 +38,7 @@ from angrmanagement.ui.dialogs.input_prompt import InputPromptDialog
 from angrmanagement.ui.dialogs.jumpto import JumpTo
 from angrmanagement.utils import is_printable
 
-from .view import SynchronizedView, ViewStatePublisherMixin
+from .view import SynchronizedInstanceView
 
 log = logging.getLogger(__name__)
 
@@ -1312,15 +1312,15 @@ class HexGraphicsView(QAbstractScrollArea):
         super().keyPressEvent(event)
 
 
-class HexView(ViewStatePublisherMixin, SynchronizedView):
+class HexView(SynchronizedInstanceView):
     """
     View and edit memory/object code in classic hex editor format.
     """
 
     _widgets_initialized: bool = False
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("hex", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("hex", workspace, default_docking_position, instance)
         self.base_caption: str = "Hex"
         self.smart_highlighting_enabled: bool = True
         self._clipboard = None

--- a/angrmanagement/ui/views/interaction_view.py
+++ b/angrmanagement/ui/views/interaction_view.py
@@ -7,7 +7,7 @@ from typing import Optional
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtWidgets import QInputDialog, QLineEdit
 
-from .view import BaseView
+from .view import InstanceView
 
 try:
     import nclib
@@ -67,9 +67,9 @@ class InteractionState(enum.Enum):
     VIEWING = 4
 
 
-class InteractionView(BaseView):
-    def __init__(self, workspace, instance, *args, **kwargs):
-        super().__init__("interaction", workspace, instance, *args, **kwargs)
+class InteractionView(InstanceView):
+    def __init__(self, workspace, instance):
+        super().__init__("interaction", workspace, "bottom", instance)
         self.base_caption = "Interaction"
         self.current_log = (
             []

--- a/angrmanagement/ui/views/log_view.py
+++ b/angrmanagement/ui/views/log_view.py
@@ -1,22 +1,18 @@
-import logging
-
 from PySide6.QtCore import QSize
 from PySide6.QtWidgets import QHBoxLayout
 
 from angrmanagement.ui.widgets.qlog_widget import QLogWidget
 
-from .view import BaseView
-
-_l = logging.getLogger(name=__name__)
+from .view import InstanceView
 
 
-class LogView(BaseView):
+class LogView(InstanceView):
     """
     Log view displays logging output.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("log", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("log", workspace, default_docking_position, instance)
 
         self.base_caption = "Log"
         self._log_widget: QLogWidget = None

--- a/angrmanagement/ui/views/patches_view.py
+++ b/angrmanagement/ui/views/patches_view.py
@@ -2,16 +2,16 @@ from PySide6.QtWidgets import QVBoxLayout
 
 from angrmanagement.ui.widgets.qpatch_table import QPatchTable
 
-from .view import BaseView
+from .view import InstanceView
 
 
-class PatchesView(BaseView):
+class PatchesView(InstanceView):
     """
     View showing all patches.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("patches", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("patches", workspace, default_docking_position, instance)
 
         self.base_caption = "Patches"
         self._patch_table: QPatchTable

--- a/angrmanagement/ui/views/proximity_view.py
+++ b/angrmanagement/ui/views/proximity_view.py
@@ -11,7 +11,7 @@ from angr.analyses.proximity_graph import (
 from PySide6.QtCore import QSize
 from PySide6.QtWidgets import QHBoxLayout
 
-from angrmanagement.ui.views.view import BaseView
+from angrmanagement.ui.views.view import InstanceView
 from angrmanagement.ui.widgets.qproximity_graph import QProximityGraph
 from angrmanagement.ui.widgets.qproximitygraph_block import (
     QProximityGraphBlock,
@@ -24,13 +24,13 @@ if TYPE_CHECKING:
     from angr.knowledge_plugins.functions import Function
 
 
-class ProximityView(BaseView):
+class ProximityView(InstanceView):
     """
     Proximity View
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("proximity", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("proximity", workspace, default_docking_position, instance)
 
         self.base_caption = "Proximity"
 

--- a/angrmanagement/ui/views/registers_view.py
+++ b/angrmanagement/ui/views/registers_view.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QTableView, QVBoxL
 from angrmanagement.config import Conf
 from angrmanagement.logic.debugger import DebuggerWatcher
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     import angr
@@ -128,13 +128,13 @@ class QRegisterTableWidget(QTableView):
         self.model.layoutChanged.emit()
 
 
-class RegistersView(BaseView):
+class RegistersView(InstanceView):
     """
     Register table view.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("registers", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("registers", workspace, default_docking_position, instance)
 
         self.base_caption = "Registers"
         self._tbl_widget: Optional[QRegisterTableWidget] = None

--- a/angrmanagement/ui/views/stack_view.py
+++ b/angrmanagement/ui/views/stack_view.py
@@ -9,7 +9,7 @@ from angrmanagement.config import Conf
 from angrmanagement.data.breakpoint import Breakpoint, BreakpointType
 from angrmanagement.logic.debugger import DebuggerWatcher
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     import angr
@@ -154,13 +154,13 @@ class QStackTableWidget(QTableView):
         return mnu
 
 
-class StackView(BaseView):
+class StackView(InstanceView):
     """
     Stack table view.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("stack", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("stack", workspace, default_docking_position, instance)
 
         self.base_caption = "Stack"
         self._tbl_widget: Optional[QStackTableWidget] = None

--- a/angrmanagement/ui/views/states_view.py
+++ b/angrmanagement/ui/views/states_view.py
@@ -3,12 +3,12 @@ from PySide6.QtWidgets import QHBoxLayout
 
 from angrmanagement.ui.widgets.qstate_table import QStateTable
 
-from .view import BaseView
+from .view import InstanceView
 
 
-class StatesView(BaseView):
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("states", workspace, instance, default_docking_position, *args, **kwargs)
+class StatesView(InstanceView):
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("states", workspace, default_docking_position, instance)
 
         self.base_caption = "States"
         self._state_table: QStateTable

--- a/angrmanagement/ui/views/strings_view.py
+++ b/angrmanagement/ui/views/strings_view.py
@@ -8,15 +8,15 @@ from PySide6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QLineEdit, QVBoxLa
 from angrmanagement.ui.widgets.qfunction_combobox import QFunctionComboBox
 from angrmanagement.ui.widgets.qstring_table import QStringTable
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.cfg.memory_data import MemoryData
 
 
-class StringsView(BaseView):
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("strings", workspace, instance, default_docking_position, *args, **kwargs)
+class StringsView(InstanceView):
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("strings", workspace, default_docking_position, instance)
 
         self.base_caption = "Strings"
 

--- a/angrmanagement/ui/views/symexec_view.py
+++ b/angrmanagement/ui/views/symexec_view.py
@@ -6,12 +6,12 @@ from angrmanagement.ui.widgets.qpathtree import QPathTree
 from angrmanagement.ui.widgets.qsimulation_managers import QSimulationManagers
 from angrmanagement.ui.widgets.state_inspector import StateInspector
 
-from .view import BaseView
+from .view import InstanceView
 
 
-class SymexecView(BaseView):
-    def __init__(self, workspace, instance, *args, **kwargs):
-        super().__init__("symexec", workspace, instance, *args, **kwargs)
+class SymexecView(InstanceView):
+    def __init__(self, workspace, instance):
+        super().__init__("symexec", workspace, "right", instance)
 
         self.base_caption = "Symbolic Execution"
 

--- a/angrmanagement/ui/views/trace_map_view.py
+++ b/angrmanagement/ui/views/trace_map_view.py
@@ -3,17 +3,17 @@ from typing import Optional
 from PySide6.QtCore import QSize
 from PySide6.QtWidgets import QVBoxLayout
 
-from angrmanagement.ui.views.view import BaseView
+from angrmanagement.ui.views.view import InstanceView
 from angrmanagement.ui.widgets import QTraceMap
 
 
-class TraceMapView(BaseView):
+class TraceMapView(InstanceView):
     """
     View container for QTraceMap.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("tracemap", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("tracemap", workspace, default_docking_position, instance)
         self.base_caption: str = "Trace Map"
         self.inner_widget: Optional[QTraceMap] = None
         self._init_widgets()

--- a/angrmanagement/ui/views/traces_view.py
+++ b/angrmanagement/ui/views/traces_view.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from PySide6.QtCore import QAbstractTableModel, QSize, Qt
 from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QMenu, QTableView, QVBoxLayout
 
-from .view import BaseView
+from .view import InstanceView
 
 if TYPE_CHECKING:
     import PySide6
@@ -116,13 +116,13 @@ class QTraceTableWidget(QTableView):
             menu.exec_(event.globalPos())
 
 
-class TracesView(BaseView):
+class TracesView(InstanceView):
     """
     Traces table view.
     """
 
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("traces", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("traces", workspace, default_docking_position, instance)
 
         self.base_caption = "Traces"
         self._tbl_widget: Optional[QTraceTableWidget] = None

--- a/angrmanagement/ui/views/types_view.py
+++ b/angrmanagement/ui/views/types_view.py
@@ -7,22 +7,20 @@ from angrmanagement.data.object_container import ObjectContainer
 from angrmanagement.ui.dialogs.type_editor import CTypeEditor
 from angrmanagement.ui.widgets.qtypedef import QCTypeDef
 
-from .view import BaseView
+from .view import FunctionView
 
 if TYPE_CHECKING:
     from angr.knowledge_plugins.types import TypesStore
     from angr.knowledge_plugins.variables.variable_manager import VariableManagerInternal
 
 
-class TypesView(BaseView):
+class TypesView(FunctionView):
     """
     The view that lets you modify project.kb.types. Creates a QTypeDef for each type.
     """
 
-    FUNCTION_SPECIFIC_VIEW = True
-
-    def __init__(self, workspace, instance, default_docking_position, *args, **kwargs):
-        super().__init__("types", workspace, instance, default_docking_position, *args, **kwargs)
+    def __init__(self, workspace, instance, default_docking_position):
+        super().__init__("types", workspace, default_docking_position, instance)
 
         self.base_caption = "Types"
 
@@ -39,15 +37,6 @@ class TypesView(BaseView):
     #
     # Properties
     #
-
-    @property
-    def function(self) -> ObjectContainer:
-        return self._function
-
-    @function.setter
-    def function(self, v):
-        self._function.am_obj = v
-        self._function.am_event()
 
     @property
     def current_typestore(self) -> "TypesStore":

--- a/angrmanagement/ui/views/view.py
+++ b/angrmanagement/ui/views/view.py
@@ -178,9 +178,12 @@ class SynchronizedView(BaseView):
     Base class for views which can be synchronized.
     """
 
-    def __init__(self):
-        self._processing_synchronized_cursor_update: bool = False
-        self.sync_state: SynchronizedViewState = SynchronizedViewState()
+    _processing_synchronized_cursor_update: bool
+    sync_state: SynchronizedViewState
+
+    def __init__(self):  # pylint: disable=super-init-not-called
+        self._processing_synchronized_cursor_update = False
+        self.sync_state = SynchronizedViewState()
         self.sync_state.register_view(self)
 
     def desync(self):

--- a/angrmanagement/ui/views/view.py
+++ b/angrmanagement/ui/views/view.py
@@ -1,12 +1,14 @@
-from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Set
 
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QFrame, QMenu
 
+from angrmanagement.data.object_container import ObjectContainer
 from angrmanagement.ui.icons import icon
 
 if TYPE_CHECKING:
+    import angr
     import PySide6.QtGui
 
     from angrmanagement.data.highlight_region import SynchronizedHighlightRegion
@@ -18,23 +20,15 @@ class BaseView(QFrame):
     Base class for all main views.
     """
 
-    # if this view has function-specific views to show. function setter must be implemented when this property is set
-    # to True.
-    FUNCTION_SPECIFIC_VIEW = False
-
     def __init__(
         self,
         category: str,
         workspace: "Workspace",
-        instance: "Instance",
         default_docking_position: str,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
+    ) -> None:
+        super().__init__()
 
         self.workspace = workspace
-        self.instance: Instance = instance
         self.category = category
         self.default_docking_position = default_docking_position
 
@@ -46,39 +40,31 @@ class BaseView(QFrame):
         self.base_caption: str = "View"
         self.icon = icon(category + "-view")
 
-    @property
-    def function(self):
-        raise NotImplementedError
-
-    @function.setter
-    def function(self, v):
-        raise NotImplementedError
-
-    def is_shown(self):
+    def is_shown(self) -> bool:
         return self.visibleRegion().isEmpty() is False
 
-    def focus(self):
+    def focus(self) -> None:
         self.workspace.view_manager.raise_view(self)
 
-    def refresh(self):
+    def refresh(self) -> None:
         pass
 
-    def reload(self):
+    def reload(self) -> None:
         pass
 
-    def sizeHint(self):
+    def sizeHint(self) -> QSize:
         return QSize(self.width_hint, self.height_hint)
 
-    def resizeEvent(self, event):
+    def resizeEvent(self, event) -> None:
         # Update current width
         self.old_width = event.oldSize().width()
         self.old_height = event.oldSize().height()
 
-    def closeEvent(self, event: "PySide6.QtGui.QCloseEvent"):
+    def closeEvent(self, event: "PySide6.QtGui.QCloseEvent") -> None:
         self.workspace.view_manager.remove_view(self)
         event.accept()
 
-    def mainWindowInitializedEvent(self):
+    def mainWindowInitializedEvent(self) -> None:
         pass
 
     #
@@ -86,7 +72,7 @@ class BaseView(QFrame):
     #
 
     @property
-    def caption(self):
+    def caption(self) -> str:
         s = self.base_caption
         if self.index > 1:
             s += f"-{self.index}"
@@ -98,17 +84,25 @@ class ViewState:
     A basic view state to be published through ViewStatePublisherMixin.
     """
 
+    cursors: List[int]
+
     def __init__(self, cursors: Optional[List[int]] = None):
-        self.cursors: List[int] = cursors or []
+        self.cursors = cursors or []
 
 
-class ViewStatePublisherMixin:
+class InstanceView(BaseView):
     """
-    Views that wish to update the instance 'active' view state for common visualization use this mixin.
+    Base class for views that are associated with an instance.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    instance: "Instance"
+    published_view_state: ViewState
+
+    def __init__(
+        self, category: str, workspace: "Workspace", default_docking_position: str, instance: "Instance"
+    ) -> None:
+        BaseView.__init__(self, category, workspace, default_docking_position)
+        self.instance = instance
         self.published_view_state = ViewState()
 
     def on_focused(self):
@@ -120,17 +114,45 @@ class ViewStatePublisherMixin:
             self.instance.active_view_state.am_event()
 
 
+class FunctionView(InstanceView):
+    """
+    Base class for views that are function-specific.
+    """
+
+    # TODO: function would ideally be provided in the constructor
+    _function: ObjectContainer
+
+    def __init__(
+        self, category: str, workspace: "Workspace", default_docking_position: str, instance: "Instance"
+    ) -> None:
+        InstanceView.__init__(self, category, workspace, default_docking_position, instance)
+        self._function = ObjectContainer(None, "Current function")
+
+    @property
+    def function(self) -> Optional["angr.knowledge_plugins.Function"]:
+        return self._function
+
+    @function.setter
+    def function(self, function: "angr.knowledge_plugins.Function") -> None:
+        self._function.am_obj = function
+        self._function.am_event()
+
+
 class SynchronizedViewState:
     """
     Simple state tracking for synchronized views.
     """
 
-    def __init__(self):
-        self.views = set()
-        self.cursor_address: Optional[int] = None
-        self.highlight_regions: Mapping[SynchronizedView, Sequence[SynchronizedHighlightRegion]] = {}
+    views: Set["SynchronizedView"]
+    cursor_address: Optional[int]
+    highlight_regions: Dict["SynchronizedView", Sequence["SynchronizedHighlightRegion"]]
 
-    def register_view(self, view: "SynchronizedView"):
+    def __init__(self) -> None:
+        self.views = set()
+        self.cursor_address = None
+        self.highlight_regions = {}
+
+    def register_view(self, view: "SynchronizedView") -> None:
         """
         Register a synchronized view.
         """
@@ -138,7 +160,7 @@ class SynchronizedViewState:
         for v in self.views:
             v.on_synchronized_view_group_changed()
 
-    def unregister_view(self, view: "SynchronizedView"):
+    def unregister_view(self, view: "SynchronizedView") -> None:
         """
         Unregister a synchronized view.
         """
@@ -156,8 +178,7 @@ class SynchronizedView(BaseView):
     Base class for views which can be synchronized.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
         self._processing_synchronized_cursor_update: bool = False
         self.sync_state: SynchronizedViewState = SynchronizedViewState()
         self.sync_state.register_view(self)
@@ -260,3 +281,27 @@ class SynchronizedView(BaseView):
                 act.toggled.connect(lambda checked, s=group: self.sync_with_state_object(s if checked else None))
                 mnu.addAction(act)
         return mnu
+
+
+class SynchronizedInstanceView(InstanceView, SynchronizedView):
+    """
+    Base class for views that are associated with an instance and can be synchronized.
+    """
+
+    def __init__(
+        self, category: str, workspace: "Workspace", default_docking_position: str, instance: "Instance"
+    ) -> None:
+        InstanceView.__init__(self, category, workspace, default_docking_position, instance)
+        SynchronizedView.__init__(self)
+
+
+class SynchronizedFunctionView(FunctionView, SynchronizedView):
+    """
+    Base class for views that are function-specific and can be synchronized.
+    """
+
+    def __init__(
+        self, category: str, workspace: "Workspace", default_docking_position: str, instance: "Instance"
+    ) -> None:
+        FunctionView.__init__(self, category, workspace, default_docking_position, instance)
+        SynchronizedView.__init__(self)

--- a/angrmanagement/ui/widgets/qdisasm_statusbar.py
+++ b/angrmanagement/ui/widgets/qdisasm_statusbar.py
@@ -131,7 +131,7 @@ class QDisasmStatusBar(QFrame):
         self._disasm_level_combo.setCurrentIndex(index)
 
     def _update_function_label(self):
-        s = f"{self._function.name} ({self._function.addr:x})" if self._function else ""
+        s = f"{self._function.name} ({self._function.addr:x})" if self._function is not None else ""
         self._function_label.setText(s)
 
     def _on_saveimage_btn_clicked(self):

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -40,6 +40,7 @@ from angrmanagement.logic.threads import gui_thread_schedule_async
 from angrmanagement.plugins import PluginManager
 from angrmanagement.ui.dialogs import AnalysisOptionsDialog
 from angrmanagement.ui.dialogs.function import FunctionDialog
+from angrmanagement.ui.views.view import FunctionView
 from angrmanagement.utils import locate_function
 from angrmanagement.utils.daemon_thread import start_daemon_thread
 
@@ -171,7 +172,7 @@ class Workspace:
 
         # Ask all current views to display this function
         current_view = self.view_manager.current_tab
-        if current_view is None or not current_view.FUNCTION_SPECIFIC_VIEW:
+        if current_view is None or not isinstance(current_view, FunctionView):
             # we don't have a current view or the current view does not have function-specific content. create a
             # disassembly view to display the selected function.
             disasm_view = self._get_or_create_view("dissasembly", DisassemblyView)


### PR DESCRIPTION
With this change, the hierarchy now looks like:

```
BaseView
InstanceView(BaseView)
FunctionView(InstanceView)
SychronizedView(BaseView) Do not derive from this directly! Maybe it should be _SychrnoizedView?
SychronizedInstanceView(InstanceView, SychrnoizedView)
SychrnoizedFunctionView(FunctionView, SychronizedView)
```

The view state publisher mixin has been rolled into the InstanceView base. Among other things, this will make it easier to identify which views are associated with specific instances, and allow views inheriting directly from BaseView to not be associated with a particular instance.