### PR TITLE
Fix UberEnginePcode being selected for VEX arches

### DIFF
--- a/angrmanagement/data/jobs/loading.py
+++ b/angrmanagement/data/jobs/loading.py
@@ -80,7 +80,7 @@ class LoadBinaryJob(InstanceJob):
             return
 
         engine = None
-        if hasattr(new_load_options["arch"], "pcode_arch"):
+        if isinstance(new_load_options.get("arch"), archinfo.ArchPcode):
             engine = angr.engines.UberEnginePcode
 
         self.load_options.update(new_load_options)


### PR DESCRIPTION
This fixes the issue in https://github.com/angr/angr-management/pull/1573. After the archinfo change, the heuristic we were using to determine if an arch was a pcode arch was to see if the parameter was defined, but now that name is a function defined on the base class. So let's just check directly instead. 