### PR TITLE
FileMenu: Add option to load FLIRT Signature

### DIFF
--- a/angrmanagement/ui/main_window.py
+++ b/angrmanagement/ui/main_window.py
@@ -504,6 +504,7 @@ class MainWindow(QMainWindow):
                     ("File: Load a new binary...", self.open_file_button),
                     ("File: Load a new trace...", self.load_trace),
                     ("File: Load angr database...", self.load_database),
+                    ("File: Load FLIRT signature file...", self.load_signature_button),
                     ("File: Preferences...", self.preferences),
                     ("File: Save angr database as...", self.save_database_as),
                     ("File: Save angr database...", self.save_database),
@@ -615,6 +616,13 @@ class MainWindow(QMainWindow):
         if not file_path:
             return
         self.load_trace_file(file_path)
+
+    def load_signature_button(self) -> None:
+        sig_mgr = self.workspace.main_instance.signature_mgr
+        if sig_mgr is None:
+            return
+        sig_mgr.load_signatures()
+        self.workspace.show_signatures_view()
 
     def load_trace_file(self, file_path) -> None:
         if isurl(file_path):

--- a/angrmanagement/ui/menus/file_menu.py
+++ b/angrmanagement/ui/menus/file_menu.py
@@ -68,6 +68,11 @@ class FileMenu(Menu):
                     main_window.open_trace_file_button,
                     shortcut=QKeySequence("Ctrl+Shift+T"),
                 ),
+                MenuEntry(
+                    "Load a &FLIRT signature file...",
+                    main_window.load_signature_button,
+                    shortcut=QKeySequence("Ctrl+Shift+F"),
+                ),
                 self.recent_menu,
                 MenuSeparator(),
                 MenuEntry(


### PR DESCRIPTION
This PR adds an option to load signature file directly from File Menu as the current way to load signatures (View Menu > Function Signature View > Load Signature File) does not seem very intuitive.
