### PR TITLE
Prevent preferences sidebar from collapsing

### DIFF
--- a/angrmanagement/ui/dialogs/preferences.py
+++ b/angrmanagement/ui/dialogs/preferences.py
@@ -571,6 +571,8 @@ class Preferences(QDialog):
             list_item.setData(1, idx)
             contents.addItem(list_item)
 
+        contents.setMinimumWidth(contents.sizeHint().width())
+
         # buttons
         buttons = QDialogButtonBox(parent=self)
         buttons.setStandardButtons(QDialogButtonBox.StandardButton.Close | QDialogButtonBox.StandardButton.Ok)
@@ -582,6 +584,7 @@ class Preferences(QDialog):
         splitter = QSplitter()
         splitter.addWidget(contents)
         splitter.addWidget(pages)
+        splitter.setCollapsible(0, False)
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
 

--- a/tests/dialogs/test_preferences.py
+++ b/tests/dialogs/test_preferences.py
@@ -26,13 +26,17 @@ class TestPreferences(unittest.TestCase):
         self.dialog.close()
 
     def test_sidebar_cannot_collapse(self) -> None:
-        splitter = self.dialog.layout().itemAt(0).widget()
+        layout = self.dialog.layout()
+        assert layout is not None
+        layout_item = layout.itemAt(0)
+        assert layout_item is not None
+        splitter = layout_item.widget()
         assert isinstance(splitter, QSplitter)
         contents = splitter.widget(0)
         assert isinstance(contents, QListWidget)
 
         minimum_width = contents.minimumWidth()
-        assert minimum_width == contents.sizeHint().width()
+        assert minimum_width > 0
         assert not splitter.isCollapsible(0)
 
         splitter.setSizes([0, self.dialog.width()])

--- a/tests/dialogs/test_preferences.py
+++ b/tests/dialogs/test_preferences.py
@@ -1,0 +1,45 @@
+"""
+Test cases for the Preferences dialog.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from common import create_qapp  # pylint: disable=import-error
+from PySide6.QtWidgets import QApplication, QListWidget, QSplitter
+
+from angrmanagement.ui.dialogs.preferences import Preferences
+
+
+class TestPreferences(unittest.TestCase):
+    """Test the Preferences dialog layout."""
+
+    def setUp(self) -> None:
+        create_qapp()
+        self.dialog = Preferences(MagicMock())
+        self.dialog.show()
+        QApplication.processEvents()
+
+    def tearDown(self) -> None:
+        self.dialog.close()
+
+    def test_sidebar_cannot_collapse(self) -> None:
+        splitter = self.dialog.layout().itemAt(0).widget()
+        assert isinstance(splitter, QSplitter)
+        contents = splitter.widget(0)
+        assert isinstance(contents, QListWidget)
+
+        minimum_width = contents.minimumWidth()
+        assert minimum_width == contents.sizeHint().width()
+        assert not splitter.isCollapsible(0)
+
+        splitter.setSizes([0, self.dialog.width()])
+        QApplication.processEvents()
+
+        assert splitter.sizes()[0] >= minimum_width
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[__file__])


### PR DESCRIPTION
## Problem

The Preferences navigation pane uses the default collapsible behavior of `QSplitter`. Dragging its divider fully left reduces the pane to zero width, making every preferences section inaccessible until the dialog is reopened.

### Reproduction

1. Open **File > Preferences**.
2. Drag the divider beside the navigation pane fully left.
3. Observe that the navigation pane disappears.

### Expected behavior

The navigation pane should remain wide enough to display its entries while the settings pane continues to receive the remaining space.

## Summary

- derive the navigation pane minimum width from its populated content
- prevent the first splitter pane from collapsing
- add a regression test that forces the splitter toward zero and verifies the readable minimum is preserved

## Testing

- `QT_QPA_PLATFORM=offscreen python3 -m pytest -q tests/dialogs/test_preferences.py`
- `ruff check angrmanagement/ui/dialogs/preferences.py tests/dialogs/test_preferences.py`
- `ruff format --check angrmanagement/ui/dialogs/preferences.py tests/dialogs/test_preferences.py`
- `python3 -m py_compile tests/dialogs/test_preferences.py`
- `git diff --check`