### PR TITLE
Use JobContext for progress callbacks

### DIFF
--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import functools
 import logging
-import time
+from typing import TYPE_CHECKING
 
 from angrmanagement.data.analysis_options import CFGForceScanMode
 from angrmanagement.logic.threads import gui_thread_schedule_async
 
 from .job import Job
+
+if TYPE_CHECKING:
+    from traitlets import Instance
+
+    from angrmanagement.logic.jobmanager import JobContext
 
 _l = logging.getLogger(name=__name__)
 
@@ -39,10 +45,9 @@ class CFGGenerationJob(Job):
             self.cfg_args["force_complete_scan"] = scanning_mode == CFGForceScanMode.CompleteScan
 
         self._cfb = None
-        self._last_progress_callback_triggered = None
         self.instance = None
 
-    def _run(self, inst):
+    def _run(self, ctx: JobContext, inst: Instance):
         self.instance = inst
         exclude_region_types = {"kernel", "tls"}
         # create a temporary CFB for displaying partially analyzed binary during CFG recovery
@@ -52,7 +57,7 @@ class CFGGenerationJob(Job):
         self._cfb = temp_cfb
 
         cfg = inst.project.analyses.CFG(
-            progress_callback=self._progress_callback,
+            progress_callback=functools.partial(self._progress_callback, ctx),
             low_priority=True,
             cfb=temp_cfb,
             **self.cfg_args,
@@ -76,12 +81,8 @@ class CFGGenerationJob(Job):
     # Private methods
     #
 
-    def _progress_callback(self, percentage, text: str | None = None, cfg=None) -> None:
-        t = time.time()
-        if self._last_progress_callback_triggered is not None and t - self._last_progress_callback_triggered < 0.2:
-            return
-        self._last_progress_callback_triggered = t
-        super()._progress_callback(percentage, text=text)
+    def _progress_callback(self, ctx: JobContext, percentage, text: str | None = None, cfg=None) -> None:
+        ctx.set_progress(percentage, text)
 
         if cfg is not None:
             # Peek into the CFG

--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -10,8 +10,7 @@ from angrmanagement.logic.threads import gui_thread_schedule_async
 from .job import Job
 
 if TYPE_CHECKING:
-    from traitlets import Instance
-
+    from angrmanagement.data.instance import Instance
     from angrmanagement.logic.jobmanager import JobContext
 
 _l = logging.getLogger(name=__name__)

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 from .job import Job
 
 if TYPE_CHECKING:
-    from traitlets import Instance
-
+    from angrmanagement.data.instance import Instance
     from angrmanagement.logic.jobmanager import JobContext
 
 

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .job import Job
+
+if TYPE_CHECKING:
+    from traitlets import Instance
+
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class CodeTaggingJob(Job):
@@ -11,7 +18,7 @@ class CodeTaggingJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Code tagging", on_finish=on_finish)
 
-    def _run(self, inst) -> None:
+    def _run(self, ctx: JobContext, inst: Instance) -> None:
         func_count = len(inst.kb.functions)
         for i, func in enumerate(inst.kb.functions.values()):
             if func.alignment:
@@ -20,7 +27,7 @@ class CodeTaggingJob(Job):
             func.tags = tuple(ct.tags)
 
             percentage = i / func_count * 100
-            super()._progress_callback(percentage)
+            ctx.set_progress(percentage)
 
     def __repr__(self) -> str:
         return "CodeTaggingJob"

--- a/angrmanagement/data/jobs/ddg_generation.py
+++ b/angrmanagement/data/jobs/ddg_generation.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import networkx
 
 from .job import Job
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class DDGGenerationJob(Job):
@@ -10,7 +16,7 @@ class DDGGenerationJob(Job):
         super().__init__("DDG generation")
         self._addr = addr
 
-    def _run(self, inst):
+    def _run(self, ctx: JobContext, inst: Instance):
         ddg = inst.project.analyses.VSA_DDG(vfg=inst.vfgs[self._addr], start_addr=self._addr)
         return ddg, networkx.relabel_nodes(ddg.graph, lambda n: n.insn_addr)
 

--- a/angrmanagement/data/jobs/decompile_function.py
+++ b/angrmanagement/data/jobs/decompile_function.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from angrmanagement.logic import GlobalInfo
 
 from .job import Job
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class DecompileFunctionJob(Job):
@@ -15,13 +21,13 @@ class DecompileFunctionJob(Job):
         self.function = function
         super().__init__(name="Decompiling", on_finish=on_finish, blocking=blocking)
 
-    def _run(self, inst) -> None:
+    def _run(self, ctx: JobContext, inst: Instance) -> None:
         decompiler = inst.project.analyses.Decompiler(
             self.function,
             flavor="pseudocode",
             variable_kb=inst.pseudocode_variable_kb,
             **self.kwargs,
-            progress_callback=self._progress_callback,
+            progress_callback=ctx.set_progress,
         )
         # cache the result
         inst.kb.structured_code[(self.function.addr, "pseudocode")] = decompiler.cache

--- a/angrmanagement/data/jobs/flirt_signature_recognition.py
+++ b/angrmanagement/data/jobs/flirt_signature_recognition.py
@@ -9,6 +9,7 @@ from .job import Job
 
 if TYPE_CHECKING:
     from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 _l = logging.getLogger(name=__name__)
 
@@ -21,7 +22,7 @@ class FlirtSignatureRecognitionJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Applying FLIRT signatures", on_finish=on_finish)
 
-    def _run(self, inst: Instance) -> None:
+    def _run(self, ctx: JobContext, inst: Instance) -> None:
         if inst.project.arch.name.lower() in angr.flirt.FLIRT_SIGNATURES_BY_ARCH:
             inst.project.analyses.Flirt()
         else:

--- a/angrmanagement/data/jobs/prototype_finding.py
+++ b/angrmanagement/data/jobs/prototype_finding.py
@@ -1,20 +1,26 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .job import Job
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class PrototypeFindingJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Function prototype finding", on_finish=on_finish)
 
-    def _run(self, inst) -> None:
+    def _run(self, ctx: JobContext, inst: Instance) -> None:
         func_count = len(inst.kb.functions)
         for i, func in enumerate(inst.kb.functions.values()):
             if func.is_simprocedure or func.is_plt:
                 func.find_declaration()
 
             percentage = i / func_count * 100
-            super()._progress_callback(percentage)
+            ctx.set_progress(percentage)
 
     def finish(self, inst, result) -> None:
         super().finish(inst, result)

--- a/angrmanagement/data/jobs/simgr_explore.py
+++ b/angrmanagement/data/jobs/simgr_explore.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .job import Job
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class SimgrExploreJob(Job):
@@ -14,7 +20,7 @@ class SimgrExploreJob(Job):
         self._until_callback = until_callback
         self._interrupted = False
 
-    def _run(self, inst):
+    def _run(self, ctx: JobContext, inst: Instance):
         """Run the job. Runs in the worker thread."""
 
         def until_callback(*args, **kwargs):

--- a/angrmanagement/data/jobs/simgr_step.py
+++ b/angrmanagement/data/jobs/simgr_step.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .job import Job
+
+if TYPE_CHECKING:
+    from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class SimgrStepJob(Job):
@@ -11,7 +17,7 @@ class SimgrStepJob(Job):
         self._until_branch = until_branch
         self._step_callback = step_callback
 
-    def _run(self, inst):
+    def _run(self, ctx: JobContext, inst: Instance):
         if self._until_branch:
             orig_len = len(self._simgr.active)
             if orig_len > 0:

--- a/angrmanagement/data/jobs/variable_recovery.py
+++ b/angrmanagement/data/jobs/variable_recovery.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING
 
 from angrmanagement.logic.threads import gui_thread_schedule_async
@@ -9,6 +8,7 @@ from .job import Job
 
 if TYPE_CHECKING:
     from angrmanagement.data.instance import Instance
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class VariableRecoveryJob(Job):
@@ -59,7 +59,7 @@ class VariableRecoveryJob(Job):
         callees = set(self.instance.kb.functions.callgraph.successors(func_addr))
         self.ccc.prioritize_functions({func_addr} | callees)
 
-    def _run(self, inst: Instance) -> None:
+    def _run(self, ctx: JobContext, inst: Instance) -> None:
         self.instance = inst
         self.started = True
 
@@ -77,7 +77,7 @@ class VariableRecoveryJob(Job):
             recover_variables=True,
             low_priority=True,
             cfg=inst.cfg.am_obj,
-            progress_callback=self._progress_callback,
+            progress_callback=ctx.set_progress,
             cc_callback=cc_callback,
             analyze_callsites=True,
             max_function_blocks=300,
@@ -92,14 +92,6 @@ class VariableRecoveryJob(Job):
 
     def _cc_callback(self, func_addr: int) -> None:
         gui_thread_schedule_async(self.on_variable_recovered, args=(func_addr,))
-
-    def _progress_callback(self, percentage, text: str | None = None) -> None:
-        t = time.time()
-        if self._last_progress_callback_triggered is not None and t - self._last_progress_callback_triggered < 0.2:
-            return
-        self._last_progress_callback_triggered = t
-
-        super()._progress_callback(percentage, text=text)
 
     def finish(self, inst, result) -> None:
         self.ccc = None  # essentially disabling self.prioritize_function()

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .job import Job
+
+if TYPE_CHECKING:
+    from traitlets import Instance
+
+    from angrmanagement.logic.jobmanager import JobContext
 
 
 class VFGGenerationJob(Job):
@@ -8,7 +15,7 @@ class VFGGenerationJob(Job):
         super().__init__("VFG generation")
         self._addr = addr
 
-    def _run(self, inst):
+    def _run(self, ctx: JobContext, inst: Instance):
         return inst.project.analyses.VFG(function_start=self._addr)
 
     def finish(self, inst, result) -> None:

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING
 from .job import Job
 
 if TYPE_CHECKING:
-    from traitlets import Instance
-
+    from angrmanagement.data.instance import Instance
     from angrmanagement.logic.jobmanager import JobContext
 
 

--- a/angrmanagement/logic/jobmanager.py
+++ b/angrmanagement/logic/jobmanager.py
@@ -123,21 +123,26 @@ class JobManager:
 
     # Worker callbacks
 
-    def callback_worker_progress_empty(self) -> None:
+    @staticmethod
+    def callback_worker_progress_empty() -> None:
         gui_thread_schedule(GlobalInfo.main_window.progress_done, args=())
 
-    def callback_worker_blocking_job(self) -> None:
+    @staticmethod
+    def callback_worker_blocking_job() -> None:
         if GlobalInfo.main_window is not None and GlobalInfo.main_window.workspace:
             gui_thread_schedule(GlobalInfo.main_window._progress_dialog.hide, args=())
 
-    def callback_worker_new_job(self) -> None:
+    @staticmethod
+    def callback_worker_new_job() -> None:
         gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0, True))
 
