### PR TITLE
fix(llm_preload): use __getitem__ on StructuredCodeManager (closes #1654)

### DIFF
--- a/angrmanagement/data/jobs/llm_preload.py
+++ b/angrmanagement/data/jobs/llm_preload.py
@@ -69,7 +69,7 @@ class LLMPreloadCalleesJob(InstanceJob):
 
             # decompile if not already cached
             key = (callee.addr, "pseudocode")
-            dec_cache = kb.decompilations[key] if key in kb.decompilations else None
+            dec_cache = kb.decompilations.get(key, None)
             if dec_cache is None or dec_cache.codegen is None:
                 try:
                     decompiler = project.analyses.Decompiler(

--- a/angrmanagement/data/jobs/llm_preload.py
+++ b/angrmanagement/data/jobs/llm_preload.py
@@ -68,7 +68,8 @@ class LLMPreloadCalleesJob(InstanceJob):
             ctx.set_progress(pct, f"Refining callee {callee.name} ({i + 1}/{total})")
 
             # decompile if not already cached
-            dec_cache = kb.decompilations.get((callee.addr, "pseudocode"))
+            key = (callee.addr, "pseudocode")
+            dec_cache = kb.decompilations[key] if key in kb.decompilations else None
             if dec_cache is None or dec_cache.codegen is None:
                 try:
                     decompiler = project.analyses.Decompiler(


### PR DESCRIPTION
Fixes #1654.

`kb.decompilations` is a `StructuredCodeManager` which exposes `__getitem__`, `__contains__` and `discard` but no `.get()`. The LLM preload job called `kb.decompilations.get((callee.addr, "pseudocode"))`, raising `AttributeError` and aborting the job (see issue traceback).

Switch to the `key in ...` / `kb.decompilations[key]` idiom already used in `llm_refine.py` (lines 76, 86) and `ui/views/code_view.py` (line 589).