### PR TITLE
Ignore vendor dir in ruff+black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ target-version = ['py38']
 [tool.ruff]
 line-length = 120
 target-version = 'py38'
+exclude = ["angrmanagement/vendor/*"]
 
 [tool.ruff.lint]
 select =  [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,12 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 120
 target-version = ['py38']
+extend-exclude = "angrmanagement/vendor/"
 
 [tool.ruff]
 line-length = 120
 target-version = 'py38'
-exclude = ["angrmanagement/vendor/*"]
+exclude = ["angrmanagement/vendor/"]
 
 [tool.ruff.lint]
 select =  [


### PR DESCRIPTION
Ignoring the directory in pre-commit makes the CI green but the tools report errors locally in the editor and cli. This allows us to use them locally again.