### PR TITLE
Bump binsync

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     tomlkit
     pyobjc-framework-Cocoa;platform_system == "Darwin"
     thefuzz[speedup]
-    binsync==5.2.0
+    binsync==5.2.1
     rpyc
 
     # requirements for vendorized qtconsole package

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     tomlkit
     pyobjc-framework-Cocoa;platform_system == "Darwin"
     thefuzz[speedup]
-    binsync==5.2.1
+    binsync==5.2.2
     rpyc
 
     # requirements for vendorized qtconsole package


### PR DESCRIPTION
Fixes the following bug:
```
Exception in thread Thread-15 (_commit_hook_based_changes):
Traceback (most recent call last):
  File "D:\My Program Files\Python313\Lib\threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "C:venvs\angr\Lib\site-packages\ipykernel\ipkernel.py", line 766, in run_closure
    _threading_Thread_run(self)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "D:\My Program Files\Python313\Lib\threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:venvs\angr\Lib\site-packages\binsync\controller.py", line 454, in _commit_hook_based_changes
    self.commit_artifact(*args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "C:venvs\angr\Lib\site-packages\binsync\controller.py", line 34, in _init_check
    raise RuntimeError("Please connect to a repo first.")
RuntimeError: Please connect to a repo first.
```