### PR TITLE
QLinearDisassembly: Render zero sized object

### DIFF
--- a/angrmanagement/ui/widgets/qlinear_viewer.py
+++ b/angrmanagement/ui/widgets/qlinear_viewer.py
@@ -413,8 +413,6 @@ class QLinearDisassembly(QDisassemblyBaseControl, QAbstractScrollArea):
         y = -start_line * self._line_height
 
         for obj_addr, obj in self.cfb.floor_items(addr=addr):
-            if not obj.size:
-                continue
             if obj_addr + obj.size <= addr and (obj.size > 0 or obj_addr < addr):
                 # top_obj_addr lands after the current object; let's move on to the next object instead
                 continue


### PR DESCRIPTION
Reverts https://github.com/angr/angr-management/pull/1672/changes#diff-6c71479c4661b0005fe39e33bce9d57faec0ae29acd42aeb72fa0b82ed95ec41R416
as the change introduced 2 issues:
- Stopped rendering Syscall and Simprocedure blocks in linear view.
- Added a scrolling issue where you cannot scroll back up once you go all the way down.