-    def callback_worker_blocking_job_2(self) -> None:
+    @staticmethod
+    def callback_worker_blocking_job_2() -> None:
         if GlobalInfo.main_window.isVisible():
             gui_thread_schedule(GlobalInfo.main_window._progress_dialog.show, args=())
 
-    def callback_worker_job_complete(self, instance: Instance, job: Job, result) -> None:
+    @staticmethod
+    def callback_worker_job_complete(instance: Instance, job: Job, result) -> None:
         gui_thread_schedule_async(job.finish, args=(instance, result))
 
     # Job callbacks

--- a/angrmanagement/logic/jobmanager.py
+++ b/angrmanagement/logic/jobmanager.py
@@ -20,6 +20,22 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+class JobContext:
+    """JobContext is a context object that is passed to each job to allow it to
+    report progress and other information back to the JobManager.
+    """
+
+    _job_manager: JobManager
+    _job: Job
+
+    def __init__(self, job_manager: JobManager, job: Job):
+        self._job_manager = job_manager
+        self._job = job
+
+    def set_progress(self, percentage: float, text: str | None = None) -> None:
+        self._job_manager.callback_job_set_progress(self._job, percentage, text)
+
+
 class JobManager:
     """JobManager is responsible for managing jobs and running them in a separate thread."""
 
