### PR TITLE
Fix job cancellation methods that depended on job.keyboard_interrupt()

### DIFF
--- a/angrmanagement/logic/debugger/simgr.py
+++ b/angrmanagement/logic/debugger/simgr.py
@@ -97,4 +97,4 @@ class SimulationDebugger(Debugger):
     def halt(self) -> None:
         for job in self.instance.job_manager.jobs:
             if isinstance(job, SimgrExploreJob):
-                job.keyboard_interrupt()
+                self.workspace.main_instance.job_manager.cancel_job(job)

--- a/angrmanagement/logic/jobmanager.py
+++ b/angrmanagement/logic/jobmanager.py
@@ -137,6 +137,12 @@ class JobManager:
         self.jobs.append(job)
         self.jobs_queue.put(job)
 
+    def cancel_job(self, job: Job) -> None:
+        if job in self.jobs:
+            self.jobs.remove(job)
+        if self.worker_thread is not None and self.worker_thread.current_job == job:
+            self.worker_thread.keyboard_interrupt()
+
     def interrupt_current_job(self) -> None:
         """Notify the current running job that the user requested an interrupt. The job may ignore it."""
         # Due to thread scheduling, current_job reference *must* first be saved on the stack. Accessing self.current_job

--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -320,7 +320,7 @@ class MainWindow(QMainWindow):
                 return
             for job in self.workspace.main_instance.job_manager.jobs:
                 if job.blocking:
-                    job.keyboard_interrupt()
+                    self.workspace.main_instance.job_manager.interrupt_current_job()
                     break
 
         self._progress_dialog.canceled.connect(on_cancel)


### PR DESCRIPTION
In previous commits I broke some of the ways jobs are cancelled. This restores those methods.