### PR TITLE
QLinearViewer: Dont skip zero sized objects

### DIFF
--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -405,7 +405,7 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         y = -start_line * self._line_height
 
         for obj_addr, obj in self.cfb.floor_items(addr=addr):
-            if obj_addr + obj.size <= addr:
+            if obj_addr + obj.size <= addr and (obj.size > 0 or obj_addr < addr):
                 # top_obj_addr lands after the current object; let's move on to the next object instead
                 continue
 


### PR DESCRIPTION
- Adds check to make sure zero-sized objects are not skipped while rendering.
- Resolves #1300 