### PR TITLE
Preserve symbolic links when creating macOS bundle

### DIFF
--- a/.github/workflows/nightly-build.sh
+++ b/.github/workflows/nightly-build.sh
@@ -43,7 +43,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     mkdir /tmp/angr-management-zip
     ZIP_PATH=$(pwd)/upload/angr-management-macOS-$(uname -m).zip
     pushd dist
-    zip -r $ZIP_PATH *.app
+    zip -ry $ZIP_PATH *.app
     popd
 elif [[ "$OSTYPE" == "linux-gnu" ]]; then
     source /etc/os-release


### PR DESCRIPTION
If this works, this should cut the macOS bundle size by nearly 50%...