### PR TITLE
QDecompilationOptions: Add search box icon and placeholder text

### DIFF
--- a/angrmanagement/ui/icons.py
+++ b/angrmanagement/ui/icons.py
@@ -26,6 +26,7 @@ NAME_TO_QTAWESOME_NAME = {
     "preferences": "fa.gear",
     "pseudocode-view": "msc.json",
     "run-analysis": "mdi.arrow-right-drop-circle",
+    "search": "fa5s.search",
     "strings-view": "msc.symbol-string",
     "traces-view": "mdi.go-kart-track",
     "types-view": "msc.symbol-class",

--- a/angrmanagement/ui/widgets/qdecomp_options.py
+++ b/angrmanagement/ui/widgets/qdecomp_options.py
@@ -19,6 +19,9 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from angrmanagement.config import Conf
+from angrmanagement.ui.icons import icon
+
 if TYPE_CHECKING:
     from angrmanagement.data.instance import Instance
     from angrmanagement.ui.views.code_view import CodeView
@@ -210,6 +213,11 @@ class QDecompilationOptions(QWidget):
 
         # search box
         self._search_box = QLineEdit()
+        self._search_box.setClearButtonEnabled(True)
+        self._search_box.addAction(
+            icon("search", color=Conf.palette_placeholdertext), QLineEdit.ActionPosition.LeadingPosition
+        )
+        self._search_box.setPlaceholderText("Filter by name...")
         self._search_box.textChanged.connect(self._on_search_box_text_changed)
 
         # tree view

--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -5,7 +5,6 @@ import string
 from functools import partial
 from typing import TYPE_CHECKING
 
-import qtawesome as qta
 from angr.analyses.code_tagging import CodeTags
 from cle.backends.uefi_firmware import UefiPE
 from PySide6.QtCore import SIGNAL, QAbstractTableModel, QEvent, Qt
@@ -24,6 +23,7 @@ from PySide6.QtWidgets import (
 
 from angrmanagement.config import Conf
 from angrmanagement.data.instance import Instance, ObjectContainer
+from angrmanagement.ui.icons import icon
 from angrmanagement.ui.menus.function_context_menu import FunctionContextMenu
 from angrmanagement.ui.toolbars import FunctionTableToolbar
 
@@ -530,7 +530,7 @@ class QFunctionTable(QWidget):
         self._filter_box = QFunctionTableFilterBox(self)
         self._filter_box.setClearButtonEnabled(True)
         self._filter_box.addAction(
-            qta.icon("fa5s.search", color=Conf.palette_placeholdertext), QLineEdit.ActionPosition.LeadingPosition
+            icon("search", color=Conf.palette_placeholdertext), QLineEdit.ActionPosition.LeadingPosition
         )
         self._filter_box.setPlaceholderText("Filter by name...")
         self._filter_box.textChanged.connect(self._on_filter_box_text_changed)


### PR DESCRIPTION
Add a hint for the user indicating they can filter all the decomp options by name using the text box at the top of the options pane

![image](https://github.com/user-attachments/assets/76ae1719-9fb9-4ec9-b520-2481f1dc1161)
