### PR TITLE
LinearDisassembly: Show alignment function as alignment_chunk and not with complete disassembly

### DIFF
--- a/angrmanagement/config/config_manager.py
+++ b/angrmanagement/config/config_manager.py
@@ -194,6 +194,7 @@ ENTRIES = [
     CE("disasm_view_branch_target_text_color", QColor, QColor(0x80, 0x80, 0x00)),
     CE("disasm_view_comment_color", QColor, QColor(0x37, 0x3D, 0x3F, 0xFF)),
     CE("disasm_view_ir_default_color", QColor, QColor(0x80, 0x80, 0x80)),
+    CE("disasm_view_alignment_color", QColor, QColor(0x00, 0x60, 0x60)),
     CE("disasm_view_label_color", QColor, QColor(0x00, 0x00, 0x80)),
     CE("disasm_view_label_highlight_color", QColor, QColor(0xF0, 0xF0, 0xBF)),
     CE("disasm_view_target_addr_color", QColor, QColor(0x00, 0x00, 0xFF)),

--- a/angrmanagement/ui/widgets/qalignment_block.py
+++ b/angrmanagement/ui/widgets/qalignment_block.py
@@ -18,12 +18,13 @@ class QAlignmentBlock(QCachedGraphicsItem):
 
     SPACING = 20
 
-    def __init__(self, instance: Instance, addr: int, size: int, parent=None) -> None:
+    def __init__(self, instance: Instance, addr: int, size: int, disasm_view, parent=None) -> None:
         super().__init__(parent=parent)
 
         self.instance = instance
         self.addr = addr
         self.size = size
+        self.disasm_view = disasm_view
 
         self._width = 0
         self._height = 0
@@ -36,6 +37,14 @@ class QAlignmentBlock(QCachedGraphicsItem):
     #
     # Public methods
     #
+
+    def refresh(self) -> None:
+        self._layout_items_and_update_size()
+
+    def setVisible(self, visible) -> None:
+        super().setVisible(visible)
+        self._addr_item.setVisible(visible and self.disasm_view.show_address)
+        self._content_item.setVisible(visible)
 
     def paint(self, painter, option, widget=None) -> None:  # pylint: disable=unused-argument
         pass
@@ -77,9 +86,13 @@ class QAlignmentBlock(QCachedGraphicsItem):
     def _layout_items_and_update_size(self) -> None:
         x, y = 0, Conf.disasm_font_height
 
-        self._addr_item.setPos(x, y)
-        x += self._addr_item.boundingRect().width()
-        x += self.SPACING
+        if self.disasm_view.show_address:
+            self._addr_item.setVisible(True)
+            self._addr_item.setPos(x, y)
+            x += self._addr_item.boundingRect().width()
+            x += self.SPACING
+        else:
+            self._addr_item.setVisible(False)
 
         self._content_item.setPos(x, y)
 

--- a/angrmanagement/ui/widgets/qalignment_block.py
+++ b/angrmanagement/ui/widgets/qalignment_block.py
@@ -10,16 +10,18 @@ from angrmanagement.config import Conf
 from .qgraph_object import QCachedGraphicsItem
 
 if TYPE_CHECKING:
-    from angrmanagement.ui.workspace import Workspace
+    from angrmanagement.data.instance import Instance
 
 
 class QAlignmentBlock(QCachedGraphicsItem):
+    """Renders an alignment function as a single summary line in the linear disassembly view."""
+
     SPACING = 20
 
-    def __init__(self, workspace: Workspace, addr: int, size: int, parent=None) -> None:
+    def __init__(self, instance: Instance, addr: int, size: int, parent=None) -> None:
         super().__init__(parent=parent)
 
-        self.workspace = workspace
+        self.instance = instance
         self.addr = addr
         self.size = size
 
@@ -35,7 +37,7 @@ class QAlignmentBlock(QCachedGraphicsItem):
     # Public methods
     #
 
-    def paint(self, painter, option, widget) -> None:  # pylint: disable=unused-argument
+    def paint(self, painter, option, widget=None) -> None:  # pylint: disable=unused-argument
         pass
 
     def _boundingRect(self):

--- a/angrmanagement/ui/widgets/qalignment_block.py
+++ b/angrmanagement/ui/widgets/qalignment_block.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QRectF
+from PySide6.QtWidgets import QGraphicsSimpleTextItem
+
+from angrmanagement.config import Conf
+
+from .qgraph_object import QCachedGraphicsItem
+
+if TYPE_CHECKING:
+    from angrmanagement.ui.workspace import Workspace
+
+
+class QAlignmentBlock(QCachedGraphicsItem):
+    SPACING = 20
+
+    def __init__(self, workspace: Workspace, addr: int, size: int, parent=None) -> None:
+        super().__init__(parent=parent)
+
+        self.workspace = workspace
+        self.addr = addr
+        self.size = size
+
+        self._width = 0
+        self._height = 0
+
+        self._addr_item: QGraphicsSimpleTextItem | None = None
+        self._content_item: QGraphicsSimpleTextItem | None = None
+
+        self._init_widgets()
+
+    #
+    # Public methods
+    #
+
+    def paint(self, painter, option, widget) -> None:  # pylint: disable=unused-argument
+        pass
+
+    def _boundingRect(self):
+        return QRectF(0, 0, self._width, self._height)
+
+    def remove_children_from_scene(self):
+        """
+        Remove this item and all its children from the scene.
+        """
+        scene = self.scene()
+        if scene is None:
+            return
+
+        if self._addr_item is not None:
+            scene.removeItem(self._addr_item)
+            self._addr_item = None
+
+        if self._content_item is not None:
+            scene.removeItem(self._content_item)
+            self._content_item = None
+
+    #
+    # Private methods
+    #
+
+    def _init_widgets(self) -> None:
+        self._addr_item = QGraphicsSimpleTextItem(f"{self.addr:08x}", self)
+        self._addr_item.setBrush(Conf.disasm_view_node_address_color)
+        self._addr_item.setFont(Conf.disasm_font)
+
+        self._content_item = QGraphicsSimpleTextItem(f"[alignment_chunk]: {self.size:#x} bytes", self)
+        self._content_item.setBrush(Conf.disasm_view_alignment_color)
+        self._content_item.setFont(Conf.disasm_font)
+
+        self._layout_items_and_update_size()
+
+    def _layout_items_and_update_size(self) -> None:
+        x, y = 0, Conf.disasm_font_height
+
+        self._addr_item.setPos(x, y)
+        x += self._addr_item.boundingRect().width()
+        x += self.SPACING
+
+        self._content_item.setPos(x, y)
+
+        self._width = x + self._content_item.boundingRect().width()
+        self._height = y + self._content_item.boundingRect().height()
+
+        self.recalculate_size()

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -531,7 +531,7 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
                 if self.instance.kb.functions.contains_addr(func_addr):
                     func = self.instance.kb.functions[func_addr]
                     if func.is_alignment:
-                        qobject = QAlignmentBlock(self.instance, obj_addr, obj.size)
+                        qobject = QAlignmentBlock(self.instance, obj_addr, obj.size, self.disasm_view)
                     else:
                         disasm = self._get_disasm(func)
                         qobject = None

--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -18,6 +18,7 @@ from angrmanagement.logic.threads import needs_gui_thread
 from angrmanagement.utils.cache import SmartLRUCache
 from angrmanagement.utils.graph import get_out_branches
 
+from .qalignment_block import QAlignmentBlock
 from .qblock import QLinearBlock
 from .qdisasm_base_control import DisassemblyLevel, QDisassemblyBaseControl
 from .qgraph import QSaveableGraphicsView
@@ -488,7 +489,12 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         self._offset = offset
         self._start_line_in_object = start_line_in_object
 
-    def _validate_cached_qobj(self, obj, cached_qobj: QLinearBlock | QMemoryDataBlock | QUnknownBlock) -> bool:
+    def _validate_cached_qobj(
+        self, obj, cached_qobj: QAlignmentBlock | QLinearBlock | QMemoryDataBlock | QUnknownBlock
+    ) -> bool:
+        if isinstance(obj, Block) and isinstance(cached_qobj, QAlignmentBlock):
+            return cached_qobj.size == obj.size
+
         if isinstance(obj, Block) and isinstance(cached_qobj, QLinearBlock):
             if self._disassembly_level != cached_qobj.disassembly_level:
                 return False
@@ -507,7 +513,7 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
 
     def _obj_to_paintable(
         self, obj_addr, obj, use_cache=True
-    ) -> tuple[bool, None | QLinearBlock | QMemoryDataBlock | QUnknownBlock]:
+    ) -> tuple[bool, None | QAlignmentBlock | QLinearBlock | QMemoryDataBlock | QUnknownBlock]:
         if use_cache and obj_addr in self.objects:
             cached_qobj = self.objects[obj_addr]
             if self._validate_cached_qobj(obj, cached_qobj):
