### PR TITLE
ci: check out a referenced angr/binaries pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
+      - id: binaries-ref
+        uses: angr/ci-settings/actions/binaries-ref@master
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           repository: angr/binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
           path: binaries
       - name: Move binaries
         run: mv binaries ..

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,10 +70,13 @@ jobs:
         run: |
           tar -xpf $PWD/env.tzst -C /
           rm env.tzst
+      - id: binaries-ref
+        uses: angr/ci-settings/actions/binaries-ref@master
       - name: Download test binaries
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:
           repository: angr/binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
           path: binaries
       - name: Relocate binaries directory
         run: mv binaries ..


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The `angr/binaries` checkout carries no `ref`, so this workflow always builds against master. A pull request whose new test loads a fixture from an open `angr/binaries` pull request fails here no matter what its body references, which is the same gap `angr/cle` closed in angr/cle#738.

This resolves the ref with the shared action from angr/ci-settings and passes it to the existing checkout, so this workflow's own checkout options are untouched.

Blocked on angr/ci-settings#123, which adds the action; this references it at `master`.
