### PR TITLE
LoadBinary: Get recommended arch names from all available arches in Backend

### DIFF
--- a/angrmanagement/ui/dialogs/load_binary.py
+++ b/angrmanagement/ui/dialogs/load_binary.py
@@ -716,12 +716,13 @@ class LoadBinary(QDialog):
         other_arches = []
 
         self_arch_str = str(self.arch)
+        arch_names = self.partial_ld.main_object.available_arches if self.partial_ld.main_object is not None else []
 
         for arch in all_arches:
             if isinstance(arch, archinfo.Arch):
                 if str(arch) == self_arch_str:
                     the_arch = arch
-                elif arch.name == self.arch.name:
+                elif arch.name in arch_names:
                     recommended_arches.append(arch)
                 else:
                     other_arches.append(arch)


### PR DESCRIPTION
angr-management currently shows only 1 architecture in recommended arches, but for backends with multiple architectures (universal2), it should show all available arches. This pr fixes that by searching over all available arches in backend.

Change depends on angr/cle#673 to show all available arches in Universal2 binary