### PR TITLE
Standardize how finish() works in jobs

### DIFF
--- a/angrmanagement/data/jobs/cfg_generation.py
+++ b/angrmanagement/data/jobs/cfg_generation.py
@@ -67,12 +67,6 @@ class CFGGenerationJob(Job):
 
         return cfg.model, cfb
 
-    def finish(self, inst, result) -> None:
-        try:
-            super().finish(inst, result)
-        except Exception:  # pylint:disable=broad-exception-caught
-            _l.error("Exception occurred in CFGGenerationJob.finish().", exc_info=True)
-
     def __repr__(self) -> str:
         return "Generating CFG"
 

--- a/angrmanagement/data/jobs/ddg_generation.py
+++ b/angrmanagement/data/jobs/ddg_generation.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class DDGGenerationJob(Job):
+    """A job that runs the VSA_DDG analysis for a function at a given address."""
+
     def __init__(self, addr: int) -> None:
         super().__init__("DDG generation", on_finish=self._finish)
         self._addr = addr

--- a/angrmanagement/data/jobs/ddg_generation.py
+++ b/angrmanagement/data/jobs/ddg_generation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import networkx
 
@@ -13,15 +13,14 @@ if TYPE_CHECKING:
 
 class DDGGenerationJob(Job):
     def __init__(self, addr: int) -> None:
-        super().__init__("DDG generation")
+        super().__init__("DDG generation", on_finish=self._finish)
         self._addr = addr
 
     def run(self, _: JobContext, inst: Instance):
         ddg = inst.project.analyses.VSA_DDG(vfg=inst.vfgs[self._addr], start_addr=self._addr)
         return ddg, networkx.relabel_nodes(ddg.graph, lambda n: n.insn_addr)
 
-    def finish(self, inst, result) -> None:
-        super().finish(inst, result)
+    def _finish(self, inst: Instance, result: Any) -> None:
         inst.ddgs[self._addr] = result
 
     def __repr__(self) -> str:

--- a/angrmanagement/data/jobs/prototype_finding.py
+++ b/angrmanagement/data/jobs/prototype_finding.py
@@ -22,8 +22,5 @@ class PrototypeFindingJob(Job):
             percentage = i / func_count * 100
             ctx.set_progress(percentage)
 
-    def finish(self, inst, result) -> None:
-        super().finish(inst, result)
-
     def __repr__(self) -> str:
         return "PrototypeFindingJob"

--- a/angrmanagement/data/jobs/simgr_explore.py
+++ b/angrmanagement/data/jobs/simgr_explore.py
@@ -10,12 +10,11 @@ if TYPE_CHECKING:
 
 
 class SimgrExploreJob(Job):
-    def __init__(self, simgr, find=None, avoid=None, step_callback=None, until_callback=None, callback=None) -> None:
+    def __init__(self, simgr, find=None, avoid=None, step_callback=None, until_callback=None) -> None:
         super().__init__("Simulation manager exploring")
         self._simgr = simgr
         self._find = find
         self._avoid = avoid
-        self._callback = callback
         self._step_callback = step_callback
         self._until_callback = until_callback
         self._interrupted = False
@@ -28,10 +27,6 @@ class SimgrExploreJob(Job):
 
         self._simgr.explore(find=self._find, avoid=self._avoid, step_func=self._step_callback, until=until_callback)
         return self._simgr
-
-    def finish(self, inst, result) -> None:
-        super().finish(inst, result)
-        self._callback(result)
 
     def __repr__(self) -> str:
         return f"Exploring {self._simgr!r}"

--- a/angrmanagement/data/jobs/simgr_explore.py
+++ b/angrmanagement/data/jobs/simgr_explore.py
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 
 
 class SimgrExploreJob(Job):
-    def __init__(self, simgr, find=None, avoid=None, step_callback=None, until_callback=None) -> None:
-        super().__init__("Simulation manager exploring")
+    """A job that runs the explore method of a simulation manager."""
+
+    def __init__(self, simgr, find=None, avoid=None, step_callback=None, until_callback=None, on_finish=None) -> None:
+        super().__init__("Simulation manager exploring", on_finish=on_finish)
         self._simgr = simgr
         self._find = find
         self._avoid = avoid
