### PR TITLE
Update angr-management.spec to support library changes in pyzmq

### DIFF
--- a/angr-management.spec
+++ b/angr-management.spec
@@ -10,6 +10,7 @@ import pyvex
 import pyxdia
 import unicorn
 import z3
+import zmq
 
 sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 
@@ -26,6 +27,7 @@ PYVEX_BASE = pathlib.Path(pyvex.__file__).parent
 PYXDIA_BASE = pathlib.Path(pyxdia.__file__).parent
 UNICORN_BASE = pathlib.Path(unicorn.__file__).parent
 Z3_BASE = pathlib.Path(z3.__file__).parent
+ZMQ_BASE = pathlib.Path(zmq.__file__).parent
 
 block_cipher = None
 icon = str(AM_BASE / "angrmanagement" / "resources" / "images" / "angr.ico")
@@ -48,6 +50,7 @@ included_data = [
     (str(CAPSTONE_BASE / "lib"), "capstone/lib"),
     (str(Z3_BASE / "lib"), "z3/lib"),
     (str(PYXDIA_BASE / "bin"), "pyxdia/bin"),
+    (str(ZMQ_BASE / "backend" / "cffi"), "zmq/backend/cffi"),
 ]
 
 
@@ -65,11 +68,6 @@ if sys.platform == "linux":
 
     included_data.append((str(ARCHR_BASE / "implants"), "archr/implants"))
     included_data.append((str(KEYSTONE_BASE), "keystone"))
-
-if sys.platform != "darwin":
-    import zmq
-
-    ZMQ_BASE = pathlib.Path(zmq.__file__).parent
     included_data.append((str(ZMQ_BASE / ".." / "pyzmq.libs"), "pyzmq.libs"))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     pygments
     ipykernel>=4.1  # not a real dependency, but require the reference kernel
     qtpy>=2.4.0
-    pyzmq>=17.1
+    pyzmq>=26.1.0
     packaging
 
 python_requires = >=3.10


### PR DESCRIPTION
The `pyzmq.libs` directory only exists on linux now. I also explicitly added the cffi backends to make sure those are included, but I'm not sure if this is strictly necessary (I think if we don't it may fall back to a `select()` backend, or its possible but unlikely that pyinstaller's heuristics do manage to find the library in the first place).