### PR TITLE
fix: add unicorn as optionnal dep to angr-management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,8 @@ Homepage = "https://angr.io"
 Repository = "https://github.com/angr/angr-management"
 
 [project.optional-dependencies]
-bintrace = [
-  "bintrace"
-]
+bintrace = ["bintrace"]
+unicorn = ["angr[unicorn]"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Pinned latest unicorn version (same as in angr)