### PR TITLE
RenameNode: Update FunctionView when a Function is renamed

### DIFF
--- a/angrmanagement/ui/dialogs/rename_node.py
+++ b/angrmanagement/ui/dialogs/rename_node.py
@@ -218,6 +218,7 @@ class RenameNode(QDialog):
                 code_kb.functions.get_by_addr(self._node.addr).name = node_name
                 self._node.name = node_name
                 self._node.demangled_name = node_name
+                self._code_view.workspace.on_function_updated()
 
             # function renaming (as a call)
             elif isinstance(self._node, CFunctionCall):
@@ -227,6 +228,7 @@ class RenameNode(QDialog):
                     )
 
                     self._node.callee_func.name = node_name
+                    self._code_view.workspace.on_function_updated()
 
             # struct renaming
             elif isinstance(self._node, CStructField):

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -274,6 +274,11 @@ class Workspace:
         if view is not None:
             view.reload()
 
+    def on_function_updated(self) -> None:
+        functions_view = self.view_manager.first_view_in_category("functions")
+        if functions_view is not None:
+            functions_view.reset_cache_and_refresh()
+
     def on_cc_recovered(self, func_addr: int) -> None:
         """
         Called when the calling convention of a given function is available.

--- a/angrmanagement/ui/workspace.py
+++ b/angrmanagement/ui/workspace.py
@@ -276,7 +276,7 @@ class Workspace:
 
     def on_function_updated(self) -> None:
         functions_view = self.view_manager.first_view_in_category("functions")
-        if functions_view is not None:
+        if functions_view is not None and isinstance(functions_view, FunctionsView):
             functions_view.reset_cache_and_refresh()
 
     def on_cc_recovered(self, func_addr: int) -> None:


### PR DESCRIPTION
- Add a `on_function_updated` function to `Workspace` to refresh FunctionView.
- Call `Workspace.on_function_updated` when a function is renamed through a `CFunction` or a `CFunctionCall`