@@ -28,9 +44,12 @@ class JobManager:
     jobs: list[Job]
     _jobs_queue: Queue[Job]
     current_job: Job | None
-    worker_thread: Thread
+    worker_thread: Thread | None
 
     job_worker_exception_callback: Callable[[Job, BaseException], None] | None
+
+    _gui_last_updated_at: float
+    _last_text: str | None
 
     def __init__(self, instance: Instance):
         self.instance = instance
@@ -40,6 +59,8 @@ class JobManager:
         self.current_job = None
         self.worker_thread = None
         self.job_worker_exception_callback = None
+        self._gui_last_updated_at = 0.0
+        self._last_text = None
 
         self._start_worker()
 
@@ -75,20 +96,21 @@ class JobManager:
     def _worker(self) -> None:
         while True:
             if self._jobs_queue.empty():
-                callback_worker_progress_empty()
+                self.callback_worker_progress_empty()
 
             if any(job.blocking for job in self.jobs):
-                callback_worker_blocking_job()
+                self.callback_worker_blocking_job()
 
             job = self._jobs_queue.get()
-            callback_worker_new_job()
+            self.callback_worker_new_job()
 
             if any(job.blocking for job in self.jobs):
-                callback_worker_blocking_job_2()
+                self.callback_worker_blocking_job_2()
 
             try:
                 self.current_job = job
