### PR TITLE
CallingConventionRecoveryConfiguration::get_default_workers: Return 0…

### DIFF
--- a/angrmanagement/data/analysis_options.py
+++ b/angrmanagement/data/analysis_options.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 import angr
 from angr.misc.testing import is_testing
 
-
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 


### PR DESCRIPTION
… when testing

Fixes recently introduced deadlock on CI