### PR TITLE
TestHexView: Stop timer when tearing down

### DIFF
--- a/tests/test_hex_view.py
+++ b/tests/test_hex_view.py
@@ -45,6 +45,10 @@ class HexGraphicsObjectTestCase(unittest.TestCase):
     def setUp(self):
         self.hex_obj = HexGraphicsObject()
 
+    def tearDown(self):
+        self.hex_obj.cursor_blink_timer.stop()
+        del self.hex_obj
+
     def _load_sample_data(self, size: int = 256, start_addr: int = 0x1000) -> None:
         """Load sample sequential byte data into the hex object."""
         data = bytes(range(size)) if size <= 256 else bytes(i % 256 for i in range(size))


### PR DESCRIPTION
After some back and forth with codex, the root cause of #1648 appears to be that several `tests/test_hex_view.py` cases start the `HexGraphicsObject` cursor blink QTimer but do not always stop it during cleanup.

Later some tests call `QApplication.processEvents()` through `join_all_jobs()`. At that point, Qt may try to dispatch a timer event for a `HexGraphicsObject` that has already been destroyed, which results in a segmentation fault.

This PR fixes the issue by explicitly stopping the cursor blink timer in the test case `tearDown()`.
