### PR TITLE
ci: Bump codecov-action to v7 so coverage uploads verify

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -129,14 +129,14 @@ jobs:
           junit=$(find . -type f -name 'junit.xml' | paste -sd, -)
           echo "junit=$junit" >> "$GITHUB_OUTPUT"
       - name: Upload test coverage to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           use_oidc: true
           fail_ci_if_error: true
           verbose: true
           files: ${{ steps.files.outputs.coverage }}
       - name: Upload test results to Codecov
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           use_oidc: true
           fail_ci_if_error: true


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The Report job has been failing on every open pull request and on master. It dies at "Upload test coverage to Codecov" with `==> Could not verify signature. Please contact Codecov if problem continues`, and because the step sets `fail_ci_if_error: true` that becomes a red check on work that is otherwise fine.

The cause is the pin rather than anything in the tests. `codecov/codecov-action@5a10915` is release 5.5.1 from September 2025, and the CLI it downloads no longer verifies against Codecov's current signing key. angr hit the same wall and moved to 7.0.0 in June, where both upload steps succeed today; this brings angr-management to that same revision.

Only the two `uses:` lines change. Worth noting separately that this repository has no `.github/dependabot.yml`, which is why the pin went stale here while angr's was bumped automatically — that seemed like a policy question for maintainers rather than something to fold into this fix.
