### PR TITLE
DisassemblyView: Validate address before jumping

### DIFF
--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -731,7 +731,14 @@ class DisassemblyView(SynchronizedFunctionView):
                 self._flow_graph.reload()
 
     def jump_to(self, addr: int, src_ins_addr=None, use_animation: bool = False, is_real_addr: bool = False) -> bool:
-        # Record the current instruction address first
+        if (
+            self.instance.project.am_obj is not None
+            and self.instance.project.loader.find_object_containing(addr) is None
+        ):
+            _l.warning("Address %#x is outside loaded memory regions, skipping jump.", addr)
+            return False
+
+        # Record the current instruction address
         if src_ins_addr is not None:
             self.jump_history.record_address(src_ins_addr)
 

--- a/angrmanagement/ui/views/disassembly_view.py
+++ b/angrmanagement/ui/views/disassembly_view.py
@@ -731,11 +731,8 @@ class DisassemblyView(SynchronizedFunctionView):
                 self._flow_graph.reload()
 
     def jump_to(self, addr: int, src_ins_addr=None, use_animation: bool = False, is_real_addr: bool = False) -> bool:
-        if (
-            self.instance.project.am_obj is not None
-            and self.instance.project.loader.find_object_containing(addr) is None
-        ):
-            _l.warning("Address %#x is outside loaded memory regions, skipping jump.", addr)
+        # Do not jump if addr is not in the binary
+        if not self.instance.project.am_none and self.instance.project.loader.find_object_containing(addr) is None:
             return False
 
         # Record the current instruction address


### PR DESCRIPTION
- Adds address validation logic to make sure the target_address is present in the binary before jumping to it in the disassembly view.