### PR TITLE
Check if cached object is outdated

### DIFF
--- a/angrmanagement/ui/widgets/qblock.py
+++ b/angrmanagement/ui/widgets/qblock.py
@@ -58,6 +58,7 @@ class QBlock(QCachedGraphicsItem):
         self.func_addr = func_addr
         self.disasm_view = disasm_view
         self.disasm = disasm
+        self.disassembly_level = disasm_view.disassembly_level
         self.infodock = infodock
         self.variable_manager = infodock.variable_manager
         self.addr = addr

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -488,12 +488,33 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         self._offset = offset
         self._start_line_in_object = start_line_in_object
 
+    @staticmethod
+    def _validate_cached_qobj(obj, cached_qobj: QLinearBlock | QMemoryDataBlock | QUnknownBlock) -> bool:
+        if isinstance(obj, Block) and isinstance(cached_qobj, QLinearBlock):
+            for cached_node in cached_qobj.cfg_nodes:
+                if cached_node.addr == obj.addr and cached_node.size == obj.size:
+                    return True
+
+        if isinstance(obj, MemoryData) and isinstance(cached_qobj, QMemoryDataBlock):
+            return cached_qobj.memory_data.size == obj.size
+
+        if isinstance(obj, Unknown) and isinstance(cached_qobj, QUnknownBlock):
+            return cached_qobj.bytes == obj.bytes
+
+        return False
+
     def _obj_to_paintable(
         self, obj_addr, obj, use_cache=True
     ) -> tuple[bool, None | QLinearBlock | QMemoryDataBlock | QUnknownBlock]:
         if use_cache and obj_addr in self.objects:
-            # print("Cached!")
-            return True, self.objects[obj_addr]
+            cached_qobj = self.objects[obj_addr]
+            if self._validate_cached_qobj(obj, cached_qobj):
+                return True, cached_qobj
+
+            # Cached object is outdated, delete it
+            cached_qobj.remove_children_from_scene()
+            self.scene.removeItem(cached_qobj)
+            del self.objects[obj_addr]
 
         if isinstance(obj, Block):
             cfg_node = self.cfg.get_any_node(obj_addr, force_fastpath=True)
@@ -519,7 +540,7 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
                                     disasm,
                                     self.disasm_view.infodock,
                                     obj.addr,
-                                    ail_obj,
+                                    [ail_obj],
                                     None,
                                 )
                     else:

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -491,9 +491,9 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
     @staticmethod
     def _validate_cached_qobj(obj, cached_qobj: QLinearBlock | QMemoryDataBlock | QUnknownBlock) -> bool:
         if isinstance(obj, Block) and isinstance(cached_qobj, QLinearBlock):
-            for cached_node in cached_qobj.cfg_nodes:
-                if cached_node.addr == obj.addr and cached_node.size == obj.size:
-                    return True
+            obj_insns = set(obj.instruction_addrs)
+            cached_insns = set(cached_qobj.addr_to_insns.keys())
+            return obj_insns == cached_insns
 
         if isinstance(obj, MemoryData) and isinstance(cached_qobj, QMemoryDataBlock):
             return cached_qobj.memory_data.size == obj.size

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -488,9 +488,11 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         self._offset = offset
         self._start_line_in_object = start_line_in_object
 
-    @staticmethod
-    def _validate_cached_qobj(obj, cached_qobj: QLinearBlock | QMemoryDataBlock | QUnknownBlock) -> bool:
+    def _validate_cached_qobj(self, obj, cached_qobj: QLinearBlock | QMemoryDataBlock | QUnknownBlock) -> bool:
         if isinstance(obj, Block) and isinstance(cached_qobj, QLinearBlock):
+            if self._disassembly_level != cached_qobj.disassembly_level:
+                return False
+
             obj_insns = set(obj.instruction_addrs)
             cached_insns = set(cached_qobj.addr_to_insns.keys())
             return obj_insns == cached_insns

