### PR TITLE
Add rpyc dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     pyobjc-framework-Cocoa;platform_system == "Darwin"
     thefuzz[speedup]
     binsync==4.0.0
+    rpyc
 
     # requirements for vendorized qtconsole package
     traitlets!=5.2.1,!=5.2.2


### PR DESCRIPTION
This was previously getting installed with angr and implicitly depended on until last week.