### PR TITLE
Fix incorrect args being passed to SimgrStepJob

### DIFF
--- a/angrmanagement/ui/widgets/qsimulation_managers.py
+++ b/angrmanagement/ui/widgets/qsimulation_managers.py
@@ -246,7 +246,7 @@ class QSimulationManagers(QFrame):
     def _on_step_clicked(self) -> None:
         if not self.simgr.am_none:
             self.workspace.job_manager.add_job(
-                SimgrStepJob.create(
+                SimgrStepJob(
                     self.instance,
                     self.simgr.am_obj,
                     until_branch=False,
@@ -257,7 +257,7 @@ class QSimulationManagers(QFrame):
     def _on_step_until_branch_clicked(self) -> None:
         if not self.simgr.am_none:
             self.workspace.job_manager.add_job(
-                SimgrStepJob.create(
+                SimgrStepJob(
                     self.instance,
                     self.simgr.am_obj,
                     until_branch=True,


### PR DESCRIPTION
The `create` function added an extra layer of indirection that caused arguments not to get refactored correctly. It doesn't do anything the constructor already supports, so just merge the code into the constructor.