### PR TITLE
Fix crash when editing a struct or union field

### DIFF
--- a/angrmanagement/ui/dialogs/type_editor.py
+++ b/angrmanagement/ui/dialogs/type_editor.py
@@ -177,9 +177,9 @@ def edit_field(ty, field, predefined_types=None) -> bool:
     text = subty.c_repr(name=name)
     dialog = CTypeEditor(None, ty._arch, text, multiline=False, editing_single=name, predefined_types=predefined_types)
     dialog.exec_()
-    if not dialog.result:
+    if not dialog.main_result:
         return False
-    name2, subty = dialog.result[0]
+    name2, subty = dialog.main_result[0]
     if name2 is not None:
         if name != name2 and name2 in fields:
             QMessageBox.warning(None, "Duplicate field name", f"The name {name2} is already used")


### PR DESCRIPTION
### PR Summary
In `edit_field`, `dialog.result` was being treated as a list of edited fields, but `CTypeEditor` never sets that attribute - `dialog.result` resolves to the inherited `QDialog.result()` bound method. So `dialog.result[0]` raises `TypeError: 'builtin_function_or_method' object is not subscriptable` when user edits a struct or union field. The preceding guard `if not dialog.result:` was also silently broken: bound methods are always truthy, so the Cancel early-return never fired either. Both references now use `dialog.main_result`, the attribute `CTypeEditor` actually populates when the user accepts the dialog.