--- a/tests/test_qlinear_viewer.py
+++ b/tests/test_qlinear_viewer.py
@@ -1,0 +1,84 @@
+# pylint:disable=missing-class-docstring,wrong-import-order
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+import angr
+from common import AngrManagementTestCase, test_location
+
+from angrmanagement.ui.views import DisassemblyView
+from angrmanagement.ui.widgets import DisassemblyLevel
+
+
+class TestQLinearViewer(AngrManagementTestCase):
+    def test_disassembly_level_change(self):
+        main = self.main
+        binpath = os.path.join(test_location, "x86_64", "fauxware")
+        main.workspace.main_instance.project.am_obj = angr.Project(binpath, auto_load_libs=False)
+        main.workspace.main_instance.project.am_event()
+        main.workspace.job_manager.join_all_jobs()
+
+        func = main.workspace.main_instance.project.kb.functions["main"]
+        assert func is not None
+
+        # load the disassembly view
+        disasm_view = main.workspace._get_or_create_view("disassembly", DisassemblyView)
+        disasm_view.display_linear_viewer()
+        disasm_view.display_function(func)
+
+        # make sure function block is in cache
+        assert func.addr in disasm_view.linear_viewer.objects
+        assert disasm_view.linear_viewer.objects[func.addr] is not None
+        assert disasm_view.linear_viewer.objects[func.addr].disassembly_level is DisassemblyLevel.MachineCode
+
+        # change disassembly level to LifterIR
+        disasm_view.set_disassembly_level_lifter_ir()
+        main.workspace.job_manager.join_all_jobs()
+        disasm_view.display_function(func)
+
+        # the block should be reloaded and the disassembly level should be updated
+        assert func.addr in disasm_view.linear_viewer.objects
+        assert disasm_view.linear_viewer.objects[func.addr] is not None
+        assert disasm_view.linear_viewer.objects[func.addr].disassembly_level is DisassemblyLevel.LifterIR
+
+    def test_cfb_update(self):
+        main = self.main
+        binpath = os.path.join(test_location, "x86_64", "fauxware")
+        main.workspace.main_instance.project.am_obj = angr.Project(binpath, auto_load_libs=False)
+        main.workspace.main_instance.project.am_event()
+        main.workspace.job_manager.join_all_jobs()
+
+        func = main.workspace.main_instance.project.kb.functions["main"]
+        assert func is not None
+
+        # load the disassembly view
+        disasm_view = main.workspace._get_or_create_view("disassembly", DisassemblyView)
+        disasm_view.display_linear_viewer()
+        disasm_view.display_function(func)
+
+        # make sure function block is in cache
+        assert func.addr in disasm_view.linear_viewer.objects
+        assert disasm_view.linear_viewer.objects[func.addr] is not None
+        assert len(disasm_view.linear_viewer.objects[func.addr].addr_to_insns) == 9
+
+        # select the third instruction of the function
+        disasm_view.infodock.select_instruction(func.addr + 4)
+        assert len(disasm_view.infodock.selected_insns) == 1
+        assert disasm_view.infodock.selected_insns == {func.addr + 4}
+
+        # undefine third instruction to trigger cfb update
+        disasm_view.undefine_code()
+        main.workspace.job_manager.join_all_jobs()
+
+        disasm_view.display_function(func)
+
+        # the block should be updated to reflect removed instructions
+        assert func.addr in disasm_view.linear_viewer.objects
+        assert disasm_view.linear_viewer.objects[func.addr] is not None
+        assert len(disasm_view.linear_viewer.objects[func.addr].addr_to_insns) == 2
+
+
+if __name__ == "__main__":
+    unittest.main(argv=sys.argv)


### PR DESCRIPTION
- Adds check for cached objects to make sure they are not outdated.
- Removes outdated cached objects.
- `ail_obj` is sent as a list while generating `QLinearBlock` as `_init_ail_block_widgets` iterates over `cfg_nodes`.
- Fixes #1554  

If the check looks good, I'll work on testcases.