### PR TITLE
ZipArchive: Check for zip header at file start

### DIFF
--- a/angrmanagement/utils/archive.py
+++ b/angrmanagement/utils/archive.py
@@ -74,6 +74,16 @@ class ZipArchive(Archive):
 
     @classmethod
     def is_type(cls, path: str) -> bool:
+        # zipfile.is_zipfile only looks for an end-of-central-directory record near the
+        # end of the file, so a binary with zip data appended would be misdetected as an
+        # archive; require a zip signature at offset 0 as well
+        try:
+            with open(path, "rb") as f:
+                magic = f.read(4)
+        except OSError:
+            return False
+        if magic not in (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"):
+            return False
         return zipfile.is_zipfile(path)
 
     def list_members(self) -> list[ArchiveMember]:

--- a/tests/dialogs/test_archive_loader.py
+++ b/tests/dialogs/test_archive_loader.py
@@ -6,10 +6,12 @@ Test cases for ArchiveLoaderDialog and archive utility functions.
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import tempfile
 import unittest
+import zipfile
 from unittest.mock import patch
 
 from common import AngrManagementTestCase, test_location  # pylint: disable=import-error
@@ -85,6 +87,19 @@ class TestArchiveClasses(unittest.TestCase):
     def test_is_archive_plain_text(self):
         """Test that plain text files are not detected as archives."""
         assert is_archive(self._not_archive_path) is False
+
+    def test_is_archive_binary_with_embedded_zip(self):
+        """Test that a binary with zip data appended is not detected as an archive."""
+        zip_buf = io.BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zf:
+            zf.writestr("payload.txt", "embedded zip member")
+
+        embedded_path = os.path.join(self._temp_dir, "elf_with_zip")
+        with open(embedded_path, "wb") as f:
+            f.write(ELF_MAGIC + b"\x00" * 128 + zip_buf.getvalue())
+
+        assert ZipArchive.is_type(embedded_path) is False
+        assert is_archive(embedded_path) is False
 
     def test_get_archive_object(self):
         """Test that get_archive_object returns the right type or raises error."""


### PR DESCRIPTION
Fixes #1707

`zipfile.is_zipfile` only searches for an end-of-central-directory record near the end of the file, so any binary with zip data appended (e.g. an ELF with an embedded zip) was misdetected as an archive, and angr management showed the archive loader dialog instead of loading the binary.

`ZipArchive.is_type` now additionally requires a zip signature at file offset 0 — one of `PK\x03\x04` (local file header), `PK\x05\x06` (empty zip), or `PK\x07\x08` (spanned archive). All valid standalone zips (including APK/JAR) start with one of these, while ELF/PE/Mach-O binaries fail the prefix check and fall through to normal binary loading.

Trade-off: zips with *prepended* data (e.g. self-extracting archives) are no longer treated as archives — but those are executables the user most likely wants to analyze anyway.

Tar detection is unaffected: `tarfile.is_tarfile` already parses the header at offset 0, so appended tar data does not misdetect.

Added a regression test that builds an ELF-magic-prefixed file with a valid zip appended and asserts it is not detected as an archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)