### PR TITLE
RenameNode: Move argument renaming code and update prototype when renaming arguments

### DIFF
--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -194,14 +194,14 @@ class RenameNode(QDialog):
                 # function argument
                 elif self._node.unified_variable.is_function_argument:
                     workspace.plugins.handle_func_arg_renamed(
-                        code_kb.functions[self._node.codegen.cfunc.addr], 0, self._node.variable.name, node_name
+                        code_kb.functions[cfunc.addr], 0, self._node.variable.name, node_name
                     )
-                    arg_names = list(self._node.codegen.cfunc.functy.arg_names)
-                    for idx, arg in enumerate(self._node.codegen.cfunc.arg_list):
+                    arg_names = list(cfunc.functy.arg_names)
+                    for idx, arg in enumerate(cfunc.arg_list):
                         if arg is self._node:
                             arg_names[idx] = node_name
                             break
-                    self._node.codegen.cfunc.functy.arg_names = tuple(arg_names)
+                    cfunc.functy.arg_names = tuple(arg_names)
 
                 self._node.unified_variable.name = node_name
                 self._node.unified_variable.renamed = True
@@ -218,9 +218,7 @@ class RenameNode(QDialog):
 
             # function name
             elif isinstance(self._node, CFunction):
-                workspace.plugins.handle_function_renamed(
-                    code_kb.functions[self._node.codegen.cfunc.addr], self._node.name, node_name
-                )
+                workspace.plugins.handle_function_renamed(code_kb.functions[cfunc.addr], self._node.name, node_name)
 
                 code_kb.functions.get_by_addr(self._node.addr).name = node_name
                 self._node.name = node_name
@@ -230,7 +228,7 @@ class RenameNode(QDialog):
             elif isinstance(self._node, CFunctionCall):
                 if self._node.callee_func is not None:
                     workspace.plugins.handle_function_renamed(
-                        code_kb.functions[self._node.codegen.cfunc.addr], self._node.callee_func.name, node_name
+                        code_kb.functions[cfunc.addr], self._node.callee_func.name, node_name
                     )
 
                     self._node.callee_func.name = node_name

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -176,9 +176,8 @@ class RenameNode(QDialog):
             workspace = self._code_view.workspace
             code_kb = self._code_view.codegen.kb
 
-            # stack variable
             if isinstance(self._node, CVariable) and self._node.unified_variable is not None:
-                # sanity check that we are a stack var
+                # Stack variable
                 if hasattr(self._node.variable, "offset") and self._node.variable.offset is not None:
                     workspace.plugins.handle_stack_var_renamed(
                         self._func,
@@ -186,6 +185,18 @@ class RenameNode(QDialog):
                         self._node.variable.name,
                         node_name,
                     )
+
+                # function argument
+                elif self._node.unified_variable.is_function_argument:
+                    workspace.plugins.handle_func_arg_renamed(
+                        code_kb.functions[self._node.codegen.cfunc.addr], 0, self._node.variable.name, node_name
+                    )
+                    arg_names = list(self._node.codegen.cfunc.functy.arg_names)
+                    for idx, arg in enumerate(self._node.codegen.cfunc.arg_list):
+                        if arg is self._node:
+                            arg_names[idx] = node_name
+                            break
+                    self._node.codegen.cfunc.functy.arg_names = tuple(arg_names)
 
                 self._node.unified_variable.name = node_name
                 self._node.unified_variable.renamed = True
@@ -197,15 +208,6 @@ class RenameNode(QDialog):
                 )
 
                 self._code_view.instance.kb.labels[self._node.variable.addr] = node_name
-                self._node.variable.name = node_name
-                self._node.variable.renamed = True
-
-            # function arg
-            elif isinstance(self._node, CVariable):
-                workspace.plugins.handle_func_arg_renamed(
-                    code_kb.functions[self._node.codegen.cfunc.addr], 0, self._node.variable.name, node_name
-                )
-
                 self._node.variable.name = node_name
                 self._node.variable.renamed = True
 

--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -175,6 +175,11 @@ class RenameNode(QDialog):
             # need workspace for altering callbacks of changes
             workspace = self._code_view.workspace
             code_kb = self._code_view.codegen.kb
+            cfunc = self._code_view.codegen.cfunc
+
+            if cfunc is None:
+                self.close()
+                return
 
             if isinstance(self._node, CVariable) and self._node.unified_variable is not None:
                 # Stack variable


### PR DESCRIPTION
- Move function argument renaming logic into unified_variable is not none branch, as arguments have unified_variables, so the older branch is never taken.
- Update arg_names in function prototype to match changes made while renaming arguments.