### PR TITLE
CodeView: Init QCCodeEdit {fore,back}ground

### DIFF
--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -456,6 +456,7 @@ class CodeView(FunctionView):
         self._textedit = QCCodeEdit(self)
         self._textedit.setTextInteractionFlags(Qt.TextSelectableByKeyboard | Qt.TextSelectableByMouse)
         self._textedit.setLineWrapMode(QCCodeEdit.NoWrap)
+        self._textedit.background = Conf.palette_base
         window.setCentralWidget(self._textedit)
 
         # decompilation options

--- a/angrmanagement/ui/widgets/qccode_highlighter.py
+++ b/angrmanagement/ui/widgets/qccode_highlighter.py
@@ -35,6 +35,14 @@ def create_char_format(color: QColor, weight: QFont.Weight, style: QFont.Style) 
 
 
 def reset_formats():
+    bg = QTextCharFormat()
+    bg.setBackground(Conf.palette_base)
+    FORMATS["background"] = bg
+
+    fg = QTextCharFormat()
+    fg.setForeground(Conf.palette_text)
+    FORMATS["normal"] = fg
+
     FORMATS["keyword"] = create_char_format(
         Conf.pseudocode_keyword_color, Conf.pseudocode_keyword_weight, Conf.pseudocode_keyword_style
     )


### PR DESCRIPTION
Fixes #847 

After testing something else on Windows I was motivated to finally fix this broken pseudocode colors issue...

![fix](https://github.com/angr/angr-management/assets/8210/b350cc8f-021a-48e8-9b10-4b9af0f423a7)

[On other platforms](https://github.com/angr/pyqodeng/blob/a71a2fba9099358fb64a62c5e370a5c5ecf4e271/pyqodeng/core/api/code_edit.py#L1412) the widget apparently fails to respect this foreground and background color, so it happily used the theme defaults. On Windows it actually does use them, but we were not changing from the default. Use theme colors (background=palette base, foreground=palette text) for now for consistency. Eventually support changing them after fixing pyqodeng.
