### PR TITLE
pyproject.toml: Drop angr package 'pcode' dependency selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pyinstaller = [
   "pyinstaller==6.14.1",
   "pillow;platform_system == \"Darwin\"",
   "keystone-engine",
-  "angr[pcode,unicorn]",
+  "angr[unicorn]",
   "cle[ar,minidump,uefi,xbe,pdb]",
 ]
 testing = [


### PR DESCRIPTION
P-Code support is no longer an optional feature of angr, it is universally supported.