### PR TITLE
JumpTo: Don't call show() in constructor

### DIFF
--- a/angrmanagement/ui/dialogs/jumpto.py
+++ b/angrmanagement/ui/dialogs/jumpto.py
@@ -28,8 +28,6 @@ class JumpTo(QDialog):
 
         self.setLayout(self.main_layout)
 
-        self.show()
-
     #
     # Private methods
     #

--- a/angrmanagement/ui/views/code_view.py
+++ b/angrmanagement/ui/views/code_view.py
@@ -443,7 +443,7 @@ class CodeView(FunctionView):
 
     def popup_jumpto_dialog(self) -> None:
         view = self.workspace._get_or_create_view("disassembly", DisassemblyView)
-        JumpTo(view, parent=self).exec_()
+        JumpTo(view, parent=self).show()
         view.decompile_current_function()
 
     def jump_forward(self) -> None:

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -459,7 +459,7 @@ class DisassemblyView(SynchronizedFunctionView):
             mnu.exec_(QCursor.pos())
 
     def popup_jumpto_dialog(self) -> None:
-        JumpTo(self, parent=self).exec_()
+        JumpTo(self, parent=self).show()
 
     def popup_rename_label_dialog(self) -> None:
         label_addr_tpl = self._address_in_selection()

--- a/angrmanagement/ui/views/hex_view.py
+++ b/angrmanagement/ui/views/hex_view.py
@@ -1821,7 +1821,7 @@ class HexView(SynchronizedInstanceView):
         """
         Display 'Jump To' dialog.
         """
-        JumpTo(self, parent=self).exec_()
+        JumpTo(self, parent=self).show()
 
     def jump_to(self, addr: int) -> bool:
         """


### PR DESCRIPTION
Fixes recent (PySide6>=6.10.0?) issue where JumpTo dialog is displayed but cannot be interacted with