### PR TITLE
pyproject.toml: Remove cle optional dependency specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ pyinstaller = [
   "pillow;platform_system == \"Darwin\"",
   "keystone-engine",
   "angr[unicorn];platform_system != \"Darwin\"",
-  "cle[ar,minidump,uefi,xbe,pdb]",
 ]
 testing = [
   "coverage",


### PR DESCRIPTION
They have been designated as required now.

See https://github.com/angr/cle/pull/631