### PR TITLE
QBlockLabel: Fix block width

### DIFF
--- a/angrmanagement/ui/widgets/qblock_label.py
+++ b/angrmanagement/ui/widgets/qblock_label.py
@@ -97,7 +97,7 @@ class QBlockLabel(QCachedGraphicsItem):
 
         self._text_item.setPos(x, y)
 
-        self._width = self._text_item.boundingRect().width()
+        self._width = x + self._text_item.boundingRect().width()
         self._height = self._text_item.boundingRect().height()
         self.recalculate_size()
 


### PR DESCRIPTION
Block width should include the width of the addr_item.