### PR TITLE
Fix empty registers in register viewer

### DIFF
--- a/angrmanagement/ui/widgets/qast_viewer.py
+++ b/angrmanagement/ui/widgets/qast_viewer.py
@@ -206,7 +206,7 @@ class QASTViewer(QFrame):
                 self._size_label.setText(f"[{len(ast) // 8}]")  # in bytes
             if not ast.symbolic:
                 format = "%02x" if self._byte_format is None else self._byte_format
-                self._ast_str = format % self._ast._model_concrete.value
+                self._ast_str = format % claripy.backends.concrete.convert(ast).value
             else:
                 # symbolic
                 if isinstance(ast, claripy.ast.BV) and ast.op == "BVS":


### PR DESCRIPTION
Fix https://github.com/angr/angr-management/issues/1495

caused in https://github.com/angr/claripy/pull/434

registers of concrete value should be displayed correctly after this fix:

<img width="351" height="1092" alt="image" src="https://github.com/user-attachments/assets/f93fde23-dcf6-41b8-9818-00fb9d5fd06e" />
