### PR TITLE
fix(qstate_block): catch ReferenceError from GC'd weakref'd state

### DIFF
--- a/angrmanagement/ui/widgets/qstate_block.py
+++ b/angrmanagement/ui/widgets/qstate_block.py
@@ -52,11 +52,21 @@ class QStateBlock(QGraphicsItem):
 
     def _init_widgets(self) -> None:
         addr = None
-        if self.state.regs._ip.symbolic:
-            self._label_str = str(self.state.regs._ip)
-        else:
-            addr = claripy.backends.concrete.convert(self.state.regs._ip).value
-            self._label_str = f"{addr:#x}"
+        try:
+            if self.state.regs._ip.symbolic:
+                self._label_str = str(self.state.regs._ip)
+            else:
+                addr = claripy.backends.concrete.convert(self.state.regs._ip).value
+                self._label_str = f"{addr:#x}"
+        except ReferenceError:
+            # The SimState was held via weakref and has been garbage-collected
+            # while the path-tree view was still alive (issue #1644). Fall back
+            # to a placeholder label instead of letting the graphical update
+            # abort halfway through.
+            self._label_str = "<state freed>"
+            self._function_str = "Function: Unknown"
+            self.addr = None
+            return
 
         self.addr = addr
 


### PR DESCRIPTION
Fixes #1644.

Some `SimState`s referenced by the path-tree are held via weakref and may be garbage-collected before the `QStateBlock` paints. Accessing `self.state.regs._ip` then raises `ReferenceError` from `_init_widgets`, which aborts the rest of the graphical update.

Catch `ReferenceError` and fall back to a `<state freed>` placeholder so the rest of the path tree still renders.