### PR TITLE
Drop PySide6<=6.6.1 constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    PySide6>=6.4.2,<=6.6.1
+    PySide6>=6.4.2
     PySide6-QtAds
     QtAwesome
     QtPy


### PR DESCRIPTION
pyqodeng v0.0.11 is released now so we can move up to latest PySide6