@@ -41,4 +43,4 @@ class SimgrExploreJob(Job):
         def callback(result) -> None:
             simgr.am_event(src="job_done", job="explore", result=result)
 
-        return cls(simgr, callback=callback, **kwargs)
+        return cls(simgr, on_finish=callback, **kwargs)

--- a/angrmanagement/data/jobs/simgr_step.py
+++ b/angrmanagement/data/jobs/simgr_step.py
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 
 
 class SimgrStepJob(Job):
-    def __init__(self, simgr, until_branch: bool = False, step_callback=None) -> None:
-        super().__init__("Simulation manager stepping")
+    """A job that runs the step method of the simulation manager."""
+
+    def __init__(self, simgr, until_branch: bool = False, step_callback=None, on_finish=None) -> None:
+        super().__init__("Simulation manager stepping", on_finish=on_finish)
         self._simgr = simgr
         self._until_branch = until_branch
         self._step_callback = step_callback
@@ -40,4 +42,4 @@ class SimgrStepJob(Job):
         def callback(result) -> None:
             simgr.am_event(src="job_done", job="step", result=result)
 
-        return cls(simgr, callback=callback, **kwargs)
+        return cls(simgr, on_finish=callback, **kwargs)

--- a/angrmanagement/data/jobs/simgr_step.py
+++ b/angrmanagement/data/jobs/simgr_step.py
@@ -10,10 +10,9 @@ if TYPE_CHECKING:
 
 
 class SimgrStepJob(Job):
-    def __init__(self, simgr, callback=None, until_branch: bool = False, step_callback=None) -> None:
+    def __init__(self, simgr, until_branch: bool = False, step_callback=None) -> None:
         super().__init__("Simulation manager stepping")
         self._simgr = simgr
-        self._callback = callback
         self._until_branch = until_branch
         self._step_callback = step_callback
 
@@ -29,11 +28,6 @@ class SimgrStepJob(Job):
             self._simgr.prune()
 
         return self._simgr
-
-    def finish(self, inst, result) -> None:
-        super().finish(inst, result)
-        if self._callback is not None:
-            self._callback(result)
 
     def __repr__(self) -> str:
         if self._until_branch:

--- a/angrmanagement/data/jobs/variable_recovery.py
+++ b/angrmanagement/data/jobs/variable_recovery.py
@@ -90,12 +90,10 @@ class VariableRecoveryJob(Job):
         )
         self.ccc.work()
 
+        self.ccc = None
+
     def _cc_callback(self, func_addr: int) -> None:
         gui_thread_schedule_async(self.on_variable_recovered, args=(func_addr,))
-
-    def finish(self, inst, result) -> None:
-        self.ccc = None  # essentially disabling self.prioritize_function()
-        super().finish(inst, result)
 
     def __repr__(self) -> str:
         return "<Variable Recovery Job>"

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .job import Job
 
@@ -11,14 +11,13 @@ if TYPE_CHECKING:
 
 class VFGGenerationJob(Job):
     def __init__(self, addr: int) -> None:
-        super().__init__("VFG generation")
+        super().__init__("VFG generation", on_finish=self._finish)
         self._addr = addr
 
     def run(self, _: JobContext, inst: Instance):
         return inst.project.analyses.VFG(function_start=self._addr)
 
-    def finish(self, inst, result) -> None:
-        super().finish(inst, result)
+    def _finish(self, inst: Instance, result: Any) -> None:
         inst.vfgs[self._addr] = result
 
     def __repr__(self) -> str:

--- a/angrmanagement/data/jobs/vfg_generation.py
+++ b/angrmanagement/data/jobs/vfg_generation.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 
 class VFGGenerationJob(Job):
+    """A job that runs the VFG analysis for a function at a given address."""
+
     def __init__(self, addr: int) -> None:
         super().__init__("VFG generation", on_finish=self._finish)
         self._addr = addr


### PR DESCRIPTION
There were several classes that had overridden finish() or implemented their own callback behavior. This standardizes it.