-                result = job.run(self.instance)
+                ctx = JobContext(self, job)
+                result = job.run(ctx, self.instance)
                 self.current_job = None
             except (Exception, KeyboardInterrupt) as e:  # pylint: disable=broad-except
                 sys.last_traceback = e.__traceback__
@@ -97,30 +119,36 @@ class JobManager:
                 if self.job_worker_exception_callback is not None:
                     self.job_worker_exception_callback(job, e)
             else:
-                callback_job_complete(self.instance, job, result)
+                self.callback_worker_job_complete(self.instance, job, result)
 
-    # pylint:disable=no-self-use
-    def _set_status(self, status_text) -> None:
-        GlobalInfo.main_window.status = status_text
+    # Worker callbacks
 
+    def callback_worker_progress_empty(self) -> None:
+        gui_thread_schedule(GlobalInfo.main_window.progress_done, args=())
 
-def callback_worker_progress_empty() -> None:
-    gui_thread_schedule(GlobalInfo.main_window.progress_done, args=())
+    def callback_worker_blocking_job(self) -> None:
+        if GlobalInfo.main_window is not None and GlobalInfo.main_window.workspace:
+            gui_thread_schedule(GlobalInfo.main_window._progress_dialog.hide, args=())
 
+    def callback_worker_new_job(self) -> None:
+        gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0, True))
 
-def callback_worker_blocking_job() -> None:
-    if GlobalInfo.main_window is not None and GlobalInfo.main_window.workspace:
-        gui_thread_schedule(GlobalInfo.main_window._progress_dialog.hide, args=())
+    def callback_worker_blocking_job_2(self) -> None:
+        if GlobalInfo.main_window.isVisible():
+            gui_thread_schedule(GlobalInfo.main_window._progress_dialog.show, args=())
 
+    def callback_worker_job_complete(self, instance: Instance, job: Job, result) -> None:
+        gui_thread_schedule_async(job.finish, args=(instance, result))
 
-def callback_worker_new_job() -> None:
-    gui_thread_schedule_async(GlobalInfo.main_window.progress, args=("Working...", 0.0, True))
+    # Job callbacks
 
+    def callback_job_set_progress(self, job: Job, percentage: float, text: str | None) -> None:
+        delta = percentage - job.progress_percentage
 
-def callback_worker_blocking_job_2() -> None:
-    if GlobalInfo.main_window.isVisible():
-        gui_thread_schedule(GlobalInfo.main_window._progress_dialog.show, args=())
+        if (delta > 0.02 or self._last_text != text) and time.time() - self._gui_last_updated_at >= 0.1:
+            self._gui_last_updated_at = time.time()
+            job.progress_percentage = percentage
+            status_text = f"{job.name}: {text}" if text else job.name
+            gui_thread_schedule_async(GlobalInfo.main_window.progress, args=(status_text, percentage))
 
-
-def callback_job_complete(instance: Instance, job: Job, result) -> None:
-    gui_thread_schedule_async(job.finish, args=(instance, result))
+    # Private methods

--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -11,7 +11,7 @@ from angrmanagement.config import Conf
 from .qgraph_object import QCachedGraphicsItem
 
 if TYPE_CHECKING:
-    from traitlets import Instance
+    from angrmanagement.data.instance import Instance
 
 
 class QBlockLabel(QCachedGraphicsItem):


### PR DESCRIPTION
As a precondition for parallel jobs, I thought it would be useful to introduce a new `JobContext` type. The `JobContext` is intended to be how a job can communicate back with its host JobManager. Right now that is limited exclusively to the progress callback, but I intend for this to be how a job views if it is cancelled, set if its progress is indeterminate, etc. It will also be useful in a distant future when jobs are run in a more confined environment from angr management, such as a subprocess.