### PR TITLE
DisassemblyView: Fix type hint for current_graph, remove unused import

### DIFF
--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -39,7 +39,6 @@ from angrmanagement.ui.widgets import (
     QDisassemblyGraph,
     QFindAddrAnnotation,
     QLinearDisassembly,
-    QLinearDisassemblyView,
 )
 from angrmanagement.ui.widgets.block_code_objects import QVariableObj
 from angrmanagement.ui.widgets.qinst_annotation import QBreakAnnotation, QHookAnnotation
@@ -215,7 +214,7 @@ class DisassemblyView(SynchronizedFunctionView):
             # TODO: Rerun the variable recovery analysis and update the current view
 
     @property
-    def current_graph(self) -> QLinearDisassemblyView | QDisassemblyGraph:
+    def current_graph(self) -> QLinearDisassembly | QDisassemblyGraph:
         """
         Return the current disassembly control, either linear viewer or flow graph.
 


### PR DESCRIPTION
- `current_graph` can be of type `QLinearDisassembly` and not `QLinearDisassemblyView`.
- `QLinearDisassemblyView` is never used, so dont import it.