### PR TITLE
Remove redundant _run in jobs

### DIFF
--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -46,7 +46,7 @@ class CFGGenerationJob(Job):
         self._cfb = None
         self.instance = None
 
-    def _run(self, ctx: JobContext, inst: Instance):
+    def run(self, ctx: JobContext, inst: Instance):
         self.instance = inst
         exclude_region_types = {"kernel", "tls"}
         # create a temporary CFB for displaying partially analyzed binary during CFG recovery

--- a/angrmanagement/data/jobs/code_tagging.py
+++ b/angrmanagement/data/jobs/code_tagging.py
@@ -17,7 +17,7 @@ class CodeTaggingJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Code tagging", on_finish=on_finish)
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         func_count = len(inst.kb.functions)
         for i, func in enumerate(inst.kb.functions.values()):
             if func.alignment:

--- a/angrmanagement/data/jobs/ddg_generation.py
+++ b/angrmanagement/data/jobs/ddg_generation.py
@@ -16,7 +16,7 @@ class DDGGenerationJob(Job):
         super().__init__("DDG generation")
         self._addr = addr
 
-    def _run(self, ctx: JobContext, inst: Instance):
+    def run(self, _: JobContext, inst: Instance):
         ddg = inst.project.analyses.VSA_DDG(vfg=inst.vfgs[self._addr], start_addr=self._addr)
         return ddg, networkx.relabel_nodes(ddg.graph, lambda n: n.insn_addr)
 

--- a/angrmanagement/data/jobs/decompile_function.py
+++ b/angrmanagement/data/jobs/decompile_function.py
@@ -21,7 +21,7 @@ class DecompileFunctionJob(Job):
         self.function = function
         super().__init__(name="Decompiling", on_finish=on_finish, blocking=blocking)
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         decompiler = inst.project.analyses.Decompiler(
             self.function,
             flavor="pseudocode",

--- a/angrmanagement/data/jobs/dependency_analysis.py
+++ b/angrmanagement/data/jobs/dependency_analysis.py
@@ -77,7 +77,7 @@ class DependencyAnalysisJob(Job):
 
         return None, None
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         ctx.set_progress(0.0)
         self._perform(ctx, inst)
         ctx.set_progress(100.0)

--- a/angrmanagement/data/jobs/flirt_signature_recognition.py
+++ b/angrmanagement/data/jobs/flirt_signature_recognition.py
@@ -22,7 +22,7 @@ class FlirtSignatureRecognitionJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Applying FLIRT signatures", on_finish=on_finish)
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, _: JobContext, inst: Instance) -> None:
         if inst.project.arch.name.lower() in angr.flirt.FLIRT_SIGNATURES_BY_ARCH:
             inst.project.analyses.Flirt()
         else:

--- a/angrmanagement/data/jobs/job.py
+++ b/angrmanagement/data/jobs/job.py
@@ -77,9 +77,6 @@ class Job:
 
     def run(self, ctx: JobContext, inst: Instance):
         """Run the job. This method is called in a worker thread."""
-        return self._run(ctx, inst)
-
-    def _run(self, ctx: JobContext, inst: Instance):
         raise NotImplementedError
 
     def finish(self, inst: Instance, result: Any) -> None:

--- a/angrmanagement/data/jobs/loading.py
+++ b/angrmanagement/data/jobs/loading.py
@@ -39,7 +39,7 @@ class LoadTargetJob(Job):
         super().__init__("Loading target", on_finish=on_finish)
         self.target = target
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         ctx.set_progress(5)
         with self.target.build().start() as t:
             ctx.set_progress(10)
@@ -69,7 +69,7 @@ class LoadBinaryJob(Job):
         self.load_options = load_options or {}
         self.fname = fname
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         ctx.set_progress(5)
 
         load_as_blob = False
@@ -161,7 +161,7 @@ class LoadAngrDBJob(Job):
 
         self.project = None
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         ctx.set_progress(5)
 
         angrdb = AngrDB()

--- a/angrmanagement/data/jobs/prototype_finding.py
+++ b/angrmanagement/data/jobs/prototype_finding.py
@@ -13,7 +13,7 @@ class PrototypeFindingJob(Job):
     def __init__(self, on_finish=None) -> None:
         super().__init__(name="Function prototype finding", on_finish=on_finish)
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         func_count = len(inst.kb.functions)
         for i, func in enumerate(inst.kb.functions.values()):
             if func.is_simprocedure or func.is_plt:

--- a/angrmanagement/data/jobs/simgr_explore.py
+++ b/angrmanagement/data/jobs/simgr_explore.py
@@ -20,7 +20,7 @@ class SimgrExploreJob(Job):
         self._until_callback = until_callback
         self._interrupted = False
 
-    def _run(self, ctx: JobContext, inst: Instance):
+    def run(self, _: JobContext, inst: Instance):
         """Run the job. Runs in the worker thread."""
 
         def until_callback(*args, **kwargs):

--- a/angrmanagement/data/jobs/simgr_step.py
+++ b/angrmanagement/data/jobs/simgr_step.py
@@ -17,7 +17,7 @@ class SimgrStepJob(Job):
         self._until_branch = until_branch
         self._step_callback = step_callback
 
-    def _run(self, ctx: JobContext, inst: Instance):
+    def run(self, _: JobContext, inst: Instance):
         if self._until_branch:
             orig_len = len(self._simgr.active)
             if orig_len > 0:

--- a/angrmanagement/data/jobs/variable_recovery.py
+++ b/angrmanagement/data/jobs/variable_recovery.py
@@ -59,7 +59,7 @@ class VariableRecoveryJob(Job):
         callees = set(self.instance.kb.functions.callgraph.successors(func_addr))
         self.ccc.prioritize_functions({func_addr} | callees)
 
-    def _run(self, ctx: JobContext, inst: Instance) -> None:
+    def run(self, ctx: JobContext, inst: Instance) -> None:
         self.instance = inst
         self.started = True
 

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -14,7 +14,7 @@ class VFGGenerationJob(Job):
         super().__init__("VFG generation")
         self._addr = addr
 
-    def _run(self, ctx: JobContext, inst: Instance):
+    def run(self, _: JobContext, inst: Instance):
         return inst.project.analyses.VFG(function_start=self._addr)
 
     def finish(self, inst, result) -> None:


### PR DESCRIPTION
In my last PR, I removed the logic in `Job.run` that wrapped `Job._run` and moved it to the worker. Since these methods are now redundant, remove `_run` and have jobs override `run` directly.