### PR TITLE
Upgrade macos 12 pyinstaller build to macos 13

### DIFF
--- a/.github/workflows/pyinstaller-build.yml
+++ b/.github/workflows/pyinstaller-build.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - windows-2022
-          - macos-12
+          - macos-13
           - macos-14
       fail-fast: false
     name: Build on ${{ matrix.os }}
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-12
+          - macos-13
           - macos-14
       fail-fast: false
     name: Test on ${{ matrix.os }}


### PR DESCRIPTION
This version is different than the rest of the angr repos because we specifically need an x86_64 build, and macos 13 is the last macOS version on github actions that is free for x86.