### PR TITLE
Quality: Disconnected clients remain in target map, causing calls into dead RPC connections

### DIFF
--- a/angrmanagement/daemon/server.py
+++ b/angrmanagement/daemon/server.py
@@ -43,8 +43,10 @@ class ManagementService(rpyc.Service):
 
     def on_disconnect(self, conn) -> None:
         self._conn = None
-        if conn in CONNECTIONS:
-            del CONNECTIONS[conn]
+        CONNECTIONS.pop(conn, None)
+        stale_targets = [target_id for target_id, target_conn in TargetIDtoCONN.items() if target_conn is conn]
+        for target_id in stale_targets:
+            del TargetIDtoCONN[target_id]
 
     def exposed_open(self, bin_path) -> None:
         if bin_path is None:


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `angrmanagement/daemon/server.py`.

**Context:**
`on_disconnect()` removes the connection from `CONNECTIONS` but does not remove entries in `TargetIDtoCONN` that point to that same connection. Subsequent `exposed_*` calls resolve a stale target ID and invoke methods on a dead `rpyc` connection, which can raise transport/EOF errors at runtime and leave invalid state accumulating over time.


**Proposed fix:**
Remove all target IDs bound to the disconnecting connection:

def on_disconnect(self, conn) -> None:
    self._conn = None
    CONNECTIONS.pop(conn, None)
    stale_targets = [tid for tid, c in TargetIDtoCONN.items() if c is conn]
    for tid in stale_targets:
        del TargetIDtoCONN[tid]


**Files touched:**
- `angrmanagement/daemon/server.py` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
