### PR TITLE
Resolve referenced sibling pull requests in the test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,43 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         if: startsWith(runner.os, 'windows')
       - uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v6
+      - name: Resolve referenced sibling pull requests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          config=$RUNNER_TEMP/uv-sources.toml
+          packages=
+          requirements=
+          seen=
+          references=$(printf '%s' "$PR_BODY" |
+            grep -Eo '[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+|github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+' |
+            sed -E -e 's|^github\.com/||' -e 's|/pull/|#|' -e 's|[/#]| |g') || true
+          while read -r owner repo number; do
+            [ -n "$number" ] || continue
+            case " $seen " in *" $owner/$repo "*) continue ;; esac
+            seen="$seen $owner/$repo"
+            package=$(sed -n '/^\[tool\.uv\.sources\]/,/^\[/p' pyproject.toml |
+              grep -F -e "\"https://github.com/$owner/$repo\"" -e "\"https://github.com/$owner/$repo.git\"" |
+              sed -E 's/^ *([^ =]+).*/\1/' |
+              head -n 1) || true
+            [ -n "$package" ] || continue
+            state=$(gh api "repos/$owner/$repo/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" != open ]; then
+              echo "$owner/$repo#$number is $state, so it is not used"
+              continue
+            fi
+            echo "Installing $package from $owner/$repo#$number"
+            packages="$packages\"$package\","
+            requirements="$requirements\"$package @ git+https://github.com/$owner/$repo@refs/pull/$number/head\","
+          done <<<"$references"
+          if [ -z "$packages" ]; then
+            echo "No sibling pull request is referenced, so every sibling stays on master"
+            exit 0
+          fi
+          printf 'no-sources-package = [%s]\nupgrade-package = [%s]\n' "$packages" "$requirements" | tee "$config"
+          echo "UV_CONFIG_FILE=$config" >>"$GITHUB_ENV"
       - name: Sync dependencies
         run: uv sync -p 3.12
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+      - name: Resolve the angr/binaries ref
+        id: binaries-ref
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ref=master
+          number=$(printf '%s' "$PR_BODY" |
+            grep -Eo '(angr/binaries#|github\.com/angr/binaries/pull/)[0-9]+' |
+            head -n 1 |
+            grep -Eo '[0-9]+$') || true
+          if [ -n "$number" ]; then
+            state=$(gh api "repos/angr/binaries/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" = open ]; then
+              ref="refs/pull/$number/head"
+            else
+              echo "angr/binaries#$number is $state, so it is not used"
+            fi
+          fi
+          echo "Checking out angr/binaries at $ref"
+          echo "ref=$ref" >>"$GITHUB_OUTPUT"
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           repository: angr/binaries
           path: binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
       - name: Move binaries
         run: mv binaries ..
       - name: Setup Rust

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,43 @@ jobs:
           path: test_durations.json
           key: cov-test-durations-${{ github.sha }}
           restore-keys: cov-test-durations-
+      - name: Resolve referenced sibling pull requests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          config=$RUNNER_TEMP/uv-sources.toml
+          packages=
+          requirements=
+          seen=
+          references=$(printf '%s' "$PR_BODY" |
+            grep -Eo '[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+|github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/[0-9]+' |
+            sed -E -e 's|^github\.com/||' -e 's|/pull/|#|' -e 's|[/#]| |g') || true
+          while read -r owner repo number; do
+            [ -n "$number" ] || continue
+            case " $seen " in *" $owner/$repo "*) continue ;; esac
+            seen="$seen $owner/$repo"
+            package=$(sed -n '/^\[tool\.uv\.sources\]/,/^\[/p' pyproject.toml |
+              grep -F -e "\"https://github.com/$owner/$repo\"" -e "\"https://github.com/$owner/$repo.git\"" |
+              sed -E 's/^ *([^ =]+).*/\1/' |
+              head -n 1) || true
+            [ -n "$package" ] || continue
+            state=$(gh api "repos/$owner/$repo/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" != open ]; then
+              echo "$owner/$repo#$number is $state, so it is not used"
+              continue
+            fi
+            echo "Installing $package from $owner/$repo#$number"
+            packages="$packages\"$package\","
+            requirements="$requirements\"$package @ git+https://github.com/$owner/$repo@refs/pull/$number/head\","
+          done <<<"$references"
+          if [ -z "$packages" ]; then
+            echo "No sibling pull request is referenced, so every sibling stays on master"
+            exit 0
+          fi
+          printf 'no-sources-package = [%s]\nupgrade-package = [%s]\n' "$packages" "$requirements" | tee "$config"
+          echo "UV_CONFIG_FILE=$config" >>"$GITHUB_ENV"
       - name: Build
         run: uv sync --managed-python -v -p 3.12 --all-groups
       - name: Archive environment

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,11 +70,34 @@ jobs:
         run: |
           tar -xpf $PWD/env.tzst -C /
           rm env.tzst
+      - name: Resolve the angr/binaries ref
+        id: binaries-ref
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ref=master
+          number=$(printf '%s' "$PR_BODY" |
+            grep -Eo '(angr/binaries#|github\.com/angr/binaries/pull/)[0-9]+' |
+            head -n 1 |
+            grep -Eo '[0-9]+$') || true
+          if [ -n "$number" ]; then
+            state=$(gh api "repos/angr/binaries/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" = open ]; then
+              ref="refs/pull/$number/head"
+            else
+              echo "angr/binaries#$number is $state, so it is not used"
+            fi
+          fi
+          echo "Checking out angr/binaries at $ref"
+          echo "ref=$ref" >>"$GITHUB_OUTPUT"
       - name: Download test binaries
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           repository: angr/binaries
           path: binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
       - name: Relocate binaries directory
         run: mv binaries ..
       - name: Run tests


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The `Test` jobs in ci.yml and coverage.yml run their own `uv sync`, and `[tool.uv.sources]` pins archinfo, pyvex, cle, claripy, angr and bintrace to a git branch of master, so a change needing a sibling change was built without it. This extends the binaries-only scan added here to all six, in the two spellings `resolve_refs.py` accepts, taking the first reference to each while it is open.

The reference becomes `no-sources-package` plus `upgrade-package` in a uv configuration file under the runner temporary directory, so uv resolves that package from the pull request head, keeps the rest on master, and writes nothing into the checkout. angr/angr#6821 and angr/cle#738 now carry this same mechanism.

Validation: https://github.com/angr/angr-management/pull/1716#issuecomment-5259983416.

The `pyinstaller / Build on macos-15-intel` check is red for a reason unrelated to this change: building angr's Rust extension there fails in the `core_affinity2` crate with `error[E0308]: mismatched types` at `core_affinity2-0.16.1/src/lib.rs:885`, which `libafl 0.16.1` pulls in. That is angr/angr#6890. Every other check on this pull request passes.
