### PR TITLE
QFunctionTableView: Load the complete function on selection

### DIFF
--- a/angrmanagement/ui/widgets/qfunction_table.py
+++ b/angrmanagement/ui/widgets/qfunction_table.py
@@ -535,7 +535,7 @@ class QFunctionTableView(QFastTableView):
     def jump_to_result(self, index: int = 0) -> None:
         if self._model.func_list is not None and len(self._model.func_list) > index:
             func_entry = self._model.func_list[index]
-            self._selected_func.am_obj = self._functions.get_by_addr(func_entry.addr, meta_only=True)
+            self._selected_func.am_obj = self._functions.get_by_addr(func_entry.addr)
             self._selected_func.am_event(func=self._selected_func.am_obj)
 
     def load_functions(self) -> None:
@@ -555,7 +555,7 @@ class QFunctionTableView(QFastTableView):
         if not 0 <= row < len(self._model.func_list):
             return
         func_entry = self._model.func_list[row]
-        self._selected_func.am_obj = self._functions.get_by_addr(func_entry.addr, meta_only=True)
+        self._selected_func.am_obj = self._functions.get_by_addr(func_entry.addr)
         self._selected_func.am_event(func=self._selected_func.am_obj)
 
     def _on_key_pressed(self, text: str) -> None:


### PR DESCRIPTION
The function table publishes the selected function to the views that render it, but
it publishes a meta-only function, which carries block addresses without the blocks
or the transition graph behind them. The disassembly view builds its graph from that
transition graph, so for any function that has been spilled out of memory it drew a
single stub block instead of the function, and raised `RuntimeError: Internal C++
object (QGraphBlock) already deleted` because no block matched the function entry.
This pr fixes that by loading the complete function on selection instead.