### PR TITLE
Pin to pyside6<6.7.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    PySide6>=6.4.2
+    PySide6>=6.4.2,<6.7.0
     PySide6-QtAds>=4.2.1
     QtAwesome
     QtPy


### PR DESCRIPTION
Last week a PySIde6-Qtads update with PySide 6.7.0 support caused nightlies to start building with Pyside 6.7.0, thus segfaulting on startup and failing the pipeline (see #1243). Let's pin to <6.7.0 until this is resolved.