### PR TITLE
Fixed unable to copy version text issue in "about".

### DIFF
--- a/angrmanagement/ui/dialogs/about.py
+++ b/angrmanagement/ui/dialogs/about.py
@@ -37,6 +37,7 @@ class LoadAboutDialog(QDialog):
         version_text = QLabel(version_text_tup)
         version_text.setFont(QFont("Consolas", weight=QFont.Bold))
         version_text.setAlignment(Qt.AlignCenter)
+        version_text.setTextInteractionFlags(Qt.TextSelectableByMouse)
         credits_text = QLabel('<a href="http://angr.io/">Credits</a>')
         credits_text.setFont(QFont("Consolas", weight=QFont.Bold))
         credits_text.setTextFormat(Qt.RichText)


### PR DESCRIPTION
Added another line of code inside of "angrmanagement/ui/dialogs/about.py", allowing version text in "about" to be selectable.

This should fix the unable to copy issue in the "about" window allowing users to select and copy the version text.

Fixes #824 