### PR TITLE
InfoDock: Unselect operands when selecting BlockTreeNode

### DIFF
--- a/angrmanagement/logic/disassembly/info_dock.py
+++ b/angrmanagement/logic/disassembly/info_dock.py
@@ -359,6 +359,7 @@ class InfoDock:
         """
 
         self.unselect_all_instructions()
+        self.unselect_all_operands()
         self.unselect_all_labels()
 
         self.selected_block_tree_node.am_obj = obj


### PR DESCRIPTION
Resolves the issue where an operand is left selected when you select a Function Header after selecting an operand.