### PR TITLE
Fix exceptions raised from async events going unreported

### DIFF
--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -37,6 +37,7 @@ from angrmanagement.data.library_docs import LibraryDocs
 from angrmanagement.errors import InvalidURLError, UnexpectedStatusCodeError
 from angrmanagement.logic import GlobalInfo
 from angrmanagement.logic.commands import BasicCommand
+from angrmanagement.logic.threads import ExecuteCodeEvent
 from angrmanagement.ui.views import DisassemblyView
 from angrmanagement.utils.env import app_root, is_pyinstaller
 from angrmanagement.utils.io import download_url, isurl
@@ -616,13 +617,13 @@ class MainWindow(QMainWindow):
         event.accept()
 
     def event(self, event):
-        if event.type() == QEvent.User:
-            # our event callback
-
+        if event.type() == QEvent.User and isinstance(event, ExecuteCodeEvent):
             try:
                 event.result = event.execute()
             except Exception as ex:  # pylint:disable=broad-except
                 event.exception = ex
+                if event.async_:
+                    _l.exception("Exception occurred in an async job:")
             event.event.set()
 
             return True


### PR DESCRIPTION
Previously the exception would be set in the event object and then deallocated. Now if the `async_` param is set, it will log the exception so that there is some user/developer feedback.