@@ -524,39 +530,42 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
                 func_addr = cfg_node.function_address
                 if self.instance.kb.functions.contains_addr(func_addr):
                     func = self.instance.kb.functions[func_addr]
-                    disasm = self._get_disasm(func)
-                    qobject = None
-                    if self._disassembly_level is DisassemblyLevel.AIL:
-                        ail_obj = None
-                        if disasm.graph is not None:
-                            # Clinic may yield a None graph when the function is empty
-                            for n in disasm.graph.nodes:
-                                if n.addr == obj.addr:
-                                    ail_obj = n
-                            # the corresponding AIL block may not exist
-                            if ail_obj is not None:
-                                qobject = QLinearBlock(
-                                    self.instance,
-                                    func_addr,
-                                    self.disasm_view,
-                                    disasm,
-                                    self.disasm_view.infodock,
-                                    obj.addr,
-                                    [ail_obj],
-                                    None,
-                                )
+                    if func.is_alignment:
+                        qobject = QAlignmentBlock(self.instance, obj_addr, obj.size)
                     else:
-                        out_branches = get_out_branches(func, obj_addr)
-                        qobject = QLinearBlock(
-                            self.instance,
-                            func_addr,
-                            self.disasm_view,
-                            disasm,
-                            self.disasm_view.infodock,
-                            obj.addr,
-                            [obj],
-                            out_branches,
-                        )
+                        disasm = self._get_disasm(func)
+                        qobject = None
+                        if self._disassembly_level is DisassemblyLevel.AIL:
+                            ail_obj = None
+                            if disasm.graph is not None:
+                                # Clinic may yield a None graph when the function is empty
+                                for n in disasm.graph.nodes:
+                                    if n.addr == obj.addr:
+                                        ail_obj = n
+                                # the corresponding AIL block may not exist
+                                if ail_obj is not None:
+                                    qobject = QLinearBlock(
+                                        self.instance,
+                                        func_addr,
+                                        self.disasm_view,
+                                        disasm,
+                                        self.disasm_view.infodock,
+                                        obj.addr,
+                                        [ail_obj],
+                                        None,
+                                    )
+                        else:
+                            out_branches = get_out_branches(func, obj_addr)
+                            qobject = QLinearBlock(
+                                self.instance,
+                                func_addr,
+                                self.disasm_view,
+                                disasm,
+                                self.disasm_view.infodock,
+                                obj.addr,
+                                [obj],
+                                out_branches,
+                            )
                 else:
                     # TODO: Get disassembly even if the function does not exist
                     _l.warning(


### PR DESCRIPTION
- Adds functionality for showing alignment functions as 
`[alignment_chunk]: {cnt} bytes`
instead of as a regular function.