### PR TITLE
Allow failing on macos-15-intel to allow nightly builds to pass

### DIFF
--- a/.github/workflows/pyinstaller-build.yml
+++ b/.github/workflows/pyinstaller-build.yml
@@ -165,4 +165,4 @@ jobs:
             fi
           done
           exit 1
-        continue-on-error: ${{ matrix.os == 'macos-15' }}
+        continue-on-error: ${{ startsWith(matrix.os, 'macos-15') }}


### PR DESCRIPTION
This has been causing the nightly builds to fail, and we have already been allowing it for arm macos. We need to find a better way to do this in the future.